### PR TITLE
Use potentially given missingEpicMultiplier to decrease max RCB in sandbox when loading from URL

### DIFF
--- a/wasmegg/artifact-sandbox/src/lib/models.ts
+++ b/wasmegg/artifact-sandbox/src/lib/models.ts
@@ -400,7 +400,7 @@ export class Config {
     self.isEnlightenment = config?.isEnlightenment ?? false;
     self.soulFood = maxSoulFood - (config?.missingSoulFood ?? 0);
     self.prophecyBonus = maxProphecyBonus - (config?.missingProphecyBonus ?? 0);
-    self.RCB = maxRCB;
+    self.RCB = maxRCB - ((config?.missingEpicMultiplier ?? 0) * 2);
     self.birdFeedActive = config?.birdFeedActive ?? false;
     self.tachyonPrismActive = config?.tachyonPrismActive ?? false;
     self.soulBeaconActive = config?.soulBeaconActive ?? false;


### PR DESCRIPTION
**Full disclosure, I never actually ran this, but I'm pretty certain it works as intended**

So this is kind of a half-fix but it at least doesn't make anything worse, I think

So there was already a `missingEpicMultiplier` which gets filled in on the smartass side when using "tweak this set in the sandbox", it just didn't actually get used on the sandbox side. This fixes that part, so using a link from smartass should now correctly decrease max RCB with your actual missing epic multiplier.

The other thing that I found out doesn't actually work yet is that changing max RCB in sandbox just doesn't change the URL and therefore also doesn't get loaded if you use that URL elsewhere. I wanted to just quickly fix that as well (by adding similar logic to the `toProto()` below), but its a bit annoying. Epic multiplier changes max RCB by 2 per tick, and is stored as an integer. This means if you put an odd number as your max RCB in sandbox, it cannot properly save it as a "missing epic multiplier". Next to that, you could of course end up with a missing epic multiplier larger than 100 if you simply do ((540 - rcb) / 2), which I guess is not a real issue, but still somewhat ugly.

The true fix is probably to change `missingEpicMultiplier` to just a `rcb` field or something like that, where you just straight up fill in the rcb value itself instead of the missing ER. However, this is not something I want to do just from github edits, and I also don't know anything about proto backwards compatibility :D