### PR TITLE
Add auto AP planner

### DIFF
--- a/wasmegg/ascension-planner/src/App.vue
+++ b/wasmegg/ascension-planner/src/App.vue
@@ -1090,4 +1090,8 @@ const ChevronIcon = {
 .btn-ghost {
   @apply bg-transparent hover:bg-slate-50 border border-slate-100;
 }
+:deep(#playerId:not(:focus)) {
+  filter: blur(4px);
+  transition: filter 0.2s;
+}
 </style>

--- a/wasmegg/ascension-planner/src/App.vue
+++ b/wasmegg/ascension-planner/src/App.vue
@@ -2,7 +2,7 @@
   
   <the-nav-bar active-entry-id="ascension-planner" />
 
-  <div :class="['min-h-screen bg-gray-100 transition-all duration-300', isFooterCollapsed ? 'pb-8' : 'pb-24']">
+  <div :class="['min-h-screen bg-gray-100 transition-all duration-300', (plannerTab === 'automatic' || isFooterCollapsed) ? 'pb-8' : 'pb-24']">
     <div class="max-w-6xl mx-auto p-4">
       <!-- Collapsible Header Region -->
       <div class="bg-white/95 backdrop-blur-xl rounded-2xl border border-slate-100 shadow-sm">
@@ -22,6 +22,33 @@
             </div>
 
             <the-player-id-form :player-id="playerId" @submit="submitPlayerId" @input="onFormInput" />
+
+            <!-- Mode Tabs -->
+            <div v-if="playerId && !loading" class="mt-6 flex justify-center animate-in fade-in slide-in-from-top-4 duration-500">
+              <div class="bg-slate-50 p-1.5 rounded-2xl border border-slate-200/50 shadow-sm flex gap-1">
+                <button
+                  class="px-6 py-2.5 rounded-xl text-[11px] font-black uppercase tracking-[0.15em] transition-all duration-300 flex items-center gap-2"
+                  :class="plannerTab === 'manual' ? 'bg-slate-900 text-white shadow-lg shadow-slate-200' : 'text-slate-400 hover:text-slate-600 hover:bg-slate-50'"
+                  @click="plannerTab = 'manual'"
+                >
+                  <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                  </svg>
+                  Manual Planner
+                </button>
+                <button
+                  class="px-6 py-2.5 rounded-xl text-[11px] font-black uppercase tracking-[0.15em] transition-all duration-300 flex items-center gap-2"
+                  :class="plannerTab === 'automatic' ? 'bg-indigo-600 text-white shadow-lg shadow-indigo-100' : 'text-slate-400 hover:text-slate-600 hover:bg-slate-50'"
+                  @click="handleAutoPlannerTabClick"
+                >
+                  <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z" />
+                  </svg>
+                  Auto Planner
+                  <span class="bg-indigo-500 text-[8px] px-1.5 py-0.5 rounded-md ml-1 border border-indigo-400/30">BETA</span>
+                </button>
+              </div>
+            </div>
 
             <!-- Plan Library Section -->
             <div v-if="playerId" class="max-w-6xl mx-auto mt-6">
@@ -239,8 +266,8 @@
         </div>
       </div>
 
-      <!-- Active Event Slide Toggle (Earnings Boost) - always visible -->
-      <div class="mt-4 flex flex-col items-center gap-2">
+      <!-- Active Event Slide Toggle (Earnings Boost) -->
+      <div v-if="plannerTab === 'manual'" class="mt-4 flex flex-col items-center gap-2">
         <div
           class="w-full max-w-sm bg-gradient-to-r from-orange-50/80 via-white to-amber-50/80 rounded-2xl p-4 border border-orange-100/50 shadow-sm relative overflow-hidden flex items-center justify-between transition-all duration-300"
         >
@@ -277,44 +304,49 @@
         {{ error }}
       </div>
 
-      <!-- Action History and Available Actions side-by-side -->
-      <div class="mt-6 grid grid-cols-1 lg:grid-cols-2 gap-6">
-        <!-- Action History -->
-        <div class="section-premium overflow-visible">
-          <div class="px-4 py-3 flex justify-between items-center rounded-t-lg">
-            <h2 class="text-lg font-semibold text-gray-800">Action History</h2>
-            <button
-              class="p-1 -mr-1 hover:bg-gray-100 rounded-lg cursor-pointer transition-colors"
-              @click="expandedSections.actionHistory = !expandedSections.actionHistory"
-            >
-              <ChevronIcon :expanded="expandedSections.actionHistory" />
-            </button>
+      <div v-if="plannerTab === 'manual'">
+        <!-- Action History and Available Actions side-by-side -->
+        <div class="mt-6 grid grid-cols-1 lg:grid-cols-2 gap-6">
+          <!-- Action History -->
+          <div class="section-premium overflow-visible">
+            <div class="px-4 py-3 flex justify-between items-center rounded-t-lg">
+              <h2 class="text-lg font-semibold text-gray-800">Action History</h2>
+              <button
+                class="p-1 -mr-1 hover:bg-gray-100 rounded-lg cursor-pointer transition-colors"
+                @click="expandedSections.actionHistory = !expandedSections.actionHistory"
+              >
+                <ChevronIcon :expanded="expandedSections.actionHistory" />
+              </button>
+            </div>
+            <div v-if="expandedSections.actionHistory" class="border-t border-gray-200 p-4 bg-gray-50 rounded-b-lg">
+              <ActionHistory @show-details="showActionDetails" @undo="showUndoConfirmation" @clear-all="handleClearAll" />
+            </div>
           </div>
-          <div v-if="expandedSections.actionHistory" class="border-t border-gray-200 p-4 bg-gray-50 rounded-b-lg">
-            <ActionHistory @show-details="showActionDetails" @undo="showUndoConfirmation" @clear-all="handleClearAll" />
-          </div>
-        </div>
 
-        <!-- Available Actions -->
-        <div class="section-premium overflow-visible">
-          <div class="px-4 py-3 flex justify-between items-center rounded-t-lg">
-            <h2 class="text-lg font-semibold text-gray-800">Available Actions</h2>
-            <button
-              class="p-1 -mr-1 hover:bg-gray-100 rounded-lg cursor-pointer transition-colors"
-              @click="expandedSections.availableActions = !expandedSections.availableActions"
-            >
-              <ChevronIcon :expanded="expandedSections.availableActions" />
-            </button>
-          </div>
-          <div v-if="expandedSections.availableActions" class="border-t border-gray-200 p-4 bg-gray-50 rounded-b-lg">
-            <AvailableActions 
-              @show-current-details="showCurrentDetails" 
-              @refresh-backup="handleRefreshReconcile"
-            />
+          <!-- Available Actions -->
+          <div class="section-premium overflow-visible">
+            <div class="px-4 py-3 flex justify-between items-center rounded-t-lg">
+              <h2 class="text-lg font-semibold text-gray-800">Available Actions</h2>
+              <button
+                class="p-1 -mr-1 hover:bg-gray-100 rounded-lg cursor-pointer transition-colors"
+                @click="expandedSections.availableActions = !expandedSections.availableActions"
+              >
+                <ChevronIcon :expanded="expandedSections.availableActions" />
+              </button>
+            </div>
+            <div v-if="expandedSections.availableActions" class="border-t border-gray-200 p-4 bg-gray-50 rounded-b-lg">
+              <AvailableActions 
+                @show-current-details="showCurrentDetails" 
+                @refresh-backup="handleRefreshReconcile"
+              />
+            </div>
           </div>
         </div>
       </div>
-    </div>
+
+      <div v-else-if="plannerTab === 'automatic' && playerId && !loading">
+        <AutomaticPlanner />
+      </div>
 
     <!-- Action Details Modal -->
     <ActionDetailsModal v-if="showDetailsModal" :action="detailsModalAction" @close="closeActionDetails" />
@@ -389,24 +421,28 @@
     <RecalculationOverlay />
 
     <PlanFinalSummary
+      v-if="plannerTab === 'manual'"
       @show-details="showCurrentDetails"
       @update:collapsed="isFooterCollapsed = $event"
       @save-plan="saveCurrentPlan"
       @save-plan-as="savePlanAs"
     />
-    <FloatingStats @show-details="showCurrentDetails" />
-    <FloatingNotes />
+    <FloatingStats v-if="plannerTab === 'manual'" @show-details="showCurrentDetails" />
+    <FloatingNotes v-if="plannerTab === 'manual'" />
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
 import { ref, computed, onMounted, watch } from 'vue';
+import { storeToRefs } from 'pinia';
 import TheNavBar from 'ui/components/NavBar.vue';
 import { getSavedPlayerID, savePlayerID, requestFirstContact } from 'lib';
 import ThePlayerIdForm from 'ui/components/PlayerIdForm.vue';
 import { useInitialStateStore } from '@/stores/initialState';
 import { useActionsStore } from '@/stores/actions';
 import { useVirtueStore } from '@/stores/virtue';
+import { useUIStore } from '@/stores/ui';
 import { useFuelTankStore } from '@/stores/fuelTank';
 import { useTruthEggsStore } from '@/stores/truthEggs';
 import { useEventsStore } from '@/stores/events';
@@ -425,6 +461,7 @@ import WarningDialog from '@/components/WarningDialog.vue';
 import RecalculationOverlay from '@/components/RecalculationOverlay.vue';
 import PlanLibrary from '@/components/PlanLibrary.vue';
 import PlanSelectionDialog from '@/components/PlanSelectionDialog.vue';
+import AutomaticPlanner from '@/components/auto/AutomaticPlanner.vue';
 import { useSalesStore } from '@/stores/sales';
 import { hashID, saveMetadata, loadMetadata } from '@/lib/storage/db';
 import { useActionExecutor } from '@/composables/useActionExecutor';
@@ -448,11 +485,10 @@ import {
 } from '@/lib/modes';
 
 const playerId = ref(new URLSearchParams(window.location.search).get('playerId') || getSavedPlayerID() || '');
-const loading = ref(false);
-const error = ref('');
-
 const initialStateStore = useInitialStateStore();
 const actionsStore = useActionsStore();
+const uiStore = useUIStore();
+const { plannerTab, isHeaderCollapsed, isFooterCollapsed, loading, error } = storeToRefs(uiStore);
 const virtueStore = useVirtueStore();
 const fuelTankStore = useFuelTankStore();
 const truthEggsStore = useTruthEggsStore();
@@ -463,7 +499,7 @@ const notesStore = useNotesStore();
 const { prepareExecution, completeExecution } = useActionExecutor();
 const { partitionHash, saveActiveDraft, initPersistence, broadcastPresence } = usePersistence();
 
-const isEarningsBoostActive = computed(() => actionsStore.effectiveSnapshot.earningsBoost.active);
+const isEarningsBoostActive = computed(() => actionsStore.effectiveSnapshot?.earningsBoost?.active ?? false);
 
 const lastBackupFormatted = computed(() => {
   const approxTime = initialStateStore.rawBackup?.approxTime;
@@ -606,9 +642,10 @@ const expandedSections = ref({
   availableActions: true,
 });
 
-const isHeaderCollapsed = ref(false);
+// isHeaderCollapsed moved to UI store
 
 function handlePlanLoaded() {
+  plannerTab.value = 'manual';
   isHeaderCollapsed.value = true;
   scrollToTop();
 }
@@ -625,7 +662,6 @@ const undoAction = ref<Action | null>(null);
 const undoDependentsA = ref<Action[]>([]);
 const undoDependentsB = ref<Action[]>([]);
 const showClearAllConfirmation = ref(false);
-const isFooterCollapsed = ref(false);
 
 const showReconcileLibraryModal = ref(false);
 const showUnsavedConfirm = ref(false);
@@ -720,6 +756,7 @@ function executeClearAll() {
 async function startFromScratch() {
   error.value = '';
   try {
+    plannerTab.value = 'manual';
     await initStartFromScratch();
     isHeaderCollapsed.value = true;
   } catch (e) {
@@ -742,6 +779,7 @@ async function handleLibraryReconcile(plan: import('@/lib/storage/db').PlanData)
   error.value = '';
 
   try {
+    plannerTab.value = 'manual';
     savePlayerID(playerId.value);
     await initReconcile(playerId.value, plan, broadcastPresence);
     isHeaderCollapsed.value = true;
@@ -788,6 +826,24 @@ function onFormInput(e: Event) {
     playerId.value = target.value.trim();
   }
   error.value = '';
+}
+
+async function handleAutoPlannerTabClick() {
+  plannerTab.value = 'automatic';
+  isHeaderCollapsed.value = true;
+  
+  if (playerId.value && !loading.value) {
+    loading.value = true;
+    try {
+      // Fetch fresh backup and initialize for "Plan Future" mode (zeroed farm)
+      await initPlanFuture(playerId.value);
+    } catch (e) {
+      console.error('Failed to auto-init Auto Planner:', e);
+      error.value = 'Failed to load fresh backup for Auto Planner.';
+    } finally {
+      loading.value = false;
+    }
+  }
 }
 
 /**
@@ -925,6 +981,7 @@ async function quickContinueAscension(selection: 'earnings' | 'elr') {
   loading.value = true;
 
   try {
+    plannerTab.value = 'manual';
     savePlayerID(playerId.value);
     await initContinueCurrent(playerId.value, selection);
     isHeaderCollapsed.value = true;
@@ -947,6 +1004,7 @@ async function planNextAscension() {
   loading.value = true;
 
   try {
+    plannerTab.value = 'manual';
     savePlayerID(playerId.value);
     await initPlanFuture(playerId.value);
     isHeaderCollapsed.value = true;

--- a/wasmegg/ascension-planner/src/auto/AGENT.md
+++ b/wasmegg/ascension-planner/src/auto/AGENT.md
@@ -1,0 +1,106 @@
+# AI Agent Instructions — Auto Planner Module
+
+> **STOP. Read this file before writing any code in this directory.**
+
+## What is this?
+
+This directory contains the **Automatic Ascension Planner** — a sequential multi-ascension plan builder for the Egg, Inc. ascension planner. The user builds their own ascension chain one step at a time, choosing a TE goal for each ascension. Each ascension's end state flows into the next. Changing an earlier ascension recalculates everything downstream.
+
+## Required Reading
+
+Before making ANY code changes in this directory or its subdirectories, you MUST:
+
+1. **Read `PLAN.md` in this directory** — This is the complete feature specification. It contains:
+   - The sequential plan builder concept and state chaining rules
+   - The 13-shift ascension template and what each shift does
+   - The C3 research strategy with its A/B condition matrix
+   - SE tracking across ascensions
+   - Event calendar (Monday 2× earnings, Friday research sales)
+   - The `AscensionSummary` interface
+   - Export/import format
+
+2. **Read `IMPLEMENTATION.md`** — The phased implementation plan with step-by-step instructions.
+
+3. **Understand the existing engine** — This module reuses (does NOT duplicate) the existing engine:
+   - `src/engine/compute.ts` — `computeSnapshot()` (use with `skipGrowth: true`)
+   - `src/engine/apply/actions.ts` — `applyAction()` for pure state transitions
+   - `src/calculations/commonResearch.ts` — research pricing, tier unlocking
+   - `src/calculations/shippingCapacity.ts` — vehicle/train capacity
+   - `src/calculations/layRate.ts` — egg laying rate
+   - `src/lib/truthEggs.ts` — TE thresholds and utilities
+   - `src/lib/events.ts` — `getNextPacificTime()` for event calendar
+   - `src/lib/artifacts/virtue.ts` — `getOptimalELRSet()` for artifact selection
+   - `lib/earning_bonus.ts` — `shiftCost()` for SE costs
+
+4. **Do NOT use Pinia stores or Vue composables** — The auto-planner works with pure `EngineState` objects, not reactive store state. All logic must be pure functions that take state in and return state + actions out.
+
+## Key Constraints
+
+- **13 shifts per ascension** (not 12)
+- **TE ≥ 100 assumed** — population = hab capacity, earnings = flat rate
+- **No fuel tank logic** — pretend it doesn't exist
+- **No code duplication** — reuse existing engine with `skipGrowth: true`
+- **SE can go negative** — don't block on insufficient SE
+- **Minimum 10 TE per ascension** — enforced in the UI input constraints
+- **State chaining** — each ascension's end state (endTime, endTE, endSoulEggs, endShiftCount, finalTE per egg) feeds into the next ascension's start state
+- **Cascading recalculation** — changing ascension N re-simulates N through the end of the chain
+
+## Architecture Overview
+
+```
+src/auto/
+  ├── AGENT.md              ← You are here
+  ├── PLAN.md               ← Full feature specification
+  ├── IMPLEMENTATION.md     ← Step-by-step implementation plan
+  ├── types.ts              // AscensionSummary, ChainedAscension, etc.
+  ├── ascension.ts          // Generate one ascension (runAscension, runUntilShift)
+  ├── calendar.ts           // Event schedule helpers
+  ├── se-tracker.ts         // SE & shift count tracking
+  ├── te-thresholds.ts      // TE threshold crossing calculations
+  ├── engine/               // Engine utilities (strategist, eggs calc)
+  ├── shifts/               // Individual shift strategies
+  │   ├── c1.ts through te-wait.ts
+  └── export.ts             // Plan export/import (TBD)
+
+src/components/auto/
+  ├── AutomaticPlanner.vue  // Main component: inputs + ascension chain
+  ├── AscensionOverview.vue // Single ascension result display
+  └── ShiftSummary.vue      // Individual shift detail view
+```
+
+## Known Bugs & Gotchas
+
+### `advanceTime` must manually credit `bankValue` (Fixed 2026-05-14)
+
+**The Bug:** Every shift file has an `advanceTime(seconds)` helper that creates a `wait_for_time` action and applies it via `applyAction()`. However, `applyAction` treats `wait_for_time` as a **no-op** — it returns the engine state completely unchanged (see `src/engine/apply/actions.ts`, lines 219-226). This means `bankValue` is never increased when the simulation "waits."
+
+Meanwhile, `buyVehicle` / `buyResearch` / etc. estimate how long to wait using:
+
+```ts
+const timeToSave = (price - bankValue) / offlineEarnings;
+advanceTime(timeToSave);
+// then deduct price from bankValue
+```
+
+Since `advanceTime` didn't credit the bank, `bankValue` went increasingly negative after each purchase. After a few buys, the bank was so deeply negative that even a Trike (cheapest vehicle) appeared unaffordable within the remaining time.
+
+**How it was found:** Console logs showed K1 buying one Hyperloop Train + 4 train cars, then being unable to afford *any* vehicle for the remaining 10 slots — despite having 480 seconds left and a positive earnings rate. The mismatch between "earning money" and "bank never growing" was the tell.
+
+**The Fix:** In every shift file's `advanceTime`, compute the current `offlineEarnings` from a snapshot *before* the wait, then manually credit `bankValue` after `applyAction` returns:
+
+```ts
+const advanceTime = (seconds: number) => {
+  if (seconds <= 0) return;
+  const snap = computeSnapshot(currentState, context, { skipGrowth: true });
+  const waitAction = createSimAction('wait_for_time', { totalTimeSeconds: seconds });
+  currentState = applyAction(currentState, waitAction);
+  // applyAction doesn't update bankValue for wait actions, so we credit earnings manually
+  currentState = { ...currentState, bankValue: (currentState.bankValue || 0) + snap.offlineEarnings * seconds };
+  actions.push(waitAction as unknown as any);
+  elapsedSeconds += seconds;
+};
+```
+
+**Files affected:** `c1.ts`, `c2.ts`, `k1.ts`, `k2.ts`, `i1.ts`, `r1.ts` — every shift file that uses `advanceTime`. Any future shift files must use this same pattern.
+
+**Why not fix `applyAction` itself?** The `wait_for_time` action is intentionally a no-op in the manual planner's action replay system. The manual planner recalculates state from scratch via `computeSnapshot` at each step, so it doesn't need `applyAction` to track bank accumulation. The auto-planner is the only consumer that needs incremental bank tracking during simulation, so the fix is correctly scoped to the shift helpers rather than changing shared engine behavior.

--- a/wasmegg/ascension-planner/src/auto/IMPLEMENTATION.md
+++ b/wasmegg/ascension-planner/src/auto/IMPLEMENTATION.md
@@ -1,0 +1,301 @@
+# Auto Planner — Phased Implementation Plan
+
+> **AGENT INSTRUCTIONS**: 
+> - Each step is designed to be independently testable and make visible, incremental progress.
+> - Steps within a phase MUST be completed in order. Phases MUST be completed in order.
+> - **When told to execute the plan or "continue"**, locate the first incomplete step, and work on that SINGLE step. 
+> - **STOP after completing ONE step**. Do not attempt to complete multiple steps at once. The user will choose whether to continue in the current chat or a new one to save context.
+> - **Mark your progress**: As you complete a step, edit this file to change `[ ]` to `[x]` next to the step title.
+
+---
+
+## Phase 0–4: Foundation through Single Ascension ✅
+
+All foundation work is complete. The following has been built and is working:
+
+- [x] `skipGrowth` option on `computeSnapshot`
+- [x] Extracted `computeRealisticELR` to shared utility
+- [x] Extracted ROI calculation to pure function
+- [x] `calendar.ts` — event schedule helpers
+- [x] `types.ts` — `AscensionSummary`, `ShiftResult`, etc.
+- [x] `se-tracker.ts` — SE cost tracking
+- [x] `te-thresholds.ts` — TE threshold crossing calculations
+- [x] Manual/Automatic tab toggle in `App.vue`
+- [x] `AutomaticPlanner.vue` — shell with player ID, target TE, start time, timezone
+- [x] All 13 shift strategies: C1, K1, I1, C2, K2, R1, C3, H1, K3, C4, I2, R2, H2
+- [x] `ascension.ts` — full single ascension orchestrator (`runAscension`, `runUntilShift`)
+- [x] `AscensionOverview.vue` — displays complete ascension results with shift breakdown
+- [x] `ShiftSummary.vue` — detailed per-shift action display
+- [x] 1-sale vs 2-sale comparison with "faster than" recommendation
+
+**Current state**: The user can enter their player ID, set a TE goal, and generate a single ascension. Both 1-sale and 2-sale strategies are simulated, and the faster one is displayed with a comparison badge.
+
+---
+
+## Phase 5: Sequential Ascension Chain
+
+This is the core new feature. Transform the single-ascension generator into a sequential plan builder where each ascension's end state feeds into the next.
+
+### [x] Step 5.1: Add goal input after `AscensionOverview`
+
+**File**: `src/components/auto/AutomaticPlanner.vue`
+
+After each `AscensionOverview` component, render a compact inline input for the next ascension's goal. The user can specify **either** a TE goal or an end date/time:
+
+- **TE Goal** input: integer, min = `previousEndTE + 10`, max = `490`, default = `min(previousEndTE + 30, 490)`
+- **End Date/Time** input: datetime, min = previous ascension's end time. Uses the same timezone as the global start time.
+- The user fills in **one** field. The other is left blank (or shows "auto" placeholder).
+- "Generate Next" button
+- Only show this input if `previousEndTE < 490` (no more ascensions needed at cap)
+
+**Goal resolution logic**:
+1. If the user specifies a **TE goal**: simulate both 1-sale and 2-sale builds to that TE, pick the faster one, back-populate the end date/time field with the winning strategy's end time.
+2. If the user specifies a **date/time goal**: simulate both 1-sale and 2-sale builds, compute how many TE each earns by that deadline, pick the one that earns more TE, back-populate the TE field.
+3. If the user later edits one field: re-evaluate the 1-sale vs. 2-sale decision, recalculate wait phases, update the other field. The build phase (C1→K3) is **not** re-simulated since the start time hasn't changed.
+
+**Visual design**: Keep it lightweight — a small card between ascension overviews, not a full form. Something like:
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  Next Ascension Goal                                        │
+│  [___225___] TE   — or —   [__2026-06-01__] [__09:00__]     │
+│                                        [Generate A2 →]      │
+└──────────────────────────────────────────────────────────────┘
+```
+
+**Test**: Generate A1. Enter a TE goal and generate — verify end date is back-populated. Clear TE, enter a date goal and generate — verify TE is back-populated.
+
+### [x] Step 5.2: Implement state chaining logic
+
+**File**: `src/components/auto/AutomaticPlanner.vue` (or extract to a composable)
+
+Create the logic that derives the next ascension's start state from the previous ascension's summary:
+
+```typescript
+function deriveNextStartState(
+  prevSummary: AscensionSummary,
+  prevActions: Action[],
+  baseBackupState: EngineState // original backup for non-chain properties
+): { startState: EngineState; context: SimulationContext; startTime: number } {
+  // startTime = prevSummary.endTime
+  // startTE = prevSummary.endTE (carried via teEarned per egg = prevSummary.finalTE)
+  // soulEggs = prevSummary.endSoulEggs
+  // shiftCount = prevSummary.endShiftCount
+  // eggsDelivered = prevSummary.eggsDelivered (carried forward — lifetime total)
+  // researchLevels = {} (reset — new farm)
+  // bankValue = 0, population = 1, currentEgg = 'curiosity'
+}
+```
+
+Key state carried forward:
+- `startTime` ← `prevSummary.endTime`
+- `teEarned` per egg ← `prevSummary.finalTE` per egg
+- `soulEggs` ← `prevSummary.endSoulEggs`
+- `shiftCount` ← `prevSummary.endShiftCount`
+
+Key state reset:
+- `eggsDelivered` ← `prevSummary.eggsDelivered` (carried forward for lifetime tracking)
+- `researchLevels` ← `{}`
+- `bankValue` ← `0`
+- `population` ← `1`
+- `currentEgg` ← `'curiosity'`
+
+**Test**: Generate A1, then A2. Verify A2's start time matches A1's end time. Verify A2's starting TE matches A1's ending TE. Verify SE balance is properly decremented.
+
+### [x] Step 5.3: Store ascension chain as reactive array
+
+**File**: `src/components/auto/AutomaticPlanner.vue`
+
+Refactor `generatedPlan` from a single result into a reactive array of ascension results:
+
+```typescript
+interface ChainedAscension {
+  index: number;              // 0-based
+  goalType: 'te' | 'date';   // Which field the user specified
+  targetTE: number;           // TE goal (user-set or back-populated)
+  targetEndTime?: number;     // End date goal as unix timestamp (user-set or back-populated)
+  summary: AscensionSummary;
+  actions: Action[];
+}
+
+const ascensionChain = ref<ChainedAscension[]>([]);
+```
+
+The template should iterate over `ascensionChain` rendering an `AscensionOverview` for each entry, with the goal input after the last entry.
+
+Update the `generate()` function to push new ascensions onto the chain rather than replacing.
+
+**Test**: Generate A1, A2, A3 sequentially. All three appear stacked on the page with correct chaining.
+
+### [x] Step 5.4: Implement cascading recalculation
+
+**File**: `src/components/auto/AutomaticPlanner.vue`
+
+When the user changes the goal (TE or date) for ascension N:
+
+**If N is the last (or only) ascension in the chain:**
+1. Re-evaluate 1-sale vs. 2-sale using the cached build phase (start time unchanged → build phase unchanged)
+2. Recalculate only the TE-wait shifts with the new goal
+3. Back-populate the other goal field
+
+**If N is not the last ascension (there are ascensions N+1 through M):**
+1. Recalculate ascension N as above (wait phase only, build phase cached)
+2. For each ascension N+1 through M: re-derive start state from previous result, **fully re-simulate** (start time changed → build phase changes → new sale boundaries)
+3. Each downstream ascension keeps its existing goal (TE or date, whichever the user originally set) but recalculates everything else
+4. Back-populate the computed field for each downstream ascension
+
+Add an edit affordance to each `AscensionOverview`:
+- The TE goal and end date shown as editable fields in the overview header
+- Changing and confirming triggers recalculation of that ascension and all subsequent ones
+
+**Implementation notes**:
+- The build phase optimization is key: for the edited ascension itself, only wait phases change. For downstream ascensions, full re-simulation is required because their start times shift.
+- Show a brief loading state during recalculation
+- Consider debouncing if the input is a live field
+
+**Test**: Generate A1 (TE goal: 200), A2 (TE goal: 230), A3 (TE goal: 260). Change A1's TE goal to 210. Verify A1's end date updates, A2 and A3 fully recalculate with new start times. Change A2's goal to a date instead of TE — verify TE is back-populated and A3 recalculates.
+
+### [x] Step 5.5: Add delete and insert controls
+
+**File**: `src/components/auto/AutomaticPlanner.vue`
+
+Add controls to each ascension in the chain:
+
+- **Delete**: Remove ascension N, recalculate N+1 onward (their TE goals stay, but start states update)
+- **Insert before**: Add a new ascension before N, prompting for a TE goal, recalculate N onward
+
+Edge cases:
+- Deleting the first ascension: the second one becomes the first, using the global start state
+- Deleting the last ascension: just remove it, show the "Next TE Goal" input after the new last
+- Insert before first: new ascension uses global start state, old first recalculates
+
+**Test**: Generate 3 ascensions. Delete #2 — verify #3 recalculates using #1's end state. Insert before #2 — verify a new ascension appears and everything recalculates.
+
+---
+
+## Phase 6: Export & Polish
+
+### [x] Step 6.1: Export chain as plan library
+
+**File**: New `src/auto/export.ts` + UI button in `AutomaticPlanner.vue`
+
+Convert the entire ascension chain into a plan library JSON file:
+
+```typescript
+interface ExportedPlan {
+  version: 1;
+  exportedAt: string;        // ISO timestamp
+  startTime: number;
+  timezone: string;
+  initialState: {
+    epicResearchLevels: Record<string, number>;
+    colleggtibleTiers: Record<string, number>;
+    artifactLoadout: any[];
+    soulEggs: number;
+    isUltra: boolean;
+    initialTankLevel: number;
+    initialFuelAmounts: Record<string, number>;
+    initialEggsDelivered: Record<string, number>;
+    initialTeEarned: Record<string, number>;
+  };
+  ascensions: {
+    index: number;
+    targetTE: number;
+    result1: { summary: AscensionSummary; actions: Action[] };
+    result2: { summary: AscensionSummary; actions: Action[] };
+    goal: {
+      type: 'te' | 'date';
+      te: number | null;
+      date: string;
+      time: string;
+    };
+  }[];
+}
+```
+
+Add an "Export Plan" button that downloads this as a `.json` file.
+
+**Test**: Generate 3 ascensions, export. Verify the JSON contains all 3 ascensions with correct data.
+
+### [x] Step 6.2: Import plan library
+
+Allow loading an exported plan back into the system via `PlanLibrary.vue`'s `handleImport` function. This should handle the `ExportedPlan` format (v1) and provide two pathways:
+
+1.  **Auto Planner Restore**: Populate the `ascensionChain` with the loaded data and set global inputs (start time, timezone) from the file. Show all ascensions immediately without re-simulating.
+2.  **Manual Library Import**: Support importing each individual ascension in the chain as a separate plan entry in the manual library. 
+
+**Plan Naming Convention**:
+When importing individual ascensions from a chain into the library, use the following name format:
+`{YYYY-MM-DD} {A#} - {peakELR/hr} from {startTE} to {endTE} - {formattedDuration} - starting {YYYY-MM-DD}`
+
+*   **First Date**: Date of the export.
+*   **A#**: Ascension number (e.g., A1, A2).
+*   **peakELR/hr**: Formatted 3-digit ELR per hour (e.g., 1.23 q/hr).
+*   **startTE/endTE**: Starting and ending TE for that specific ascension.
+*   **formattedDuration**: Duration of the ascension (e.g., `5d 4h`).
+*   **Last Date**: Start date of that specific ascension.
+
+**Test**: Export a plan with multiple ascensions. Import it via the library and verify:
+- The Auto Planner restores the full chain correctly.
+- Individual plans can be imported with the specified naming convention.
+
+### [x] Step 6.3: Copy roadmap summary to clipboard
+
+Add a "Copy Summary" button that generates a compact text roadmap:
+
+```
+Ascension Plan — Starting TE: 175
+  A1: 175 → 195 TE (1-sale, 6d 12h)
+  A2: 195 → 225 TE (2-sale, 8d 3h)
+  A3: 225 → 260 TE (1-sale, 5d 18h)
+Total: 175 → 260 TE in ~20 days, 45.2T SE consumed
+```
+
+**Test**: Generate a chain, click Copy Summary, paste into a text editor. Verify the format matches.
+
+### [x] Step 6.4: Running totals in chain view
+
+Add a cumulative summary bar at the bottom of the ascension chain showing:
+- Total duration across all ascensions
+- Total SE consumed
+- Overall TE progress (start → final)
+- Number of ascensions
+
+This updates live as ascensions are added/removed/edited.
+
+**Test**: Generate 3 ascensions. Verify totals match the sum of individual ascension metrics.
+
+---
+
+## Phase 7: Cleanup & Hardening
+
+### [x] Step 7.1: Remove dead tree code & types
+
+Remove any types, functions, or references related to the abandoned decision tree:
+- `tree.ts` (if created)
+- `AutoPlanGoal.maxAscensions` (no longer needed — user adds as many as they want)
+- Any tree-related fields in `AscensionSummary` that are no longer used (`parentId`, `depth` if not used for display)
+- `fullPlanRef?: WeakRef<Action[]>` in `AscensionSummary` — this was a memory optimization for hundreds of tree nodes; with ~dozen sequential plans, just keep actions directly in the `ChainedAscension` array
+- Update `types.ts` to only include what the sequential chain needs
+
+**Test**: TypeScript compiles with no errors. No dead imports.
+
+### [x] Step 7.2: Loading states and error handling
+
+- Show a spinner/skeleton while each ascension simulates
+- Handle edge cases: TE goal already reached, SE going deeply negative, simulation failures
+- Validate that each ascension's TE goal is achievable (endTE matches or exceeds goal)
+- Show a warning if an ascension takes an unreasonably long time (e.g., > 60 days)
+
+### [x] Step 7.3: Responsive layout
+
+- Ensure the chain view works on mobile/tablet
+- The "Next TE Goal" inline input should stack vertically on small screens
+- Ascension overviews should remain readable at narrow widths
+
+### [x] Step 7.4: Ascension numbering and labels
+
+Update `AscensionOverview` to show clear numbering:
+- "Ascension 1", "Ascension 2", etc.
+- Show the TE goal in the header (not just the result)
+- Show cumulative position: "A3 of 5" or similar

--- a/wasmegg/ascension-planner/src/auto/PLAN.md
+++ b/wasmegg/ascension-planner/src/auto/PLAN.md
@@ -1,0 +1,411 @@
+# Automatic Ascension Planner — Spec v5
+
+## 1. The System
+
+A **sequential ascension plan builder** that lets a user construct their own multi-ascension roadmap toward a target TE. The user adds ascensions one at a time, choosing the TE goal for each. Each ascension's end state (end date/time, end TE, SE balance, shift count) automatically becomes the start state of the next. The user can go back and change an earlier ascension's goal, and everything downstream recalculates.
+
+```mermaid
+flowchart TD
+    A["Player Backup<br>Current TE: 175"] --> B["Ascension 1<br>Goal: 195 TE"]
+    B --> C["Ascension 2<br>Goal: 225 TE"]
+    C --> D["Ascension 3<br>Goal: 260 TE"]
+    D --> E["..."]
+    
+    style B fill:#4f46e5,stroke:#6366f1,color:#fff
+    style C fill:#4f46e5,stroke:#6366f1,color:#fff
+    style D fill:#4f46e5,stroke:#6366f1,color:#fff
+```
+
+The tool does **not** auto-generate or branch. The user is in full control of:
+- How many ascensions to plan
+- What TE goal each ascension targets
+- Whether to use a 1-sale or 2-sale build phase (the tool simulates both and recommends the faster one)
+
+---
+
+## 2. User Inputs
+
+### Global Inputs (top of the form)
+
+| Input | Type | Constraints | Description |
+|---|---|---|---|
+| **Player ID** | string | Required | Loads raw backup |
+| **Initial TE** | per-egg breakdown | Auto-populated from backup | Eggs delivered + TE earned per egg, editable |
+| **Ascension Start Time** | datetime + timezone | Defaults to now | When the first ascension begins |
+| **Timezone** | timezone selector | Defaults to browser tz | Reused from initial state tab |
+
+### Per-Ascension Input
+
+After each generated ascension overview, a goal input appears for the next ascension. The user can specify **either** a TE goal **or** a date/time goal — whichever they provide, the tool calculates the other:
+
+| Input | Type | Constraints | Description |
+|---|---|---|---|
+| **TE Goal** | integer | Min: `previousEndTE + 10`, Max: `490` | Target TE for the next ascension |
+| **End Date/Time** | datetime | Min: previous ascension's end time | Target end date (uses same timezone as global start time) |
+
+The user fills in **one** of these fields. The tool then:
+1. Simulates both 1-sale and 2-sale build strategies
+2. Picks the faster/better strategy
+3. Back-populates the other field (either the resulting end date for a TE goal, or the achievable TE for a date goal)
+
+If the user later changes one field, the tool re-evaluates the 1-sale vs. 2-sale decision and recalculates the TE-wait shifts. The build phase (C1→K3) does **not** need to be re-simulated since the ascension's start time hasn't changed — only the wait phase durations change.
+
+The minimum gain of 10 TE per ascension is enforced — smaller gains are always more efficient as extensions of the previous ascension.
+
+### Pre-Calculation Display
+
+Before generating the first ascension, show:
+- **Current TE**: from backup (earned + pending)
+- **TE to gain**: `targetTE - currentTE` (where targetTE is the per-ascension goal)
+
+---
+
+## 3. Sequential Plan Flow
+
+### How It Works
+
+1. **User sets global inputs** (player ID, start time, timezone, initial TE)
+2. **User sets their first goal** (either TE target or end date) and clicks Generate
+3. **Tool simulates both 1-sale and 2-sale builds**, picks the best, back-populates the other goal field, and shows the `AscensionOverview`
+4. **Below the overview**, a new goal input appears for the next ascension
+5. **User enters a goal and generates** — the tool uses the previous ascension's end time, end TE, ending SE, and ending shift count as the start state
+6. **Repeat** until the user reaches 490 TE or stops adding ascensions
+
+### State Chaining
+
+Each ascension's output state becomes the next ascension's input state:
+
+| Property | Source |
+|---|---|
+| `startTime` | Previous ascension's `endTime` |
+| `startTE` | Previous ascension's `endTE` |
+| `startSoulEggs` | Previous ascension's `endSoulEggs` |
+| `startShiftCount` | Previous ascension's `endShiftCount` |
+| `eggsDelivered` | Reset to 0 per egg (new ascension = new farm) |
+| `teEarned` | Previous ascension's `finalTE` per egg |
+| `researchLevels` | Reset to `{}` (new ascension) |
+| `bankValue` | Reset to 0 (new ascension) |
+| `population` | Reset to 1 (new ascension) |
+| `currentEgg` | Reset to `curiosity` (C1 start) |
+
+> [!IMPORTANT]
+> `eggsDelivered` resets per ascension because you start a new farm. But `teEarned` carries over because TE is permanent. The engine uses `teEarned` (not `eggsDelivered`) to determine starting TE for the next ascension's build phase.
+
+### Cascading Recalculation
+
+If the user changes the goal (TE or date) of ascension N (where there are M > N total ascensions):
+- **Ascension N**: Only the TE-wait phase is recalculated (build phase C1→K3 is unchanged since start time didn't change). The 1-sale vs. 2-sale decision is re-evaluated. The other goal field is back-populated.
+- **Ascensions N+1 through M**: Fully re-simulated using updated start states from the chain (new start time, new start TE, updated SE/shift count). Each downstream ascension keeps its existing goal but recalculates everything else (timing, SE costs, ELR, build strategy).
+
+This ensures the plan stays internally consistent. A change to an early ascension that shifts the start date for later ones will change which research sales those later ascensions can access, potentially changing their optimal build strategy and requiring full re-simulation of the build phase.
+
+---
+
+## 4. The 13-Shift Ascension Template
+
+> [!IMPORTANT]
+> Every ascension follows this exact 13-shift sequence. Artifacts start as earnings set.
+
+| # | Egg | Label | Strategy | Time |
+|---|---|---|---|---|
+| 1 | Curiosity | **C1** | Buy cheap research to unlock tiers → fleet_size research → graviton_coupling → earnings research (ROI order) | ≤ 30 min |
+| 2 | Kindness | **K1** | Buy vehicles to maximize earnings first (shipping ≥ lay rate). Then buy biggest vehicles/trains for max shipping capacity. No intermediate vehicles. | ≤ 30 min |
+| 3 | Integrity | **I1** | Buy 4 Chicken Universes | Variable |
+| 4 | Curiosity | **C2** | Finish fleet_size research if needed. Buy graviton_coupling. | Few min |
+| 5 | Kindness | **K2** | Max all vehicles and trains. | Variable |
+| 6 | Resilience | **R1** | Buy as many silos as possible | ≤ 1 hr |
+| 7 | Curiosity | **C3** | **Phase A**: Earnings ROI research → **Phase B**: ELR Impact research. Duration anchored to final research sale. See §8.5 for full strategy. | Variable (sale-anchored) |
+| 8 | Humility | **H1** | Switch to optimal ELR artifacts (existing `getOptimalELRSet`) | Instant |
+| 9 | Kindness | **K3** | Buy last vehicles/trains. **Wait for TE.** *(1st TE-earning shift)* | Variable |
+| 10 | Curiosity | **C4** | Wait for TE *(2nd TE-earning shift)* | Long |
+| 11 | Integrity | **I2** | Wait for TE *(3rd TE-earning shift)* | Long |
+| 12 | Resilience | **R2** | Wait for TE *(4th TE-earning shift)* | Long |
+| 13 | Humility | **H2** | Wait for TE *(5th TE-earning shift)* | Long |
+
+**Max ELR is determined after K3 completes its purchases (shift 9).** H1 switches to ELR artifacts *before* K3, so K3's purchases are made with the ELR set already equipped.
+
+### TE-Earning Shifts
+
+- **5 total TE-earning shifts**: K3 (after purchases), C4, I2, R2, H2
+- Shifts 10-13 (C4/I2/R2/H2) are in **any order** — they're all just waiting for TE
+- K3 earns TE while waiting after its purchases are complete
+
+### Events During Simulation
+
+| Event | Schedule | Effect |
+|---|---|---|
+| **Monday 2× Earnings** | Mon 9 AM PT → Tue 9 AM PT | `earningsBoost.active = true, multiplier = 2` |
+| **Friday Research Sale** | Fri 9 AM PT → Sat 9 AM PT | `activeSales.research = true` (70% off) |
+
+The auto-planner must track simulation time and apply/remove events as the clock crosses these boundaries.
+
+---
+
+## 5. TE ≥ 100 Simplification
+
+**All players using this tool have ≥ 100 TE.** This allows:
+
+- **Population = hab capacity** at all times (IHR so high habs fill instantly)
+- **Earnings = flat rate** (no population growth integration)
+- **Time to save = `price / offlineEarnings`** (simple division)
+- **Skip `wait_for_full_habs` actions entirely**
+- **Skip population growth modeling** in `computeSnapshot`
+
+---
+
+## 6. Engine Integration (No Duplication)
+
+Reuse the existing engine — no separate engine file:
+
+```typescript
+// Use existing computeSnapshot with skipGrowth option
+const snapshot = computeSnapshot(engineState, context, { skipGrowth: true });
+
+// Simplified time-to-save (TE ≥ 100 means flat earnings)
+function fastTimeToSave(price: number, snapshot: CalculationsSnapshot): number {
+  const available = snapshot.bankValue;
+  if (available >= price) return 0;
+  const earnings = snapshot.offlineEarnings;
+  if (earnings <= 0) return Infinity;
+  return (price - available) / earnings;
+}
+```
+
+Key functions reused directly:
+- `computeSnapshot()` — with `skipGrowth: true`
+- `applyAction()` — pure state transitions
+- `getDiscountedVirtuePrice()` — research pricing
+- `getCommonResearches()`, `isTierUnlocked()` — research definitions
+- `calculateArtifactModifiers()` — artifact effects
+- `getOptimalELRSet()` — optimal ELR artifact selection
+- `calculateMaxVehicleSlots()`, `calculateMaxTrainLength()` — vehicle research queries
+- `shiftCost()` — SE cost per shift
+- `getNextPacificTime()` — event calendar
+- `computeRealisticELR()` — exists in `useResearchViews.ts`, extract to shared utility
+
+### What We DON'T Reuse
+- Vue composables — UI-coupled
+- Pinia stores — auto-planner works with pure `EngineState` objects
+- Full simulation pipeline (`simulate.ts`) — we generate actions, not replay them
+
+---
+
+## 7. AscensionSummary: Lightweight Result
+
+```typescript
+interface AscensionSummary {
+  id: string;
+  
+  // Timing
+  startTime: number;                      // Unix timestamp (seconds)
+  endTime: number;                        // Unix timestamp (seconds)
+  totalDurationSeconds: number;
+  
+  // Build phase info
+  buildPhaseEndTime: number;              // When build phase ended (sale boundary)
+  buildPhaseSaleCount: 1 | 2;             // Which sale boundary was used
+  
+  // Key metrics at END of ascension
+  startTE: number;
+  endTE: number;
+  teGained: number;
+  maxELR: number;                         // Peak ELR after K3 purchases (eggs/second)
+  
+  // SE tracking
+  startSoulEggs: number;
+  endSoulEggs: number;                    // After 13 shifts deducted (may be negative)
+  startShiftCount: number;
+  endShiftCount: number;                  // startShiftCount + 13
+  totalShiftCost: number;                 // Sum of 13 shift costs
+  
+  // Per-egg summary
+  eggsDelivered: Record<VirtueEgg, number>;
+  teEarned: Record<VirtueEgg, number>;    // Gained during this ascension
+  finalTE: Record<VirtueEgg, number>;     // Total after ascension
+  
+  // Strategy label for display
+  strategyLabel: string;                  // e.g., "1-sale build"
+  
+  // Max ELR milestone flag
+  isMaxELRAscension: boolean;             // True if this is the ~300 TE collapse
+}
+```
+
+---
+
+## 8. TE Earning Mechanics
+
+TE is earned by delivering eggs past thresholds. The thresholds are defined in `src/lib/truthEggs.ts` — 98 breakpoints per egg in the `TE_BREAKPOINTS` array (from 5e7 to 3.655e19 eggs delivered). Key utilities:
+
+- `countTEThresholdsPassed(delivered)` — how many TE earned for a given eggs-delivered count
+- `nextTEThreshold(delivered)` — eggs needed for the next TE
+- `eggsNeededForTE(currentDelivered, targetTE)` — eggs remaining to reach a specific TE number
+- `pendingTruthEggs(delivered, earnedTE)` — pending (unclaimed) TE
+- `MAX_TE = 98` per egg, `MAX_TOTAL_TE = 490`
+
+### During TE-Earning Shifts (K3, C4, I2, R2, H2)
+
+After the build phase, ELR is constant (max ELR after K3). TE earning is a simple linear calculation:
+
+1. **Eggs delivered per second** = max ELR (constant)
+2. **Time to cross threshold N**: `(TE_BREAKPOINTS[N] - currentEggsDelivered) / maxELR`
+3. **Total TE in time `t`**: count thresholds crossed by `currentEggsDelivered + maxELR × t`
+
+### During Build Phase (C1 through K3)
+
+> [!WARNING]
+> During the build phase, ELR changes with every action (research purchased, vehicle bought, artifact swap). TE is still being earned from eggs delivered at the *current* ELR. The auto-planner must track cumulative eggs delivered as the build phase progresses, using the ELR at each point in time, not a constant rate.
+
+---
+
+## 9. K1 Strategy Clarification
+
+### Goal
+Maximize shipping capacity within ≤ 30 minutes. Do NOT buy intermediate vehicles that don't increase earnings.
+
+### Algorithm
+```
+Phase 1: Get shipping ≥ lay rate (maximize earnings)
+  - Buy the minimum vehicles needed so shipping capacity ≥ lay rate
+  - This unlocks maximum earnings for saving
+  - Skip intermediate vehicle tiers — go straight to the most efficient option
+
+Phase 2: Save and buy biggest (remaining time in ≤ 30 min)
+  - With earnings now maximized, compute what vehicles/trains are affordable
+  - Buy the combination that gives highest total shipping capacity
+  - Don't buy intermediate vehicles just to replace them — 
+    skip to the best vehicle you can afford in the time remaining
+```
+
+---
+
+### 8.5 C3 Strategy — Full Specification
+
+C3 is the longest and most impactful Curiosity shift. Its duration is anchored to the **final research sale** of the build phase. Two main steps:
+
+#### Step 1: Buy Earnings Research
+
+Buy earnings-relevant research (same filter as ROI view — exclude IHR, hab capacity, running chicken bonus, hatchery refill) sorted by **Earnings ROI**.
+
+For each candidate, evaluate two conditions:
+
+- **Condition A**: The research will achieve **70% ROI** before the **start of the next research sale**
+  - Formally: `earningsDelta × (nextSaleStart - purchaseTime) ≥ 0.7 × price`
+- **Condition B**: The research will achieve **100% ROI** before the **end of the build phase**
+  - Formally: `earningsDelta × (buildPhaseEnd - purchaseTime) ≥ price`
+
+Decision matrix:
+
+| A | B | Action |
+|---|---|---|
+| ✅ | ✅ | **Buy now** — it pays for itself and earns 70% back before the sale discount would matter |
+| ❌ | ✅ | **Buy at the start of the next research sale** — wait for the 70% discount, it still pays off before the build phase ends |
+| ❌ | ❌ | **Never buy** — it won't pay for itself even by the end of the build phase |
+| ✅ | ❌ | *(Impossible — if 70% ROI is reached before the sale, 100% ROI is reached shortly after, which is before build phase end in any practical case. Treat as "never buy" if it somehow occurs.)* |
+
+Continue buying earnings research (in ROI order) until no more candidates satisfy A or B.
+
+> [!NOTE]
+> Don't forget to track the **Monday 2× earnings event** during C3. When active, earnings double, which affects both the time-to-save for purchases and the ROI calculations.
+
+#### Step 2: Buy ELR Research
+
+Wait for the **final research sale** to start (Friday 9 AM PT), then buy ELR research:
+
+- View: **ELR Impact, Realistic mode** (optimal ELR artifacts, max habs/vehicles assumed)
+- Sort: **Time Efficiency** (`hpp` — hours per percentage point of ELR improvement)
+- Buy the best time-efficiency research first
+- Continue buying until the sale ends (Saturday 9 AM PT)
+
+This uses the `computeRealisticELR` function (to be extracted from `useResearchViews.ts`).
+
+**Edge case**: Some ELR research may *also* meet Conditions A and B from Step 1 (i.e., it improves earnings enough to pay for itself before the build phase ends). In that case, **buy it immediately** during Step 1, don't wait for the sale.
+
+#### C3 Timeline Example
+
+```
+C3 starts (e.g., Wednesday)
+│
+├─ Step 1: Earnings ROI research
+│  ├─ Buy A+B candidates now
+│  ├─ Queue !A+B candidates for sale start
+│  ├─ Skip !A+!B candidates entirely
+│  └─ Check ELR research for A+B edge case → buy immediately if found
+│
+├─ Monday 9 AM PT: 2× earnings event (if applicable)
+│  └─ Earnings double → recalculate ROI for remaining candidates
+│
+├─ Friday 9 AM PT: Final research sale begins
+│  ├─ Buy queued !A+B earnings research at 70% off
+│  └─ Step 2: Buy ELR Impact research (Realistic, Time Efficiency)
+│
+└─ Saturday 9 AM PT: Sale ends → C3 complete → shift to H1
+```
+
+---
+
+## 10. Architecture
+
+```
+src/auto/
+  ├── AGENT.md                 ← Agent instructions
+  ├── PLAN.md                  ← This file: feature specification
+  ├── IMPLEMENTATION.md        ← Step-by-step implementation plan
+  ├── types.ts                 // AscensionSummary, etc.
+  ├── ascension.ts             // Generate one ascension
+  ├── calendar.ts              // Event schedule helpers
+  ├── se-tracker.ts            // SE & shift count tracking across ascensions
+  ├── te-thresholds.ts         // TE threshold crossing calculations
+  ├── engine/                  // Engine utilities (strategist, eggs calc)
+  ├── shifts/                  // Individual shift strategies
+  │   ├── index.ts
+  │   ├── c1.ts through te-wait.ts
+  └── extract.ts               // Pure functions extracted from UI composables
+
+src/components/auto/
+  ├── AutomaticPlanner.vue     // Main auto planner: inputs + chain of ascensions
+  ├── AscensionOverview.vue    // Single ascension result display
+  └── ShiftSummary.vue         // Individual shift detail view
+```
+
+---
+
+## 11. Export
+
+### Plan Library Export
+
+The user can export their entire ascension chain as a plan library file (JSON). This file contains:
+- Global metadata (player ID, start time, timezone)
+- An ordered array of ascension entries, each with:
+  - TE goal
+  - The full `Action[]` array
+  - The `AscensionSummary`
+
+### Import Back to Manual Planner
+
+An exported plan can be loaded back into the manual planner via "Load Saved Plan." Each ascension in the chain becomes a separate plan entry. The manual planner can replay all actions to verify correctness.
+
+### Copy / Share
+
+A lightweight text summary (no actions, just the roadmap) can be copied to clipboard:
+```
+Ascension Plan - Starting TE: 175
+  A1: 175 → 195 TE (1-sale, 6d 12h) 
+  A2: 195 → 225 TE (2-sale, 8d 3h)
+  A3: 225 → 260 TE (1-sale, 5d 18h)
+  ...
+Total: 175 → 490 TE in ~45 days
+```
+
+---
+
+## 12. Open Questions
+
+All questions have been resolved. ✅
+
+| Question | Resolution |
+|---|---|
+| **C3 Logic** | Fully specified in §8.5 — Earnings ROI with A/B condition matrix → ELR Impact during final sale |
+| **~300 TE Threshold** | Varies by player, computed dynamically per build phase |
+| **TE Thresholds Data** | `src/lib/truthEggs.ts` — `TE_BREAKPOINTS` array + existing utilities |
+| **Decision tree vs. manual** | Abandoned decision tree — user builds their own sequential plan |

--- a/wasmegg/ascension-planner/src/auto/ascension.ts
+++ b/wasmegg/ascension-planner/src/auto/ascension.ts
@@ -1,0 +1,489 @@
+import { type Action, generateActionId } from '@/types/actions/meta';
+import { computeSnapshot } from '@/engine/compute';
+import { countTEThresholdsPassed } from '@/lib/truthEggs';
+import { computeShiftCosts } from './se-tracker';
+import { calculateEggsLaidDuringActions } from './engine/eggs';
+import type { EngineState, SimulationContext, AscensionSummary, ShiftResult } from './types';
+import { runC1 } from './shifts/c1';
+import { runK1 } from './shifts/k1';
+import { runI1 } from './shifts/i1';
+import { runC2 } from './shifts/c2';
+import { runK2 } from './shifts/k2';
+import { runR1 } from './shifts/r1';
+import { runC3 } from './shifts/c3';
+import { runH1 } from './shifts/h1';
+import { runK3 } from './shifts/k3';
+import { runC4, runI2, runR2, runH2, runTEWaitShift, distributeTargetTE, solveTEForTimeBudget } from './shifts/te-wait';
+import { getNextSaleStart, getNextSaleEnd, isResearchSaleActive, isEarningsBoostActive } from './calendar';
+import { calculateArtifactModifiers } from '@/lib/artifacts';
+import { computeRealisticELR } from '@/calculations/realisticELR';
+import type { VirtueEgg } from '@/types';
+
+/**
+ * Derives the starting state for the next ascension in a sequential chain.
+ * Carries forward permanent metrics (TE, SE, shifts) and resets farm-specific progress.
+ */
+export function deriveNextStartState(
+  prevSummary: AscensionSummary,
+  baseBackupState: EngineState
+): EngineState {
+  const totalTE = Object.values(prevSummary.finalTE).reduce((a, b) => a + b, 0);
+
+  return {
+    ...JSON.parse(JSON.stringify(baseBackupState)), // Copy permanent upgrades, artifact sets, etc.
+    
+    // Carried forward metrics
+    te: totalTE,
+    teEarned: { ...prevSummary.finalTE },
+    soulEggs: prevSummary.endSoulEggs,
+    shiftCount: prevSummary.endShiftCount,
+
+    // Reset farm-specific progress
+    currentEgg: 'curiosity',
+    population: 1,
+    bankValue: 0,
+    researchLevels: {},
+    habIds: [0, null, null, null],
+    vehicles: [{ vehicleId: 0, trainLength: 1 }],
+    lastStepTime: 0,
+    eggsDelivered: { ...prevSummary.eggsDelivered },
+    
+    // Reset active modifiers
+    activeSales: {
+      research: false,
+      hab: false,
+      vehicle: false,
+    },
+    earningsBoost: {
+      active: false,
+      multiplier: 1,
+    },
+  };
+}
+
+type ShiftRunner = (state: EngineState, context: SimulationContext, arg3?: number, arg4?: number) => ShiftResult;
+
+const allShifts: { name: string; run: ShiftRunner }[] = [
+  { name: 'C1', run: runC1 },
+  { name: 'K1', run: runK1 },
+  { name: 'I1', run: runI1 },
+  { name: 'C2', run: runC2 },
+  { name: 'K2', run: runK2 },
+  { name: 'R1', run: runR1 },
+  { name: 'C3', run: runC3 },
+  { name: 'H1', run: runH1 },
+  { name: 'K3', run: runK3 },
+  { name: 'C4', run: runC4 },
+  { name: 'I2', run: runI2 },
+  { name: 'R2', run: runR2 },
+  { name: 'H2', run: runH2 },
+];
+
+/**
+ * Runs the simulation until a specific shift name is reached.
+ * Useful for precomputing common phases or debugging.
+ */
+export function runUntilShift(
+  startState: EngineState,
+  context: SimulationContext,
+  stopBeforeShift: string
+) {
+  let currentState = JSON.parse(JSON.stringify(startState));
+  let currentActions: Action[] = [];
+  let totalElapsedSeconds = 0;
+
+  const shiftTimings: { name: string; ms: number }[] = [];
+
+  for (const shift of allShifts) {
+    if (shift.name === stopBeforeShift) break;
+    currentState.lastStepTime = totalElapsedSeconds;
+    const t0 = performance.now();
+    const result = shift.run(currentState, context);
+    shiftTimings.push({ name: shift.name, ms: performance.now() - t0 });
+
+    // Calculate eggs laid during this shift (assuming full habs)
+    const eggsLaid = calculateEggsLaidDuringActions(result.actions, currentState, context);
+    if (result.actions.length > 0 && result.actions[0].type === 'shift') {
+      result.actions[0].payload.eggsLaid = eggsLaid;
+    }
+
+    currentActions.push(...result.actions);
+    currentState = result.endState;
+    totalElapsedSeconds += result.elapsedSeconds;
+  }
+
+  // const totalMs = shiftTimings.reduce((sum, t) => sum + t.ms, 0);
+  // console.log(
+  //   `[C1 to R1] ${totalMs.toFixed(1)}ms total\n` +
+  //   shiftTimings.map(t => `  ${t.name}: ${t.ms.toFixed(1)}ms`).join('\n')
+  // );
+
+  return { state: currentState, actions: currentActions, elapsedSeconds: totalElapsedSeconds };
+}
+
+/**
+ * Calculates the peak ELR reachable at the end of the build phase (K3).
+ * This simulates buying a full fleet of the best vehicles.
+ */
+function calculatePeakELR(state: EngineState, context: SimulationContext): number {
+  const currentState = JSON.parse(JSON.stringify(state));
+  const maxSlots = 17; // Max slots in Egg Inc
+  const maxLen = 10;   // Max cars per train (conservative estimate, will be updated by K3)
+  
+  // Fill fleet with Hyperloops (ID 11)
+  currentState.vehicles = [];
+  for (let i = 0; i < maxSlots; i++) {
+    currentState.vehicles.push({ vehicleId: 11, trainLength: maxLen });
+  }
+
+  const artMods = calculateArtifactModifiers(currentState.artifactLoadout);
+  const elrResult = computeRealisticELR(
+    currentState.researchLevels,
+    artMods,
+    context.epicResearchLevels,
+    context.colleggtibleModifiers
+  );
+  
+  return elrResult.effectiveRate;
+}
+
+/**
+ * Orchestrates a complete 12-shift ascension (C1 does not count as a shift).
+ * 
+ * @param startState - Starting engine state
+ * @param context - Simulation context
+ * @param buildPhaseEnd - Unix timestamp when the build phase should end (C3 end/sale boundary)
+ * @param startTime - Unix timestamp when the ascension starts
+ * @param id - Optional ID for the ascension
+ * @param targetTE - Final target total TE for the entire ascension
+ * @param resumeData - Optional data to skip ahead in the simulation
+ */
+export function runAscension(
+  startState: EngineState,
+  context: SimulationContext,
+  buildPhaseEnd: number,
+  startTime: number,
+  id: string = 'asc_0',
+  targetTE?: number,
+  targetEndTime?: number,
+  resumeData?: { actions: Action[]; state: EngineState; elapsedSeconds: number; resumeShiftName: string }
+): { actions: Action[]; summary: AscensionSummary } {
+  const actualStartState = JSON.parse(JSON.stringify(startState));
+  
+  if (!resumeData) {
+    actualStartState.activeSales.research = isResearchSaleActive(startTime);
+    actualStartState.earningsBoost.active = isEarningsBoostActive(startTime);
+    actualStartState.earningsBoost.multiplier = 2;
+  }
+  
+  let currentState = resumeData ? JSON.parse(JSON.stringify(resumeData.state)) : JSON.parse(JSON.stringify(actualStartState));
+  let currentActions: Action[] = resumeData ? [...resumeData.actions] : [];
+  let totalElapsedSeconds = resumeData ? resumeData.elapsedSeconds : 0;
+
+  let skip = resumeData ? true : false;
+  const ascShiftTimings: { name: string; ms: number }[] = [];
+
+  for (const shift of allShifts) {
+    if (skip) {
+      if (shift.name === resumeData!.resumeShiftName) skip = false;
+      else continue;
+    }
+
+    currentState.lastStepTime = totalElapsedSeconds;
+
+    const t0 = performance.now();
+    let result: ShiftResult;
+    if (shift.name === 'C3') {
+      result = shift.run(currentState, context, buildPhaseEnd);
+    } else if (shift.name === 'K3' || shift.name === 'C4' || shift.name === 'I2' || shift.name === 'R2' || shift.name === 'H2') {
+      // For these shifts, we need the target TE split
+      const currentTEs: any = {
+        curiosity: countTEThresholdsPassed(currentState.eggsDelivered['curiosity'] || 0),
+        integrity: countTEThresholdsPassed(currentState.eggsDelivered['integrity'] || 0),
+        resilience: countTEThresholdsPassed(currentState.eggsDelivered['resilience'] || 0),
+        humility: countTEThresholdsPassed(currentState.eggsDelivered['humility'] || 0),
+        kindness: countTEThresholdsPassed(currentState.eggsDelivered['kindness'] || 0),
+      };
+      
+      let peakELR = currentState.maxELR || 0;
+      if (shift.name === 'K3' && peakELR === 0) {
+        peakELR = calculatePeakELR(currentState, context);
+      }
+      
+      let effectiveTargetTE = targetTE;
+      if (targetEndTime && !effectiveTargetTE) {
+        const timeBudget = Math.max(0, targetEndTime - (startTime + totalElapsedSeconds));
+        effectiveTargetTE = solveTEForTimeBudget(currentTEs, currentState.eggsDelivered, peakELR, timeBudget);
+      }
+
+      const targets = distributeTargetTE(currentTEs, effectiveTargetTE || currentState.te);
+
+      if (shift.name === 'K3') {
+        result = shift.run(currentState, context, buildPhaseEnd, targets['kindness']);
+      } else {
+        const eggMap: Record<string, VirtueEgg> = { 'C4': 'curiosity', 'I2': 'integrity', 'R2': 'resilience', 'H2': 'humility' };
+        result = shift.run(currentState, context, targets[eggMap[shift.name]], peakELR);
+      }
+    } else {
+      result = shift.run(currentState, context);
+    }
+
+    // Calculate eggs laid during this shift (assuming full habs)
+    const eggsLaid = calculateEggsLaidDuringActions(result.actions, currentState, context);
+    if (result.actions.length > 0 && result.actions[0].type === 'shift') {
+      result.actions[0].payload.eggsLaid = eggsLaid;
+    }
+
+    ascShiftTimings.push({ name: shift.name, ms: performance.now() - t0 });
+
+    currentActions.push(...result.actions);
+    currentState = result.endState;
+    totalElapsedSeconds += result.elapsedSeconds;
+  }
+
+  // const ascTotalMs = ascShiftTimings.reduce((sum, t) => sum + t.ms, 0);
+  // console.log(
+  //   `[C3 to H2 ${id}] ${ascTotalMs.toFixed(1)}ms total\n` +
+  //   ascShiftTimings.map(t => `  ${t.name}: ${t.ms.toFixed(1)}ms`).join('\n')
+  // );
+
+  // Prepend start action if not resuming
+  if (!resumeData) {
+    const startSnapshot = computeSnapshot(actualStartState, context);
+    const startAction: Action = {
+      id: generateActionId(),
+      index: 0,
+      timestamp: startTime * 1000,
+      type: 'start_ascension',
+      payload: { initialEgg: actualStartState.currentEgg as VirtueEgg },
+      cost: 0,
+      elrDelta: 0,
+      offlineEarningsDelta: 0,
+      eggValueDelta: 0,
+      habCapacityDelta: 0,
+      layRateDelta: 0,
+      shippingCapacityDelta: 0,
+      ihrDelta: 0,
+      bankDelta: 0,
+      populationDelta: 0,
+      totalTimeSeconds: 0,
+      endState: startSnapshot,
+      dependsOn: [],
+      dependents: [],
+    };
+    currentActions.unshift(startAction);
+  }
+
+  // Ensure indices are correct
+  currentActions.forEach((a, idx) => {
+    a.index = idx;
+  });
+
+  // SE cost tracking (C1 does not count as a shift; count actual shift actions in case some were skipped)
+  const actualShiftCount = currentActions.filter(a => a.type === 'shift').length;
+  const seResult = computeShiftCosts(startState.soulEggs, startState.shiftCount, actualShiftCount);
+
+  // Calculate sale count in build phase
+  let saleCount = isResearchSaleActive(startTime) ? 1 : 0;
+  let nextSale = getNextSaleStart(startTime);
+  while (nextSale < buildPhaseEnd) {
+    saleCount++;
+    nextSale = getNextSaleStart(nextSale + 1);
+  }
+
+  // Build the summary
+  const summary: AscensionSummary = {
+    id,
+    startTime,
+    endTime: startTime + totalElapsedSeconds,
+    totalDurationSeconds: totalElapsedSeconds,
+    buildPhaseEndTime: buildPhaseEnd,
+    buildPhaseSaleCount: (saleCount === 2 ? 2 : 1) as 1 | 2,
+    startTE: startState.te,
+    endTE: currentState.te,
+    teGained: currentState.te - startState.te,
+    maxELR: currentState.maxELR || 0,
+    startSoulEggs: startState.soulEggs,
+    endSoulEggs: seResult.endingSE,
+    startShiftCount: startState.shiftCount,
+    endShiftCount: seResult.endingShiftCount,
+    totalShiftCost: seResult.totalCost,
+    eggsDelivered: { ...currentState.eggsDelivered },
+    teEarned: {
+      curiosity: (currentState.teEarned['curiosity'] || 0) - (startState.teEarned['curiosity'] || 0),
+      integrity: (currentState.teEarned['integrity'] || 0) - (startState.teEarned['integrity'] || 0),
+      resilience: (currentState.teEarned['resilience'] || 0) - (startState.teEarned['resilience'] || 0),
+      humility: (currentState.teEarned['humility'] || 0) - (startState.teEarned['humility'] || 0),
+      kindness: (currentState.teEarned['kindness'] || 0) - (startState.teEarned['kindness'] || 0),
+    },
+    finalTE: {
+      curiosity: countTEThresholdsPassed(currentState.eggsDelivered['curiosity'] || 0),
+      integrity: countTEThresholdsPassed(currentState.eggsDelivered['integrity'] || 0),
+      resilience: countTEThresholdsPassed(currentState.eggsDelivered['resilience'] || 0),
+      humility: countTEThresholdsPassed(currentState.eggsDelivered['humility'] || 0),
+      kindness: countTEThresholdsPassed(currentState.eggsDelivered['kindness'] || 0),
+    },
+    strategyLabel: `${saleCount}-sale build`,
+    isMaxELRAscension: false,
+  };
+
+  return {
+    actions: currentActions,
+    summary,
+  };
+}
+
+/**
+ * Simulates continuing the current ascension without any purchases or build phase.
+ * Only shifts between eggs and waits for TE at the player's current ELR.
+ * Visits each of the 5 virtue eggs 0 or 1 times, ending with balanced TE.
+ * 
+ * @param startState - Current engine state (with existing farm intact)
+ * @param context - Simulation context
+ * @param startTime - Unix timestamp when the plan starts
+ * @param currentELR - The player's current effective lay rate (eggs/second)
+ * @param targetTE - Final target total TE
+ * @param id - Optional ID for the ascension
+ */
+export function runContinueCurrent(
+  startState: EngineState,
+  context: SimulationContext,
+  startTime: number,
+  currentELR: number,
+  targetTE: number,
+  id: string = 'asc_continue'
+): { actions: Action[]; summary: AscensionSummary } {
+  const actualStartState: EngineState = JSON.parse(JSON.stringify(startState));
+
+  // Catch-up earnings: determine how long ago the last backup was,
+  // then add that many eggs based on current ELR.
+  const approxTime = context.rawBackup?.approxTime || 0;
+  if (approxTime > 0 && startTime > approxTime) {
+    const elapsedSeconds = startTime - approxTime;
+    const catchUpEggs = currentELR * elapsedSeconds;
+    const currentEgg = actualStartState.currentEgg;
+    actualStartState.eggsDelivered[currentEgg] = (actualStartState.eggsDelivered[currentEgg] || 0) + catchUpEggs;
+
+    // Recalculate TE earned for the current egg and total TE
+    const newTE = countTEThresholdsPassed(actualStartState.eggsDelivered[currentEgg]);
+    actualStartState.teEarned[currentEgg] = Math.max(actualStartState.teEarned[currentEgg] || 0, newTE);
+    actualStartState.te = Object.values(actualStartState.teEarned).reduce((a, b) => a + b, 0);
+  }
+
+  let currentState: EngineState = JSON.parse(JSON.stringify(actualStartState));
+  const currentActions: Action[] = [];
+  let totalElapsedSeconds = 0;
+
+  const allEggs: VirtueEgg[] = ['curiosity', 'kindness', 'integrity', 'resilience', 'humility'];
+
+  // Calculate current TE per egg from eggs delivered
+  const currentTEs: Record<VirtueEgg, number> = {
+    curiosity: countTEThresholdsPassed(currentState.eggsDelivered['curiosity'] || 0),
+    integrity: countTEThresholdsPassed(currentState.eggsDelivered['integrity'] || 0),
+    resilience: countTEThresholdsPassed(currentState.eggsDelivered['resilience'] || 0),
+    humility: countTEThresholdsPassed(currentState.eggsDelivered['humility'] || 0),
+    kindness: countTEThresholdsPassed(currentState.eggsDelivered['kindness'] || 0),
+  };
+
+  // Distribute target TE balanced across eggs
+  const targets = distributeTargetTE(currentTEs, targetTE);
+
+  // Determine which eggs need more TE, sorted by needed TE (ascending — cheapest first)
+  const eggsToVisit = allEggs
+    .filter(egg => targets[egg] > currentTEs[egg])
+    .sort((a, b) => (targets[a] - currentTEs[a]) - (targets[b] - currentTEs[b]));
+
+  // If the player's current egg from backup needs visiting, prioritize it to the front
+  const currentEggIdx = eggsToVisit.indexOf(currentState.currentEgg as VirtueEgg);
+  if (currentEggIdx !== -1) {
+    eggsToVisit.splice(currentEggIdx, 1);
+    eggsToVisit.unshift(currentState.currentEgg as VirtueEgg);
+  }
+
+  // Run TE wait shifts for each egg that needs visiting
+  for (const egg of eggsToVisit) {
+    currentState.lastStepTime = totalElapsedSeconds;
+    const result = runTEWaitShift(currentState, context, egg, targets[egg], currentELR);
+
+    currentActions.push(...result.actions);
+    currentState = result.endState;
+    totalElapsedSeconds += result.elapsedSeconds;
+  }
+
+  // If the player is already on an egg that doesn't need visiting (e.g. kindness with 0 needed),
+  // we might end on a different egg. The TE wait shifts handle this via their shift logic.
+
+  // Prepend start action
+  const startSnapshot = computeSnapshot(actualStartState, context);
+  const startAction: Action = {
+    id: generateActionId(),
+    index: 0,
+    timestamp: startTime * 1000,
+    type: 'start_ascension',
+    payload: { initialEgg: actualStartState.currentEgg as VirtueEgg },
+    cost: 0,
+    elrDelta: 0,
+    offlineEarningsDelta: 0,
+    eggValueDelta: 0,
+    habCapacityDelta: 0,
+    layRateDelta: 0,
+    shippingCapacityDelta: 0,
+    ihrDelta: 0,
+    bankDelta: 0,
+    populationDelta: 0,
+    totalTimeSeconds: 0,
+    endState: startSnapshot,
+    dependsOn: [],
+    dependents: [],
+  };
+  currentActions.unshift(startAction);
+
+  // Fix indices
+  currentActions.forEach((a, idx) => {
+    a.index = idx;
+  });
+
+  // SE cost — count only the shifts we actually did
+  const shiftCount = currentActions.filter(a => a.type === 'shift').length;
+  const seResult = computeShiftCosts(startState.soulEggs, startState.shiftCount, shiftCount);
+
+  const summary: AscensionSummary = {
+    id,
+    startTime,
+    endTime: startTime + totalElapsedSeconds,
+    totalDurationSeconds: totalElapsedSeconds,
+    buildPhaseEndTime: startTime, // No build phase
+    buildPhaseSaleCount: 1,
+    startTE: startState.te,
+    endTE: currentState.te,
+    teGained: currentState.te - startState.te,
+    maxELR: currentELR,
+    startSoulEggs: startState.soulEggs,
+    endSoulEggs: seResult.endingSE,
+    startShiftCount: startState.shiftCount,
+    endShiftCount: seResult.endingShiftCount,
+    totalShiftCost: seResult.totalCost,
+    eggsDelivered: { ...currentState.eggsDelivered },
+    teEarned: {
+      curiosity: (currentState.teEarned['curiosity'] || 0) - (startState.teEarned['curiosity'] || 0),
+      integrity: (currentState.teEarned['integrity'] || 0) - (startState.teEarned['integrity'] || 0),
+      resilience: (currentState.teEarned['resilience'] || 0) - (startState.teEarned['resilience'] || 0),
+      humility: (currentState.teEarned['humility'] || 0) - (startState.teEarned['humility'] || 0),
+      kindness: (currentState.teEarned['kindness'] || 0) - (startState.teEarned['kindness'] || 0),
+    },
+    finalTE: {
+      curiosity: countTEThresholdsPassed(currentState.eggsDelivered['curiosity'] || 0),
+      integrity: countTEThresholdsPassed(currentState.eggsDelivered['integrity'] || 0),
+      resilience: countTEThresholdsPassed(currentState.eggsDelivered['resilience'] || 0),
+      humility: countTEThresholdsPassed(currentState.eggsDelivered['humility'] || 0),
+      kindness: countTEThresholdsPassed(currentState.eggsDelivered['kindness'] || 0),
+    },
+    strategyLabel: 'Continue current',
+    isMaxELRAscension: false,
+  };
+
+  return {
+    actions: currentActions,
+    summary,
+  };
+}

--- a/wasmegg/ascension-planner/src/auto/buildLibraryPlans.ts
+++ b/wasmegg/ascension-planner/src/auto/buildLibraryPlans.ts
@@ -2,13 +2,11 @@ import { formatNumber, formatDuration, formatUnixToDateInput, formatUnixToTimeIn
 import { createEmptySnapshot } from '@/types';
 import type { ExportedPlan } from './export';
 
-function pickBest(a: any, idx: number, a1ForceMode: 'continue' | 'prestige' | null): any {
-  if (idx === 0 && a1ForceMode === 'continue' && a.result3) return a.result3;
-  if (idx === 0 && a1ForceMode === 'prestige') {
-    return a.result1.summary.totalDurationSeconds <= a.result2.summary.totalDurationSeconds
-      ? a.result1
-      : a.result2;
-  }
+function pickBest(a: any, idx: number, overrides: Record<number, string>): any {
+  const override = overrides[idx];
+  if (override === 'continue' && a.result3) return a.result3;
+  if (override === '1-sale') return a.result1;
+  if (override === '2-sale') return a.result2;
   const candidates = [a.result1, a.result2, ...(a.result3 ? [a.result3] : [])].filter(Boolean);
   return candidates.reduce((b: any, c: any) =>
     c.summary.totalDurationSeconds < b.summary.totalDurationSeconds ? c : b
@@ -19,10 +17,12 @@ export function buildLibraryPlansFromExport(
   imported: ExportedPlan,
   namePrefix: string,
 ): { name: string; data: Record<string, unknown> }[] {
-  const a1ForceMode = imported.a1ForceMode ?? null;
+  const overrides: Record<number, string> = imported.planVariantOverrides ?? (
+    imported.a1ForceMode === 'continue' ? { 0: 'continue' } : {}
+  );
 
   return imported.ascensions.map((a, idx) => {
-    const best = pickBest(a, idx, a1ForceMode);
+    const best = pickBest(a, idx, overrides);
 
     let finalActions = best.actions;
     if (finalActions.length === 0 || finalActions[0].type !== 'start_ascension') {
@@ -51,7 +51,7 @@ export function buildLibraryPlansFromExport(
     const state = JSON.parse(JSON.stringify(imported.initialState));
 
     if (idx > 0) {
-      const prevBest = pickBest(imported.ascensions[idx - 1], idx - 1, a1ForceMode);
+      const prevBest = pickBest(imported.ascensions[idx - 1], idx - 1, overrides);
       state.initialTeEarned = { ...prevBest.summary.finalTE };
       state.initialEggsDelivered = { ...prevBest.summary.eggsDelivered };
       state.soulEggs = prevBest.summary.endSoulEggs;

--- a/wasmegg/ascension-planner/src/auto/buildLibraryPlans.ts
+++ b/wasmegg/ascension-planner/src/auto/buildLibraryPlans.ts
@@ -1,0 +1,86 @@
+import { formatNumber, formatDuration, formatUnixToDateInput, formatUnixToTimeInput } from '@/lib/format';
+import { createEmptySnapshot } from '@/types';
+import type { ExportedPlan } from './export';
+
+function pickBest(a: any, idx: number, a1ForceMode: 'continue' | 'prestige' | null): any {
+  if (idx === 0 && a1ForceMode === 'continue' && a.result3) return a.result3;
+  if (idx === 0 && a1ForceMode === 'prestige') {
+    return a.result1.summary.totalDurationSeconds <= a.result2.summary.totalDurationSeconds
+      ? a.result1
+      : a.result2;
+  }
+  const candidates = [a.result1, a.result2, ...(a.result3 ? [a.result3] : [])].filter(Boolean);
+  return candidates.reduce((b: any, c: any) =>
+    c.summary.totalDurationSeconds < b.summary.totalDurationSeconds ? c : b
+  );
+}
+
+export function buildLibraryPlansFromExport(
+  imported: ExportedPlan,
+  namePrefix: string,
+): { name: string; data: Record<string, unknown> }[] {
+  const a1ForceMode = imported.a1ForceMode ?? null;
+
+  return imported.ascensions.map((a, idx) => {
+    const best = pickBest(a, idx, a1ForceMode);
+
+    let finalActions = best.actions;
+    if (finalActions.length === 0 || finalActions[0].type !== 'start_ascension') {
+      const startAction = {
+        id: 'start_' + Math.random().toString(36).substring(2, 9),
+        index: 0,
+        timestamp: best.summary.startTime * 1000,
+        type: 'start_ascension',
+        payload: { initialEgg: 'curiosity' },
+        cost: 0, elrDelta: 0, offlineEarningsDelta: 0, eggValueDelta: 0,
+        habCapacityDelta: 0, layRateDelta: 0, shippingCapacityDelta: 0,
+        ihrDelta: 0, bankDelta: 0, populationDelta: 0, totalTimeSeconds: 0,
+        endState: createEmptySnapshot(),
+        dependsOn: [], dependents: [],
+      };
+      finalActions = [startAction, ...finalActions];
+      finalActions.forEach((action: any, i: number) => { action.index = i; });
+    }
+
+    const summary = best.summary;
+    const startStr = new Date(summary.startTime * 1000).toISOString().split('T')[0];
+    const peakELR = formatNumber(summary.maxELR * 3600, 2);
+    const duration = formatDuration(summary.totalDurationSeconds);
+    const name = `${namePrefix} A${idx + 1} - ${peakELR}/hr from ${summary.startTE} to ${summary.endTE} - ${duration} - starting ${startStr}`;
+
+    const state = JSON.parse(JSON.stringify(imported.initialState));
+
+    if (idx > 0) {
+      const prevBest = pickBest(imported.ascensions[idx - 1], idx - 1, a1ForceMode);
+      state.initialTeEarned = { ...prevBest.summary.finalTE };
+      state.initialEggsDelivered = { ...prevBest.summary.eggsDelivered };
+      state.soulEggs = prevBest.summary.endSoulEggs;
+      state.initialShiftCount = prevBest.summary.endShiftCount;
+    }
+
+    return {
+      name,
+      data: {
+        version: 1,
+        actions: finalActions,
+        initialState: state,
+        virtueState: {
+          shiftCount: state.initialShiftCount || 0,
+          initialTE: Object.values(state.initialTeEarned || {}).reduce((s: number, v: any) => s + (v || 0), 0),
+          ascensionDate: formatUnixToDateInput(imported.startTime, imported.timezone),
+          ascensionTime: formatUnixToTimeInput(imported.startTime, imported.timezone),
+          ascensionTimezone: imported.timezone,
+        },
+        fuelTankState: {
+          tankLevel: state.initialTankLevel || 0,
+          fuelAmounts: state.initialFuelAmounts || {},
+        },
+        truthEggsState: {
+          eggsDelivered: state.initialEggsDelivered || {},
+          teEarned: state.initialTeEarned || {},
+        },
+        notesState: { notes: [] },
+      },
+    };
+  });
+}

--- a/wasmegg/ascension-planner/src/auto/buildLibraryPlans.ts
+++ b/wasmegg/ascension-planner/src/auto/buildLibraryPlans.ts
@@ -67,8 +67,8 @@ export function buildLibraryPlansFromExport(
         virtueState: {
           shiftCount: state.initialShiftCount || 0,
           initialTE: Object.values(state.initialTeEarned || {}).reduce((s: number, v: any) => s + (v || 0), 0),
-          ascensionDate: formatUnixToDateInput(imported.startTime, imported.timezone),
-          ascensionTime: formatUnixToTimeInput(imported.startTime, imported.timezone),
+          ascensionDate: formatUnixToDateInput(best.summary.startTime, imported.timezone),
+          ascensionTime: formatUnixToTimeInput(best.summary.startTime, imported.timezone),
           ascensionTimezone: imported.timezone,
         },
         fuelTankState: {

--- a/wasmegg/ascension-planner/src/auto/calendar.ts
+++ b/wasmegg/ascension-planner/src/auto/calendar.ts
@@ -1,0 +1,45 @@
+import { getNextPacificTime } from '@/lib/events';
+
+/**
+ * Returns the Unix timestamp (in seconds) of the next Research Sale start (Friday 9 AM PT).
+ */
+export function getNextSaleStart(timestampSeconds: number): number {
+  return getNextPacificTime(5, 9, timestampSeconds);
+}
+
+/**
+ * Returns the Unix timestamp (in seconds) of the next Research Sale end (Saturday 9 AM PT).
+ */
+export function getNextSaleEnd(timestampSeconds: number): number {
+  return getNextPacificTime(6, 9, timestampSeconds);
+}
+
+/**
+ * Returns true if a Research Sale is active at the given timestamp.
+ */
+export function isResearchSaleActive(timestampSeconds: number): boolean {
+  // If the next end is sooner than the next start, we are currently in a sale.
+  return getNextSaleEnd(timestampSeconds) < getNextSaleStart(timestampSeconds);
+}
+
+/**
+ * Returns the Unix timestamp (in seconds) of the next Earnings Boost start (Monday 9 AM PT).
+ */
+export function getNextEarningsBoostStart(timestampSeconds: number): number {
+  return getNextPacificTime(1, 9, timestampSeconds);
+}
+
+/**
+ * Returns the Unix timestamp (in seconds) of the next Earnings Boost end (Tuesday 9 AM PT).
+ */
+export function getNextEarningsBoostEnd(timestampSeconds: number): number {
+  return getNextPacificTime(2, 9, timestampSeconds);
+}
+
+/**
+ * Returns true if an Earnings Boost is active at the given timestamp.
+ */
+export function isEarningsBoostActive(timestampSeconds: number): boolean {
+  // If the next end is sooner than the next start, we are currently in an earnings boost.
+  return getNextEarningsBoostEnd(timestampSeconds) < getNextEarningsBoostStart(timestampSeconds);
+}

--- a/wasmegg/ascension-planner/src/auto/engine/eggs.ts
+++ b/wasmegg/ascension-planner/src/auto/engine/eggs.ts
@@ -1,0 +1,33 @@
+import type { Action } from '@/types/actions/meta';
+import type { EngineState, SimulationContext } from '../types';
+import { computeSnapshot } from '../../engine/compute';
+import { applyAction } from '../../engine/apply';
+
+/**
+ * Calculates the total eggs laid during a sequence of actions.
+ * Assumes habitats were full the entire time.
+ */
+export function calculateEggsLaidDuringActions(
+  actions: Action[],
+  startState: EngineState,
+  context: SimulationContext
+): number {
+  let currentState = { ...startState };
+  let totalEggs = 0;
+
+  for (const action of actions) {
+    // Before applying the action, we compute the ELR of the current state.
+    // If the action has a duration (wait_for_time), we lay eggs at this ELR.
+    const snap = computeSnapshot(currentState, context, { skipGrowth: true });
+    
+    if (action.type === 'wait_for_time') {
+      const duration = action.payload.totalTimeSeconds || 0;
+      totalEggs += snap.elr * duration;
+    }
+
+    // Apply the action to move to the next state
+    currentState = applyAction(currentState, action);
+  }
+
+  return totalEggs;
+}

--- a/wasmegg/ascension-planner/src/auto/engine/strategist.ts
+++ b/wasmegg/ascension-planner/src/auto/engine/strategist.ts
@@ -1,0 +1,197 @@
+import type { EngineState, SimulationContext } from '../types';
+import { calculateResearchROI } from '../../calculations/researchROI';
+import {
+  getCommonResearches,
+  getDiscountedVirtuePrice,
+  type ResearchCostModifiers,
+  isTierUnlocked,
+  purchasesNeededForTier,
+} from '../../calculations/commonResearch';
+import { computeSnapshot } from '../../engine/compute';
+
+export interface EventTiming {
+  absoluteSimTime: number;
+  nextSaleStart: number;
+  eventExpirationSeconds: number;
+  researchSaleDeadline: number;
+  isSaleActive: boolean;
+}
+
+export interface EarningsRecommendation {
+  researchId: string;
+  price: number;
+  isFiller: boolean;
+  roiSeconds: number;
+  name: string;
+  timeToBuySeconds: number;
+  earningsDelta: number;
+}
+
+export const DEFAULT_EARNINGS_CATEGORIES = [
+  'egg_value',
+  'egg_laying_rate',
+  'shipping_capacity',
+  'hab_capacity',
+];
+
+/**
+ * Finds the best earnings-related research to buy, considering both direct ROI 
+ * and the "Path ROI" of unlocking higher tiers.
+ */
+export function getBestEarningsRecommendation(
+  currentState: EngineState,
+  context: SimulationContext,
+  eventTiming: EventTiming,
+  modifiers: ResearchCostModifiers,
+  timeLeft: number,
+  categories: string[] = DEFAULT_EARNINGS_CATEGORIES,
+  buildPhaseEnd?: number
+): EarningsRecommendation | null {
+  if (timeLeft <= 0 || timeLeft === Infinity) return null;
+
+  const currentSnap = computeSnapshot(currentState, context, { skipGrowth: true });
+  const allCommon = getCommonResearches();
+  const unmaxed = allCommon.filter(r => (currentState.researchLevels[r.id] || 0) < r.levels);
+  const unlockedTiers = Array.from(
+    new Set(allCommon.filter(r => isTierUnlocked(currentState.researchLevels, r.tier)).map(r => r.tier))
+  );
+  const maxUnlockedTier = Math.max(0, ...unlockedTiers);
+  const absTime = eventTiming.absoluteSimTime;
+
+  // 1. Evaluate current best ROI among unlocked research
+  const candidates = unmaxed
+    .filter(r => categories.some(cat => r.categories.includes(cat)))
+    .filter(r => r.tier <= maxUnlockedTier)
+    .map(r => {
+      const level = currentState.researchLevels[r.id] || 0;
+      const price = getDiscountedVirtuePrice(r, level, modifiers, eventTiming.isSaleActive);
+      return {
+        research: r,
+        price,
+        roi: calculateResearchROI({
+          research: r,
+          level,
+          price,
+          snapshot: currentSnap,
+          context,
+          eventTiming,
+        }),
+      };
+    })
+    .filter(item => item.roi.roiSeconds < timeLeft)
+    .sort((a, b) => a.roi.roiSeconds - b.roi.roiSeconds);
+
+  const bestCurrentROI = candidates.length > 0 ? candidates[0].roi.roiSeconds : Infinity;
+
+  // Filter candidates by "Meets A/B" criteria if buildPhaseEnd is provided
+  const validCandidates = candidates.filter(c => {
+    if (buildPhaseEnd === undefined) return true;
+
+    const purchaseTime = absTime + c.roi.timeToBuySeconds;
+    if (purchaseTime > buildPhaseEnd) return false;
+    
+    // Meets B: Research pays for itself before the end of the build phase
+    const meetsB = c.roi.earningsDelta * (buildPhaseEnd - purchaseTime) >= c.price;
+    if (!meetsB) return false;
+
+    // Meets A: If no sale, is it better to buy now vs wait for Friday?
+    // (Buying now is worth it if it earns back at least 70% of its price before the sale starts)
+    const meetsA = eventTiming.isSaleActive || 
+      (c.roi.earningsDelta * (eventTiming.nextSaleStart - purchaseTime) >= 0.7 * c.price);
+    
+    return meetsA;
+  });
+
+  let bestRecommendation: EarningsRecommendation | null = null;
+  if (validCandidates.length > 0) {
+    const best = validCandidates[0];
+    bestRecommendation = {
+      researchId: best.research.id,
+      price: best.price,
+      isFiller: false,
+      roiSeconds: best.roi.roiSeconds,
+      name: best.research.name,
+      timeToBuySeconds: best.roi.timeToBuySeconds,
+      earningsDelta: best.roi.earningsDelta,
+    };
+  }
+
+  // 2. Evaluate ROI of unlocking the next tier (targeting big gains)
+  if (maxUnlockedTier < 13) {
+    const nextTier = maxUnlockedTier + 1;
+    const needed = purchasesNeededForTier(currentState.researchLevels, nextTier);
+
+    if (needed > 0) {
+      const fillers = unmaxed
+        .filter(r => r.tier < nextTier)
+        .map(r => {
+          const currentLevel = currentState.researchLevels[r.id] || 0;
+          const price = getDiscountedVirtuePrice(
+            r,
+            currentLevel,
+            modifiers,
+            eventTiming.isSaleActive
+          );
+          return { id: r.id, name: r.name, price, levelsLeft: r.levels - currentLevel };
+        })
+        .sort((a, b) => a.price - b.price);
+
+      const totalFillerLevels = fillers.reduce((sum, f) => sum + f.levelsLeft, 0);
+
+      if (totalFillerLevels >= needed) {
+        // Approximate cost to unlock using the cheapest filler
+        const unlockPrice = fillers[0].price * Math.min(needed, fillers[0].levelsLeft);
+
+        const nextTierEarnings = unmaxed
+          .filter(r => r.tier === nextTier && categories.some(cat => r.categories.includes(cat)))
+          .map(r => {
+            const level = currentState.researchLevels[r.id] || 0;
+            const price = getDiscountedVirtuePrice(r, level, modifiers, eventTiming.isSaleActive);
+            return {
+              research: r,
+              price,
+              roi: calculateResearchROI({
+                research: r,
+                level,
+                price,
+                snapshot: currentSnap,
+                context,
+                eventTiming,
+              }),
+            };
+          })
+          .filter(c => c.roi.roiSeconds !== Infinity)
+          .sort((a, b) => a.roi.roiSeconds - b.roi.roiSeconds);
+
+        if (nextTierEarnings.length > 0) {
+          const bestNext = nextTierEarnings[0];
+          const totalPathPrice = unlockPrice + bestNext.price;
+
+          const timeToSaveAll =
+            currentSnap.offlineEarnings > 0 ? totalPathPrice / currentSnap.offlineEarnings : Infinity;
+          const paybackTime =
+            bestNext.roi.earningsDelta > 0 ? totalPathPrice / bestNext.roi.earningsDelta : Infinity;
+          const pathROI = timeToSaveAll + paybackTime;
+
+          if (pathROI < timeLeft && pathROI < bestCurrentROI) {
+            const cheapest = fillers[0];
+            bestRecommendation = {
+              researchId: cheapest.id,
+              price: cheapest.price,
+              isFiller: true,
+              roiSeconds: pathROI,
+              name: cheapest.name,
+              timeToBuySeconds: currentSnap.offlineEarnings > 0 
+                ? Math.max(0, (cheapest.price - currentSnap.bankValue) / currentSnap.offlineEarnings)
+                : Infinity,
+              earningsDelta: bestNext.roi.earningsDelta,
+            };
+          }
+        }
+      }
+    }
+  }
+
+  return bestRecommendation;
+}
+

--- a/wasmegg/ascension-planner/src/auto/export.ts
+++ b/wasmegg/ascension-planner/src/auto/export.ts
@@ -1,0 +1,49 @@
+import { downloadFile } from '@/utils/export';
+import type { Action } from '@/types/actions/meta';
+import type { AscensionSummary } from './types';
+
+export interface ExportedPlan {
+  version: 1;
+  exportedAt: string;        // ISO timestamp
+  startTime: number;
+  timezone: string;
+  initialState: {
+    epicResearchLevels: Record<string, number>;
+    colleggtibleTiers: Record<string, number>;
+    artifactLoadout: any[];
+    soulEggs: number;
+    isUltra: boolean;
+    initialTankLevel: number;
+    initialFuelAmounts: Record<string, number>;
+    initialEggsDelivered: Record<string, number>;
+    initialTeEarned: Record<string, number>;
+  };
+  a1ForceMode?: 'continue' | 'prestige' | null;
+  ascensions: {
+    index: number;
+    targetTE: number;
+    result1: { summary: AscensionSummary; actions: Action[] };
+    result2: { summary: AscensionSummary; actions: Action[] };
+    result3?: { summary: AscensionSummary; actions: Action[] };
+    goal: {
+      type: 'te' | 'date';
+      te: number | null;
+      date: string;
+      time: string;
+    };
+  }[];
+}
+
+/**
+ * Triggers a browser download of the ascension plan as a JSON file.
+ */
+export function triggerPlanExport(plan: ExportedPlan) {
+  const dateStr = new Date().toISOString().split('T')[0];
+  const x = plan.ascensions.length;
+  const startTE = plan.ascensions[0]?.result1.summary.startTE ?? 0;
+  const endTE = plan.ascensions[x - 1]?.result1.summary.endTE ?? 0;
+  
+  const filename = `Auto_AP_${dateStr}_${x}-ascensions_${startTE}_to_${endTE}.json`;
+  const content = JSON.stringify(plan);
+  downloadFile(filename, content, 'application/json');
+}

--- a/wasmegg/ascension-planner/src/auto/export.ts
+++ b/wasmegg/ascension-planner/src/auto/export.ts
@@ -18,6 +18,8 @@ export interface ExportedPlan {
     initialEggsDelivered: Record<string, number>;
     initialTeEarned: Record<string, number>;
   };
+  planVariantOverrides?: Record<number, 'continue' | '1-sale' | '2-sale'>;
+  /** @deprecated use planVariantOverrides */
   a1ForceMode?: 'continue' | 'prestige' | null;
   ascensions: {
     index: number;

--- a/wasmegg/ascension-planner/src/auto/se-tracker.ts
+++ b/wasmegg/ascension-planner/src/auto/se-tracker.ts
@@ -1,0 +1,64 @@
+import { shiftCost } from 'lib';
+
+/**
+ * Computes SE costs for a sequence of shifts.
+ * 
+ * Each shift's cost depends on the current SE and the shift count.
+ * As we "pay" for each shift, the remaining SE decreases and the shift count increases,
+ * which affects the cost of the next shift.
+ */
+export function computeShiftCosts(
+  startingSE: number,
+  startingShiftCount: number,
+  numShifts: number
+) {
+  const costs: number[] = [];
+  let currentSE = startingSE;
+  let currentShiftCount = startingShiftCount;
+
+  for (let i = 0; i < numShifts; i++) {
+    const cost = shiftCost(currentSE, currentShiftCount);
+    costs.push(cost);
+    currentSE -= cost;
+    currentShiftCount++;
+  }
+
+  return {
+    costs,
+    totalCost: costs.reduce((sum, cost) => sum + cost, 0),
+    endingSE: currentSE,
+    endingShiftCount: currentShiftCount,
+  };
+}
+
+/**
+ * Computes cumulative SE costs for multiple ascensions, each having 12 shifts.
+ */
+export function computeMultiAscensionSECost(
+  startingSE: number,
+  startingShiftCount: number,
+  numAscensions: number
+) {
+  let totalCost = 0;
+  let currentSE = startingSE;
+  let currentShiftCount = startingShiftCount;
+  const perAscension: { cost: number; endingSE: number }[] = [];
+
+  for (let i = 0; i < numAscensions; i++) {
+    const result = computeShiftCosts(currentSE, currentShiftCount, 12);
+    perAscension.push({
+      cost: result.totalCost,
+      endingSE: result.endingSE,
+    });
+    totalCost += result.totalCost;
+    currentSE = result.endingSE;
+    currentShiftCount = result.endingShiftCount;
+  }
+
+  return {
+    totalCost,
+    endingSE: currentSE,
+    endingShiftCount: currentShiftCount,
+    perAscension,
+  };
+}

--- a/wasmegg/ascension-planner/src/auto/shifts/c1.ts
+++ b/wasmegg/ascension-planner/src/auto/shifts/c1.ts
@@ -1,0 +1,438 @@
+import type { Action } from '@/types/actions/meta';
+import type { EngineState, SimulationContext, ShiftResult } from '../types';
+import {
+  getCommonResearches,
+  isTierUnlocked,
+  getDiscountedVirtuePrice,
+  type ResearchCostModifiers,
+  getResearchById,
+} from '../../calculations/commonResearch';
+import { runQuickWins } from './quickWins';
+import {
+  getBestEarningsRecommendation,
+  DEFAULT_EARNINGS_CATEGORIES,
+} from '../engine/strategist';
+import { getArtifact, getStone, calculateArtifactModifiers } from '../../lib/artifacts';
+import { computeSnapshot } from '../../engine/compute';
+import { applyAction } from '../../engine/apply';
+import { createSimAction } from '@/types/actions/meta';
+import {
+  isResearchSaleActive,
+  getNextSaleStart,
+  getNextSaleEnd,
+  isEarningsBoostActive,
+  getNextEarningsBoostEnd,
+  getNextEarningsBoostStart,
+} from '../calendar';
+import { formatNumber } from '@/lib/format';
+
+const FLEET_RESEARCH_IDS = [
+  'vehicle_reliablity',
+  'excoskeletons',
+  'traffic_management',
+  'egg_loading_bots',
+  'autonomous_vehicles',
+];
+const GRAVITON_COUPLING_ID = 'micro_coupling';
+
+/** Categories that increase earnings (directly or via shipping bottleneck). */
+const EARNINGS_CATEGORIES = ['egg_value', 'egg_laying_rate', 'shipping_capacity'];
+
+/**
+ * C1 Shift Strategy (Interleaved):
+ *
+ * PHASE 1: Interleaved tier-unlock + fleet + earnings (tiers 2→10)
+ *   For each tier: unlock it (prefer earnings research within 2× cheapest),
+ *   buy fleet_size research in that tier immediately, then buy quick-win
+ *   earnings/shipping research before moving on.
+ *   NOTE: autonomous_vehicles (tier 10) is deferred to Phase 4.
+ *
+ * PHASE 2: Checkpoint at tier 10 + graviton coupling attempt
+ *   Save state. Try to unlock tiers 11→12 and buy graviton_coupling.
+ *   If no graviton bought, roll back to checkpoint.
+ *
+ * PHASE 3: Earnings research to maximize rate
+ *   Buy all ROI-positive earnings research (including shipping_capacity
+ *   when shipping-bottlenecked) to maximize earnings for the rest of C1.
+ *
+ * PHASE 4: Buy autonomous_vehicles + graviton with remaining time/bank
+ *   Now that earnings rate is maximized, buy as many autonomous_vehicles
+ *   levels as affordable. Also buy more graviton if time permits.
+ */
+export function runC1(
+  startState: EngineState,
+  context: SimulationContext,
+  timeLimit: number = 1800,
+  peakELR: number = 0
+): ShiftResult {
+  const c1Start = performance.now();
+  // console.log('[C1] Starting...');
+  let currentState: EngineState = { ...startState, maxELR: peakELR };
+  let elapsedSeconds = 0;
+  let actions: Action[] = [];
+  let memoHits = 0;
+  let memoMisses = 0;
+
+  const getAbsTime = () => context.ascensionStartTime + context.planStartOffset + (startState.lastStepTime || 0) + elapsedSeconds;
+
+  const getModifiers = (snapshot: any): ResearchCostModifiers => {
+    const artifactMods = calculateArtifactModifiers(currentState.artifactLoadout);
+    return {
+      labUpgradeLevel: context.epicResearchLevels['cheaper_research'] || 0,
+      waterballoonMultiplier: context.colleggtibleModifiers.researchCost || 1,
+      puzzleCubeMultiplier: artifactMods.researchCost.totalMultiplier,
+    };
+  };
+
+  const advanceTime = (totalSeconds: number) => {
+    let remaining = totalSeconds;
+
+    while (remaining > 0) {
+      const absTime = getAbsTime();
+      const nextSaleStart = getNextSaleStart(absTime);
+      const nextBoostStart = getNextEarningsBoostStart(absTime);
+      const nextSaleEnd = getNextSaleStart(absTime) + 24 * 3600;
+      const nextBoostEnd = getNextEarningsBoostEnd(absTime);
+      
+      const boundaries = [
+        { time: nextSaleStart, type: 'research_sale' },
+        { time: getNextSaleEnd(absTime), type: 'research_sale_end' },
+        { time: nextBoostStart, type: 'earnings_boost' },
+        { time: nextBoostEnd, type: 'earnings_boost_end' },
+      ].filter(b => b.time > absTime).sort((a, b) => a.time - b.time);
+
+      const nextBoundary = boundaries[0];
+      
+      let stepSeconds = remaining;
+      let targetEvent: string | undefined;
+
+      if (nextBoundary && (nextBoundary.time - absTime) <= remaining) {
+        stepSeconds = nextBoundary.time - absTime;
+        targetEvent = nextBoundary.type;
+      }
+
+      if (stepSeconds > 0) {
+        let actionType: any = 'wait_for_time';
+        if (targetEvent === 'research_sale') actionType = 'wait_for_research_sale';
+        else if (targetEvent === 'earnings_boost') actionType = 'wait_for_earnings_boost';
+
+        const snap = computeSnapshot(currentState, context, { skipGrowth: true });
+        const waitAction = createSimAction(actionType, { totalTimeSeconds: stepSeconds });
+        
+        currentState = applyAction(currentState, waitAction);
+        currentState = { ...currentState, lastStepTime: (currentState.lastStepTime || 0) + stepSeconds, bankValue: (currentState.bankValue || 0) + snap.offlineEarnings * stepSeconds };
+
+        const finalSnap = computeSnapshot(currentState, context, { skipGrowth: true });
+        waitAction.endState = finalSnap;
+        waitAction.totalTimeSeconds = stepSeconds;
+        waitAction.bankDelta = snap.offlineEarnings * stepSeconds;
+
+        actions.push(waitAction);
+        elapsedSeconds += stepSeconds;
+        remaining -= stepSeconds;
+      }
+
+      const newAbsTime = getAbsTime();
+
+      const isBoostNow = isEarningsBoostActive(newAbsTime);
+      if (currentState.earningsBoost?.active !== isBoostNow) {
+        const toggleBoost = createSimAction('toggle_earnings_boost', {
+          active: isBoostNow,
+          multiplier: 2
+        });
+        currentState = applyAction(currentState, toggleBoost);
+        toggleBoost.endState = computeSnapshot(currentState, context, { skipGrowth: true });
+        actions.push(toggleBoost);
+      }
+
+      const isSaleNow = isResearchSaleActive(newAbsTime);
+      if (currentState.activeSales?.research !== isSaleNow) {
+        const toggleSale = createSimAction('toggle_sale', {
+          saleType: 'research',
+          active: isSaleNow,
+          multiplier: 0.35
+        });
+        currentState = applyAction(currentState, toggleSale);
+        toggleSale.endState = computeSnapshot(currentState, context, { skipGrowth: true });
+        actions.push(toggleSale);
+      }
+    }
+  };
+
+  const buyResearch = (researchId: string): boolean => {
+    const research = getResearchById(researchId);
+    if (!research) return false;
+    const currentLevel = currentState.researchLevels[researchId] || 0;
+    if (currentLevel >= research.levels) return false;
+    if (!isTierUnlocked(currentState.researchLevels, research.tier)) return false;
+
+    const snapshot = computeSnapshot(currentState, context, { skipGrowth: true });
+    const price = getDiscountedVirtuePrice(
+      research,
+      currentLevel,
+      getModifiers(snapshot),
+      isResearchSaleActive(getAbsTime())
+    );
+
+    if (snapshot.offlineEarnings <= 0) return false;
+
+    const timeToSave = Math.max(0, (price - snapshot.bankValue) / snapshot.offlineEarnings);
+    if (elapsedSeconds + timeToSave > timeLimit) return false;
+
+    advanceTime(timeToSave);
+
+    const action = createSimAction('buy_research', {
+      researchId,
+      fromLevel: currentLevel,
+      toLevel: currentLevel + 1,
+    }, price);
+
+    currentState = applyAction(currentState, action);
+    
+    // Decoration for the action store
+    const finalSnap = computeSnapshot(currentState, context, { skipGrowth: true });
+    action.endState = finalSnap;
+    action.totalTimeSeconds = 0;
+    action.bankDelta = -price;
+
+    actions.push(action);
+    return true;
+  };
+
+  // --- Metrics logging ---
+  const snapshot = computeSnapshot(currentState, context, { skipGrowth: true });
+  const allStones = currentState.artifactLoadout.flatMap(slot => slot.stones).filter(Boolean);
+  const stoneCounts: Record<string, number> = {};
+  for (const stoneId of allStones) {
+    const label = String(getStone(stoneId as string)?.label || stoneId);
+    stoneCounts[label] = (stoneCounts[label] || 0) + 1;
+  }
+  const stonesSummary = Object.entries(stoneCounts)
+    .map(([label, count]) => `${count}x ${label}`)
+    .join(', ');
+
+  // --- Helper: find best tier-unlock candidate, preferring earnings within 2× cheapest ---
+  const findTierUnlockCandidate = (targetTier: number): string | null => {
+    const snap = computeSnapshot(currentState, context, { skipGrowth: true });
+    const isSale = isResearchSaleActive(getAbsTime());
+    const mods = getModifiers(snap);
+
+    const candidates = getCommonResearches()
+      .filter(r => r.tier < targetTier && (currentState.researchLevels[r.id] || 0) < r.levels)
+      .filter(r => isTierUnlocked(currentState.researchLevels, r.tier))
+      .map(r => ({
+        id: r.id,
+        price: getDiscountedVirtuePrice(r, currentState.researchLevels[r.id] || 0, mods, isSale),
+        isEarnings: EARNINGS_CATEGORIES.some(cat => r.categories.includes(cat)),
+      }))
+      .sort((a, b) => a.price - b.price);
+
+    if (candidates.length === 0) return null;
+
+    const cheapest = candidates[0];
+    // Prefer earnings/shipping research if within 2× the cheapest option
+    const earningsCandidate = candidates.find(c => c.isEarnings && c.price <= cheapest.price * 2);
+    return earningsCandidate ? earningsCandidate.id : cheapest.id;
+  };
+
+  // Memoize getBestEarningsRecommendation keyed on earnings-relevant research + tier state.
+  // Fleet, filler, and graviton purchases don't invalidate the cache, so repeated calls
+  // between non-earnings purchases (common in Phase 1's tier-unlock loops) are free.
+  const earningsResearchIds = new Set(
+    getCommonResearches()
+      .filter(r => DEFAULT_EARNINGS_CATEGORIES.some(cat => r.categories.includes(cat)))
+      .map(r => r.id)
+  );
+  const earningsMemo = new Map<string, ReturnType<typeof getBestEarningsRecommendation>>();
+  const getEarningsKey = (timeLeft: number): string => {
+    const isSale = isResearchSaleActive(getAbsTime());
+    let maxTier = 0;
+    for (let t = 1; t <= 13; t++) {
+      if (isTierUnlocked(currentState.researchLevels, t)) maxTier = t; else break;
+    }
+    return JSON.stringify([
+      Object.entries(currentState.researchLevels)
+        .filter(([id]) => earningsResearchIds.has(id))
+        .sort(([a], [b]) => a.localeCompare(b)),
+      maxTier,
+      isSale,
+      Math.floor(timeLeft / 300), // 5-minute bucket
+    ]);
+  };
+
+  // --- Helper: build event timing for ROI calculations ---
+  const getEventTiming = () => {
+    const absTime = getAbsTime();
+    return {
+      absoluteSimTime: absTime,
+      nextSaleStart: getNextSaleStart(absTime),
+      eventExpirationSeconds: isEarningsBoostActive(absTime)
+        ? getNextEarningsBoostEnd(absTime) - absTime
+        : getNextEarningsBoostStart(absTime) - absTime,
+      researchSaleDeadline: getNextSaleStart(absTime),
+      isSaleActive: isResearchSaleActive(absTime),
+    };
+  };
+
+  // --- Helper: buy all research purchasable within QUICK_BUY_THRESHOLD_SECONDS of waiting ---
+  // See quickWins.ts for the rationale and full implementation.
+  const buyQuickWins = (): number => {
+    const snap = computeSnapshot(currentState, context, { skipGrowth: true });
+    const result = runQuickWins(
+      currentState, actions, elapsedSeconds,
+      snap.offlineEarnings, getModifiers(snap),
+      context, getAbsTime, snap,
+      timeLimit, EARNINGS_CATEGORIES,
+    );
+    currentState = result.currentState;
+    elapsedSeconds = result.elapsedSeconds;
+    return result.count;
+  };
+
+  // --- Helper: buy best ROI-positive earnings research (single purchase) ---
+  const buyBestEarningsResearch = (): boolean => {
+    const timeLeft = timeLimit - elapsedSeconds;
+    const key = getEarningsKey(timeLeft);
+    let recommendation = earningsMemo.get(key);
+    if (recommendation === undefined) {
+      const snap = computeSnapshot(currentState, context, { skipGrowth: true });
+      recommendation = getBestEarningsRecommendation(
+        currentState, context, getEventTiming(), getModifiers(snap), timeLeft
+      );
+      earningsMemo.set(key, recommendation);
+      memoMisses++;
+    } else {
+      memoHits++;
+    }
+    if (recommendation) {
+      return buyResearch(recommendation.researchId);
+    }
+    return false;
+  };
+
+
+  // ========================================================================
+  // PHASE 1: Interleaved tier-unlock + fleet + earnings (tiers 2→10)
+  // ========================================================================
+  const p1Start = performance.now();
+  let p1Earnings = 0;
+  let p1Fleet = 0;
+  let p1QuickWins = 0;
+
+  for (let targetTier = 2; targetTier <= 10 && elapsedSeconds <= timeLimit; targetTier++) {
+    // Quick-win sweep: buy anything in any currently-unlocked tier that costs ≤3s of wait.
+    // Buying cheap items accumulates purchases toward tier-unlock thresholds and may
+    // unlock targetTier immediately, short-circuiting the tier-unlock loop below.
+    p1QuickWins += buyQuickWins();
+
+    // a) Unlock the tier
+    while (!isTierUnlocked(currentState.researchLevels, targetTier) && elapsedSeconds <= timeLimit) {
+      const candidate = findTierUnlockCandidate(targetTier);
+      if (!candidate || !buyResearch(candidate)) break;
+    }
+
+    if (!isTierUnlocked(currentState.researchLevels, targetTier)) {
+      break;
+    }
+
+    // b) Buy quick-win earnings research before moving to next tier
+    while (elapsedSeconds <= timeLimit && buyBestEarningsResearch()) {
+      p1Earnings++;
+    }
+
+    // c) Buy fleet_size research in this tier (except autonomous_vehicles, deferred to Phase 4)
+    for (const id of FLEET_RESEARCH_IDS) {
+      const research = getResearchById(id);
+      if (research && research.tier === targetTier && id !== 'autonomous_vehicles') {
+        while (buyResearch(id)) { p1Fleet++; }
+      }
+    }
+  }
+
+  const tier10Unlocked = isTierUnlocked(currentState.researchLevels, 10);
+  // console.log(`[C1 P1] ${(performance.now() - p1Start).toFixed(0)}ms | quickWins: ${p1QuickWins}, earnings: ${p1Earnings}, fleet: ${p1Fleet}, tier10: ${tier10Unlocked}`);
+
+  // ========================================================================
+  // PHASE 2: Checkpoint + graviton coupling attempt
+  // ========================================================================
+  const p2Start = performance.now();
+  let p2Graviton = 0;
+  let p2Rolled = false;
+  let p2QuickWins = 0;
+
+  if (tier10Unlocked && elapsedSeconds <= timeLimit) {
+    // Quick-win sweep before taking the checkpoint: anything cheap in tiers 1–10 is
+    // unconditionally beneficial and must not be lost if the graviton attempt rolls back.
+    p2QuickWins += buyQuickWins();
+
+    const checkpointState = JSON.parse(JSON.stringify(currentState));
+    const checkpointElapsed = elapsedSeconds;
+    const checkpointActions = [...actions];
+
+    let rollback = false;
+
+    for (let tier = 11; tier <= 12 && elapsedSeconds <= timeLimit; tier++) {
+      while (!isTierUnlocked(currentState.researchLevels, tier) && elapsedSeconds <= timeLimit) {
+        const candidate = findTierUnlockCandidate(tier);
+        if (!candidate || !buyResearch(candidate)) break;
+      }
+
+      if (!isTierUnlocked(currentState.researchLevels, tier)) {
+        rollback = true;
+        break;
+      }
+    }
+
+    if (!rollback && isTierUnlocked(currentState.researchLevels, 12)) {
+      while (elapsedSeconds <= timeLimit && buyResearch(GRAVITON_COUPLING_ID)) {
+        p2Graviton++;
+      }
+      if (p2Graviton === 0) rollback = true;
+    }
+
+    if (rollback) {
+      currentState = JSON.parse(JSON.stringify(checkpointState));
+      elapsedSeconds = checkpointElapsed;
+      actions = [...checkpointActions];
+      p2Rolled = true;
+    }
+  }
+
+  // console.log(`[C1 P2] ${(performance.now() - p2Start).toFixed(0)}ms | quickWins: ${p2QuickWins}, graviton: ${p2Graviton}, rolled back: ${p2Rolled}`);
+
+  // ========================================================================
+  // PHASE 3: Maximize earnings rate with remaining time
+  // ========================================================================
+  const p3Start = performance.now();
+  let p3Earnings = 0;
+  while (elapsedSeconds <= timeLimit && buyBestEarningsResearch()) {
+    p3Earnings++;
+  }
+  // console.log(`[C1 P3] ${(performance.now() - p3Start).toFixed(0)}ms | earnings: ${p3Earnings}`);
+
+  // ========================================================================
+  // PHASE 4: Buy autonomous_vehicles (and more graviton if time permits)
+  // ========================================================================
+  const p4Start = performance.now();
+  let p4AV = 0;
+  let p4GC = 0;
+
+  if (tier10Unlocked) {
+    while (elapsedSeconds <= timeLimit && buyResearch('autonomous_vehicles')) { p4AV++; }
+
+    if (isTierUnlocked(currentState.researchLevels, 12)) {
+      while (elapsedSeconds <= timeLimit && buyResearch(GRAVITON_COUPLING_ID)) { p4GC++; }
+    }
+  }
+
+  // console.log(`[C1 P4] ${(performance.now() - p4Start).toFixed(0)}ms | AV: ${p4AV}, graviton: ${p4GC}`);
+
+  const researchActions = actions.filter(a => a.type === 'buy_research');
+  // console.log(`[C1] Total: ${(performance.now() - c1Start).toFixed(0)}ms | ${researchActions.length} purchases | memo ${memoHits} hits / ${memoMisses} misses`);
+
+  return {
+    actions,
+    elapsedSeconds,
+    endState: currentState,
+  };
+}

--- a/wasmegg/ascension-planner/src/auto/shifts/c2.ts
+++ b/wasmegg/ascension-planner/src/auto/shifts/c2.ts
@@ -1,0 +1,431 @@
+import type { Action } from '@/types/actions/meta';
+import type { EngineState, SimulationContext, ShiftResult } from '../types';
+import {
+  getDiscountedVirtuePrice,
+  type ResearchCostModifiers,
+  getResearchById,
+  isTierUnlocked,
+  purchasesNeededForTier,
+  getCommonResearches,
+} from '../../calculations/commonResearch';
+import { runQuickWins } from './quickWins';
+import {
+  getBestEarningsRecommendation,
+  DEFAULT_EARNINGS_CATEGORIES,
+} from '../engine/strategist';
+import { computeSnapshot } from '../../engine/compute';
+import { applyAction } from '../../engine/apply';
+import { createSimAction } from '@/types/actions/meta';
+import { shiftCost } from 'lib';
+import {
+  isResearchSaleActive,
+  getNextSaleStart,
+  getNextSaleEnd,
+  isEarningsBoostActive,
+  getNextEarningsBoostEnd,
+  getNextEarningsBoostStart,
+} from '../calendar';
+import { calculateArtifactModifiers } from '../../lib/artifacts';
+
+const FLEET_RESEARCH_IDS = [
+  'vehicle_reliablity',
+  'excoskeletons',
+  'traffic_management',
+  'egg_loading_bots',
+  'autonomous_vehicles',
+];
+const GRAVITON_COUPLING_ID = 'micro_coupling';
+
+/**
+ * C2 Shift Strategy:
+ * 1. Shift to Curiosity.
+ * 2. Buy all fleet_size research until maxed.
+ * 3. Buy graviton_coupling, trying to keep wait time < 4 hours. 
+ *    If wait time > 4h, check if buying ROI earnings research reduces it < 4h.
+ *    If so, buy earnings research and then graviton_coupling. 
+ *    If not, just let the shift end.
+ */
+export function runC2(
+  startState: EngineState,
+  context: SimulationContext
+): ShiftResult {
+  const c2Start = performance.now();
+  // console.log('[C2] Starting...');
+  let currentState: EngineState = { ...startState };
+  let elapsedSeconds = 0;
+  const actions: Action[] = [];
+  let memoHits = 0;
+  let memoMisses = 0;
+
+  const getAbsTime = () => context.ascensionStartTime + context.planStartOffset + (startState.lastStepTime || 0) + elapsedSeconds;
+
+  // Mods are constant for the entire C2 run — artifact/epic/colleggtible multipliers don't
+  // change during research purchases, so we compute them once instead of per buyResearch call.
+  const mods: ResearchCostModifiers = {
+    labUpgradeLevel: context.epicResearchLevels['cheaper_research'] || 0,
+    waterballoonMultiplier: context.colleggtibleModifiers.researchCost || 1,
+    puzzleCubeMultiplier: calculateArtifactModifiers(currentState.artifactLoadout).researchCost.totalMultiplier,
+  };
+
+  // Cached earnings rate. Invalidated when:
+  //   - earnings-category research is bought (updated from endState snapshot in buyResearch)
+  //   - earnings boost toggles (updated from the toggle's snapshot in advanceTime)
+  // Everything else (time advancement, filler research) leaves offlineEarnings unchanged.
+  let offlineEarnings = 0; // set after the shift action
+
+  const advanceTime = (totalSeconds: number) => {
+    let remaining = totalSeconds;
+
+    while (remaining > 0) {
+      const absTime = getAbsTime();
+      const nextSaleStart = getNextSaleStart(absTime);
+      const nextBoostStart = getNextEarningsBoostStart(absTime);
+      const nextBoostEnd = getNextEarningsBoostEnd(absTime);
+      
+      const boundaries = [
+        { time: nextSaleStart, type: 'research_sale' },
+        { time: getNextSaleEnd(absTime), type: 'research_sale_end' },
+        { time: nextBoostStart, type: 'earnings_boost' },
+        { time: nextBoostEnd, type: 'earnings_boost_end' },
+      ].filter(b => b.time > absTime).sort((a, b) => a.time - b.time);
+
+      const nextBoundary = boundaries[0];
+      
+      let stepSeconds = remaining;
+      let targetEvent: string | undefined;
+
+      if (nextBoundary && (nextBoundary.time - absTime) <= remaining) {
+        stepSeconds = nextBoundary.time - absTime;
+        targetEvent = nextBoundary.type;
+      }
+
+      if (stepSeconds > 0) {
+        let actionType: any = 'wait_for_time';
+        if (targetEvent === 'research_sale') actionType = 'wait_for_research_sale';
+        else if (targetEvent === 'earnings_boost') actionType = 'wait_for_earnings_boost';
+
+        const snap = computeSnapshot(currentState, context, { skipGrowth: true });
+        const waitAction = createSimAction(actionType, { totalTimeSeconds: stepSeconds });
+        
+        currentState = applyAction(currentState, waitAction);
+        currentState = { ...currentState, lastStepTime: (currentState.lastStepTime || 0) + stepSeconds, bankValue: (currentState.bankValue || 0) + snap.offlineEarnings * stepSeconds };
+
+        const finalSnap = computeSnapshot(currentState, context, { skipGrowth: true });
+        waitAction.endState = finalSnap;
+        waitAction.totalTimeSeconds = stepSeconds;
+        waitAction.bankDelta = snap.offlineEarnings * stepSeconds;
+
+        actions.push(waitAction);
+        elapsedSeconds += stepSeconds;
+        remaining -= stepSeconds;
+      }
+
+      const newAbsTime = getAbsTime();
+
+      const isBoostNow = isEarningsBoostActive(newAbsTime);
+      if (currentState.earningsBoost?.active !== isBoostNow) {
+        const toggleBoost = createSimAction('toggle_earnings_boost', {
+          active: isBoostNow,
+          multiplier: 2
+        });
+        currentState = applyAction(currentState, toggleBoost);
+        const boostSnap = computeSnapshot(currentState, context, { skipGrowth: true });
+        toggleBoost.endState = boostSnap;
+        // Piggyback: the boost changes the earnings multiplier, so update the cache.
+        offlineEarnings = boostSnap.offlineEarnings;
+        actions.push(toggleBoost);
+      }
+
+      const isSaleNow = isResearchSaleActive(newAbsTime);
+      if (currentState.activeSales?.research !== isSaleNow) {
+        const toggleSale = createSimAction('toggle_sale', {
+          saleType: 'research',
+          active: isSaleNow,
+          multiplier: 0.35
+        });
+        currentState = applyAction(currentState, toggleSale);
+        toggleSale.endState = computeSnapshot(currentState, context, { skipGrowth: true });
+        actions.push(toggleSale);
+      }
+    }
+  };
+
+  const buyResearch = (researchId: string): boolean => {
+    const research = getResearchById(researchId);
+    if (!research) return false;
+    const currentLevel = currentState.researchLevels[researchId] || 0;
+    if (currentLevel >= research.levels) return false;
+    if (!isTierUnlocked(currentState.researchLevels, research.tier)) return false;
+
+    // Use cached offlineEarnings and currentState.bankValue directly — no snapshot needed for
+    // the affordability check. (applyAction for buy_research keeps bankValue in sync.)
+    if (offlineEarnings <= 0) return false;
+
+    const price = getDiscountedVirtuePrice(research, currentLevel, mods, isResearchSaleActive(getAbsTime()));
+    const timeToSave = Math.max(0, ((currentState.bankValue || 0) - price < 0
+      ? (price - (currentState.bankValue || 0)) / offlineEarnings
+      : 0));
+    if (!Number.isFinite(timeToSave)) return false;
+    if (elapsedSeconds + timeToSave > 14400) return false;
+
+    advanceTime(timeToSave);
+
+    const action = createSimAction('buy_research', {
+      researchId,
+      fromLevel: currentLevel,
+      toLevel: currentLevel + 1,
+    }, price);
+
+    currentState = applyAction(currentState, action);
+
+    // Always compute endState for display (we need the snapshot here regardless).
+    // Piggyback: if this was earnings research, update the cached rate from the same snapshot.
+    const finalSnap = computeSnapshot(currentState, context, { skipGrowth: true });
+    action.endState = finalSnap;
+    action.totalTimeSeconds = 0;
+    action.bankDelta = -price;
+    actions.push(action);
+
+    if (DEFAULT_EARNINGS_CATEGORIES.some(cat => research.categories.includes(cat))) {
+      offlineEarnings = finalSnap.offlineEarnings;
+    }
+
+    return true;
+  };
+
+  // 1. Shift to Curiosity
+  const sCost = shiftCost(currentState.soulEggs, currentState.shiftCount);
+  const shiftAction = createSimAction('shift', {
+    fromEgg: currentState.currentEgg,
+    toEgg: 'curiosity',
+    newShiftCount: currentState.shiftCount + 1,
+  }, sCost);
+  
+  currentState = applyAction(currentState, shiftAction);
+
+  // Decoration — and seed offlineEarnings from the post-shift snapshot.
+  const shiftSnap = computeSnapshot(currentState, context, { skipGrowth: true });
+  shiftAction.endState = shiftSnap;
+  shiftAction.totalTimeSeconds = 0;
+  offlineEarnings = shiftSnap.offlineEarnings;
+
+  actions.push(shiftAction);
+  // console.log(`  Shifted to Curiosity. Cost: ${formatNumber(sCost, 3)} SE`);
+
+  // Memoize getBestEarningsRecommendation — same principle as C3's ELR memo.
+  // Key on earnings-relevant research + tier state so fleet/graviton purchases
+  // (which dominate C2) don't cause expensive re-evaluations.
+  const earningsResearchIds = new Set(
+    getCommonResearches()
+      .filter(r => DEFAULT_EARNINGS_CATEGORIES.some(cat => r.categories.includes(cat)))
+      .map(r => r.id)
+  );
+  const earningsMemo = new Map<string, ReturnType<typeof getBestEarningsRecommendation>>();
+  const getEarningsKey = (timeLeft: number): string => {
+    const isSale = isResearchSaleActive(getAbsTime());
+    let maxTier = 0;
+    for (let t = 1; t <= 13; t++) {
+      if (isTierUnlocked(currentState.researchLevels, t)) maxTier = t; else break;
+    }
+    return JSON.stringify([
+      Object.entries(currentState.researchLevels)
+        .filter(([id]) => earningsResearchIds.has(id))
+        .sort(([a], [b]) => a.localeCompare(b)),
+      maxTier,
+      isSale,
+      Math.floor(timeLeft / 300),
+    ]);
+  };
+
+  // --- Helper: build event timing for ROI calculations ---
+  const getEventTiming = () => {
+    const absTime = getAbsTime();
+    return {
+      absoluteSimTime: absTime,
+      nextSaleStart: getNextSaleStart(absTime),
+      eventExpirationSeconds: isEarningsBoostActive(absTime)
+        ? getNextEarningsBoostEnd(absTime) - absTime
+        : getNextEarningsBoostStart(absTime) - absTime,
+      researchSaleDeadline: getNextSaleStart(absTime),
+      isSaleActive: isResearchSaleActive(absTime),
+    };
+  };
+
+  // --- Helper: estimate remaining shift time ---
+  // Uses cached offlineEarnings and currentState.bankValue directly — no snapshot needed.
+  const getEstimatedRemainingShiftTime = (): number => {
+    if (offlineEarnings <= 0) return Infinity;
+    const isSale = isResearchSaleActive(getAbsTime());
+
+    let totalTargetCost = 0;
+    for (const id of FLEET_RESEARCH_IDS) {
+      const research = getResearchById(id);
+      if (research) {
+        let level = currentState.researchLevels[id] || 0;
+        while (level < research.levels) {
+          totalTargetCost += getDiscountedVirtuePrice(research, level, mods, isSale);
+          level++;
+        }
+      }
+    }
+    const gcResearch = getResearchById(GRAVITON_COUPLING_ID);
+    if (gcResearch) {
+      let gcLevel = currentState.researchLevels[GRAVITON_COUPLING_ID] || 0;
+      while (gcLevel < gcResearch.levels) {
+        totalTargetCost += getDiscountedVirtuePrice(gcResearch, gcLevel, mods, isSale);
+        gcLevel++;
+      }
+    }
+
+    const costLeft = Math.max(0, totalTargetCost - (currentState.bankValue || 0));
+    const timeToHardLimit = Math.max(0, 14400 - elapsedSeconds);
+    return Math.min(costLeft / offlineEarnings, timeToHardLimit);
+  };
+
+  // --- Helper: buy best ROI-positive earnings research (single purchase) ---
+  const buyBestEarningsResearch = (): boolean => {
+    const timeLeft = getEstimatedRemainingShiftTime();
+    const key = getEarningsKey(timeLeft);
+    let recommendation = earningsMemo.get(key);
+    if (recommendation === undefined) {
+      recommendation = getBestEarningsRecommendation(
+        currentState, context, getEventTiming(), mods, timeLeft
+      );
+      earningsMemo.set(key, recommendation);
+      memoMisses++;
+    } else {
+      memoHits++;
+    }
+    if (recommendation) {
+      return buyResearch(recommendation.researchId);
+    }
+    return false;
+  };
+
+  // --- Helper: buy all research within QUICK_BUY_THRESHOLD_SECONDS of waiting ---
+  // See quickWins.ts for the rationale and full implementation.
+  const buyQuickWins = (): number => {
+    const result = runQuickWins(
+      currentState, actions, elapsedSeconds,
+      offlineEarnings, mods,
+      context, getAbsTime, shiftSnap,
+      14400, DEFAULT_EARNINGS_CATEGORIES,
+    );
+    currentState = result.currentState;
+    elapsedSeconds = result.elapsedSeconds;
+    offlineEarnings = result.offlineEarnings;
+    return result.count;
+  };
+
+  // --- Helper: try to unlock a tier by buying the cheapest available research ---
+  const tryUnlockTier = (targetTier: number, targetResearchId: string): boolean => {
+    if (isTierUnlocked(currentState.researchLevels, targetTier)) return true;
+
+    // Quick-win sweep first: cheap items contribute to the purchase threshold and
+    // may unlock the tier outright without needing the expensive items below.
+    buyQuickWins();
+    if (isTierUnlocked(currentState.researchLevels, targetTier)) return true;
+
+    const needed = purchasesNeededForTier(currentState.researchLevels, targetTier);
+    if (needed === Infinity) return false;
+
+    // Estimate total cost using cached mods and offlineEarnings — no snapshot needed.
+    const isSale = isResearchSaleActive(getAbsTime());
+    let estimatedUnlockCost = 0;
+    const tempLevels = { ...currentState.researchLevels };
+    for (let i = 0; i < needed; i++) {
+      let cheapestPrice = Infinity;
+      let cheapestId = '';
+      for (const r of getCommonResearches()) {
+        if (
+          r.tier < targetTier &&
+          (tempLevels[r.id] || 0) < r.levels &&
+          isTierUnlocked(tempLevels, r.tier)
+        ) {
+          const p = getDiscountedVirtuePrice(r, tempLevels[r.id] || 0, mods, isSale);
+          if (p < cheapestPrice) { cheapestPrice = p; cheapestId = r.id; }
+        }
+      }
+      if (!cheapestId) break;
+      estimatedUnlockCost += cheapestPrice;
+      tempLevels[cheapestId] = (tempLevels[cheapestId] || 0) + 1;
+    }
+    const targetResearch = getResearchById(targetResearchId);
+    if (targetResearch) {
+      estimatedUnlockCost += getDiscountedVirtuePrice(
+        targetResearch, currentState.researchLevels[targetResearchId] || 0, mods, isSale
+      );
+    }
+
+    const timeToSave = Math.max(0, (estimatedUnlockCost - (currentState.bankValue || 0)) / offlineEarnings);
+    if (elapsedSeconds + timeToSave > 14400) return false;
+
+    while (!isTierUnlocked(currentState.researchLevels, targetTier)) {
+      let cheapestPrice = Infinity;
+      let cheapestId = '';
+      for (const r of getCommonResearches()) {
+        if (
+          r.tier < targetTier &&
+          (currentState.researchLevels[r.id] || 0) < r.levels &&
+          isTierUnlocked(currentState.researchLevels, r.tier)
+        ) {
+          const p = getDiscountedVirtuePrice(r, currentState.researchLevels[r.id] || 0, mods, isSale);
+          if (p < cheapestPrice) { cheapestPrice = p; cheapestId = r.id; }
+        }
+      }
+      if (!cheapestId) break;
+      if (!buyResearch(cheapestId)) break;
+    }
+
+    return isTierUnlocked(currentState.researchLevels, targetTier);
+  };
+
+  // 2. Buy all fleet_size research until maxed
+  const p1Start = performance.now();
+  let p1Fleet = 0;
+  let p1Earnings = 0;
+  // Quick-win sweep after the Curiosity shift: C2's earnings rate may differ from C1's,
+  // potentially making items affordable that weren't within C1's 3-second threshold.
+  const p1QuickWins = buyQuickWins();
+  for (const id of FLEET_RESEARCH_IDS) {
+    const research = getResearchById(id);
+    while (research && (currentState.researchLevels[id] || 0) < research.levels) {
+      while (buyBestEarningsResearch()) { p1Earnings++; }
+      if (!buyResearch(id)) break;
+      p1Fleet++;
+    }
+  }
+  // console.log(`[C2 P1] ${(performance.now() - p1Start).toFixed(0)}ms | quickWins: ${p1QuickWins}, fleet: ${p1Fleet}, earnings: ${p1Earnings}`);
+
+  // 3. Buy graviton_coupling until we hit the 4h limit or max it out
+  const p2Start = performance.now();
+  let p2GC = 0;
+  let p2Earnings = 0;
+  const gcResearch = getResearchById(GRAVITON_COUPLING_ID);
+
+  while (gcResearch && (currentState.researchLevels[GRAVITON_COUPLING_ID] || 0) < gcResearch.levels) {
+    while (buyBestEarningsResearch()) { p2Earnings++; }
+
+    if (!isTierUnlocked(currentState.researchLevels, gcResearch.tier)) {
+      if (!tryUnlockTier(gcResearch.tier, GRAVITON_COUPLING_ID)) {
+        break;
+      }
+    }
+
+    if (!buyResearch(GRAVITON_COUPLING_ID)) {
+      break;
+    }
+    p2GC++;
+  }
+  // console.log(`[C2 P2] ${(performance.now() - p2Start).toFixed(0)}ms | graviton: ${p2GC}, earnings: ${p2Earnings}`);
+
+  const researchActions = actions.filter(a => a.type === 'buy_research');
+  // console.log(`[C2] Total: ${(performance.now() - c2Start).toFixed(0)}ms | ${researchActions.length} purchases | memo ${memoHits} hits / ${memoMisses} misses`);
+
+  return {
+    actions,
+    elapsedSeconds,
+    endState: currentState,
+  };
+}
+

--- a/wasmegg/ascension-planner/src/auto/shifts/c3.ts
+++ b/wasmegg/ascension-planner/src/auto/shifts/c3.ts
@@ -1,0 +1,432 @@
+import type { Action } from '@/types/actions/meta';
+import type { EngineState, SimulationContext, ShiftResult } from '../types';
+import {
+  getCommonResearches,
+  getDiscountedVirtuePrice,
+  type ResearchCostModifiers,
+  getResearchById,
+  isTierUnlocked,
+} from '../../calculations/commonResearch';
+import {
+  getBestEarningsRecommendation,
+} from '../engine/strategist';
+import { computeSnapshot } from '../../engine/compute';
+import { applyAction } from '../../engine/apply';
+import { createSimAction } from '@/types/actions/meta';
+import { shiftCost } from 'lib';
+import {
+  isResearchSaleActive,
+  getNextSaleStart,
+  getNextSaleEnd,
+  isEarningsBoostActive,
+  getNextEarningsBoostEnd,
+  getNextEarningsBoostStart,
+} from '../calendar';
+import { computeRealisticELR } from '../../calculations/realisticELR';
+import { buildELRCandidatePool, evaluateELRWithPool, evaluateELRForStructure, type ELRCandidatePool } from '../../lib/artifacts/virtue';
+import type { EquippedArtifact } from '../../lib/artifacts/types';
+import { calculateArtifactModifiers } from '../../lib/artifacts';
+
+const EARNINGS_CATEGORIES = ['egg_value', 'egg_laying_rate', 'shipping_capacity', 'hab_capacity'];
+
+/** Research IDs that feed into ELR calculations (lay rate, shipping capacity, hab capacity). */
+const ELR_RELEVANT_RESEARCH_IDS = new Set([
+  // Lay rate
+  'comfy_nests', 'hen_house_ac', 'improved_genetics', 'time_compress',
+  'timeline_diversion', 'relativity_optimization',
+  // Shipping capacity
+  'leafsprings', 'lightweight_boxes', 'driver_training', 'super_alloy',
+  'quantum_storage', 'hover_upgrades', 'dark_containment', 'neural_net_refine', 'hyper_portalling',
+  // Fleet size (vehicle slots → total shipping)
+  'vehicle_reliablity', 'excoskeletons', 'traffic_management', 'egg_loading_bots', 'autonomous_vehicles',
+  // Train length (Graviton Coupling → shipping per vehicle)
+  'micro_coupling',
+  // Hab capacity (population → lay rate)
+  'hab_capacity1', 'microlux', 'grav_plating', 'wormhole_dampening',
+]);
+
+function calculateTotalPurchases(researchLevels: Record<string, number>): number {
+  let total = 0;
+  for (const level of Object.values(researchLevels)) {
+    total += level;
+  }
+  return total;
+}
+
+export function runC3(
+  startState: EngineState,
+  context: SimulationContext,
+  buildPhaseEnd: number = 0
+): ShiftResult {
+  let currentState = { ...startState };
+  let elapsedSeconds = 0;
+  const actions: Action[] = [];
+
+  const getAbsTime = () => context.ascensionStartTime + context.planStartOffset + (startState.lastStepTime || 0) + elapsedSeconds;
+
+  const getModifiers = (snapshot: any): ResearchCostModifiers => {
+    const artifactMods = calculateArtifactModifiers(currentState.artifactLoadout);
+    return {
+      labUpgradeLevel: context.epicResearchLevels['cheaper_research'] || 0,
+      waterballoonMultiplier: context.colleggtibleModifiers.researchCost || 1,
+      puzzleCubeMultiplier: artifactMods.researchCost.totalMultiplier,
+    };
+  };
+
+  const advanceTime = (totalSeconds: number) => {
+    let remaining = totalSeconds;
+
+    while (remaining > 0) {
+      const absTime = getAbsTime();
+      const nextSaleStart = getNextSaleStart(absTime);
+      const nextBoostStart = getNextEarningsBoostStart(absTime);
+      const nextSaleEnd = getNextSaleStart(absTime) + 24 * 3600; // rough, but works for boundaries
+      const nextBoostEnd = getNextEarningsBoostEnd(absTime);
+      
+      const boundaries = [
+        { time: nextSaleStart, type: 'research_sale' },
+        { time: getNextSaleEnd(absTime), type: 'research_sale_end' },
+        { time: nextBoostStart, type: 'earnings_boost' },
+        { time: nextBoostEnd, type: 'earnings_boost_end' },
+      ].filter(b => b.time > absTime).sort((a, b) => a.time - b.time);
+
+      const nextBoundary = boundaries[0];
+      
+      let stepSeconds = remaining;
+      let targetEvent: string | undefined;
+
+      if (nextBoundary && (nextBoundary.time - absTime) <= remaining) {
+        stepSeconds = nextBoundary.time - absTime;
+        targetEvent = nextBoundary.type;
+      }
+
+      if (stepSeconds > 0) {
+        let actionType: any = 'wait_for_time';
+        if (targetEvent === 'research_sale') actionType = 'wait_for_research_sale';
+        else if (targetEvent === 'earnings_boost') actionType = 'wait_for_earnings_boost';
+
+        const snap = computeSnapshot(currentState, context, { skipGrowth: true });
+        const waitAction = createSimAction(actionType, { totalTimeSeconds: stepSeconds });
+        
+        currentState = applyAction(currentState, waitAction);
+        currentState = { ...currentState, lastStepTime: (currentState.lastStepTime || 0) + stepSeconds, bankValue: (currentState.bankValue || 0) + snap.offlineEarnings * stepSeconds };
+
+        const finalSnap = computeSnapshot(currentState, context, { skipGrowth: true });
+        waitAction.endState = finalSnap;
+        waitAction.totalTimeSeconds = stepSeconds;
+        waitAction.bankDelta = snap.offlineEarnings * stepSeconds;
+
+        actions.push(waitAction);
+        elapsedSeconds += stepSeconds;
+        remaining -= stepSeconds;
+      }
+
+      // Check toggles after advancing
+      const newAbsTime = getAbsTime();
+      
+      const isBoostNow = isEarningsBoostActive(newAbsTime);
+      if (currentState.earningsBoost?.active !== isBoostNow) {
+        const toggleBoost = createSimAction('toggle_earnings_boost', {
+          active: isBoostNow,
+          multiplier: 2
+        });
+        currentState = applyAction(currentState, toggleBoost);
+        toggleBoost.endState = computeSnapshot(currentState, context, { skipGrowth: true });
+        actions.push(toggleBoost);
+      }
+
+      const isSaleNow = isResearchSaleActive(newAbsTime);
+      if (currentState.activeSales?.research !== isSaleNow) {
+        const toggleSale = createSimAction('toggle_sale', {
+          saleType: 'research',
+          active: isSaleNow,
+          multiplier: 0.35
+        });
+        currentState = applyAction(currentState, toggleSale);
+        toggleSale.endState = computeSnapshot(currentState, context, { skipGrowth: true });
+        actions.push(toggleSale);
+      }
+    }
+  };
+
+  const buyResearch = (researchId: string, customPrice?: number): boolean => {
+    const research = getResearchById(researchId);
+    if (!research) return false;
+    const currentLevel = currentState.researchLevels[researchId] || 0;
+    if (currentLevel >= research.levels) return false;
+
+    const snapshot = computeSnapshot(currentState, context, { skipGrowth: true });
+    const price = customPrice !== undefined ? customPrice : getDiscountedVirtuePrice(
+      research,
+      currentLevel,
+      getModifiers(snapshot),
+      isResearchSaleActive(getAbsTime())
+    );
+
+    if (snapshot.offlineEarnings <= 0) return false;
+
+    const timeToSave = Math.max(0, (price - snapshot.bankValue) / snapshot.offlineEarnings);
+    advanceTime(timeToSave);
+
+    const action = createSimAction('buy_research', {
+      researchId,
+      fromLevel: currentLevel,
+      toLevel: currentLevel + 1,
+    }, price);
+
+    currentState = applyAction(currentState, action);
+    
+    // Decoration
+    const finalSnap = computeSnapshot(currentState, context, { skipGrowth: true });
+    action.endState = finalSnap;
+    action.totalTimeSeconds = 0;
+    action.bankDelta = -price;
+
+    actions.push(action);
+    return true;
+  };
+
+  // 1. Shift to Curiosity
+  const sCost = shiftCost(currentState.soulEggs, currentState.shiftCount);
+  const shiftAction = createSimAction('shift', {
+    fromEgg: currentState.currentEgg,
+    toEgg: 'curiosity',
+    newShiftCount: currentState.shiftCount + 1,
+  }, sCost);
+  
+  currentState = applyAction(currentState, shiftAction);
+  
+  // Decoration
+  const finalSnap = computeSnapshot(currentState, context, { skipGrowth: true });
+  shiftAction.endState = finalSnap;
+  shiftAction.totalTimeSeconds = 0;
+
+  actions.push(shiftAction);
+
+  const finalSaleStart = buildPhaseEnd - 86400;
+
+  // Step 1: Earnings ROI matrix
+  let step1Active = true;
+  while (step1Active && getAbsTime() < buildPhaseEnd) {
+    const absTime = getAbsTime();
+    const nextSaleStart = getNextSaleStart(absTime);
+    const nextBoostStart = getNextEarningsBoostStart(absTime);
+    const nextBoostEnd = getNextEarningsBoostEnd(absTime);
+    
+    const boundaries = [
+      nextSaleStart,
+      getNextSaleEnd(absTime),
+      nextBoostStart,
+      nextBoostEnd,
+      finalSaleStart,
+      buildPhaseEnd
+    ].filter(b => b > absTime).sort((a, b) => a - b);
+    
+    const nextBoundary = boundaries[0];
+
+    const eventTiming = {
+      absoluteSimTime: absTime,
+      nextSaleStart,
+      eventExpirationSeconds: isEarningsBoostActive(absTime)
+        ? nextBoostEnd - absTime
+        : nextBoostStart - absTime,
+      researchSaleDeadline: getNextSaleStart(absTime),
+      isSaleActive: isResearchSaleActive(absTime),
+    };
+
+    const currentSnap = computeSnapshot(currentState, context, { skipGrowth: true });
+
+    const recommendation = getBestEarningsRecommendation(
+      currentState,
+      context,
+      eventTiming,
+      getModifiers(currentSnap),
+      buildPhaseEnd - absTime,
+      undefined,
+      buildPhaseEnd
+    );
+
+    if (recommendation) {
+      const purchaseTime = absTime + (recommendation.timeToBuySeconds || 0);
+      if (purchaseTime <= nextBoundary) {
+        buyResearch(recommendation.researchId, recommendation.price);
+      } else {
+        advanceTime(nextBoundary - absTime);
+      }
+    } else {
+      if (absTime >= finalSaleStart) {
+        step1Active = false;
+      } else {
+        advanceTime(nextBoundary - absTime);
+      }
+    }
+  }
+
+  // Step 2: Buy ELR Impact research (Realistic, Time Efficiency)
+
+  // Build the artifact candidate pool and lock the best structure — both done once.
+  // The 500-combo structure search runs exactly once; every subsequent ELR evaluation
+  // only runs the cheap stone allocation on that fixed structure (~500× less work).
+  const elrPool: ELRCandidatePool | null = context.rawBackup
+    ? buildELRCandidatePool(context.rawBackup, false)
+    : null;
+
+  // Run the full combo search once to find the best artifact structure.
+  let bestELRStructure: EquippedArtifact[] | null = null;
+  if (elrPool) {
+    const initialSet = evaluateELRWithPool(elrPool, {
+      commonResearch: currentState.researchLevels,
+      epicResearchLevels: context.epicResearchLevels,
+      colleggtibleModifiers: context.colleggtibleModifiers,
+    });
+    // Store artifact IDs + slot counts only; stones are re-allocated per research state.
+    bestELRStructure = initialSet.map(slot => ({
+      artifactId: slot.artifactId,
+      stones: new Array(slot.stones.length).fill(null),
+    }));
+  }
+
+  // Memoize ELR stats by research state. Each miss only re-runs stone allocation
+  // on the fixed structure (~12 evaluations) rather than the full 500-combo search.
+  // Reuse a shared memo from context (populated by a prior C3 run, e.g. the 1-sale run)
+  // so the 2-sale run benefits from already-computed states.
+  const elrMemo: Map<string, { layRate: number; shippingRate: number; effectiveRate: number }> =
+    context.elrMemo ?? new Map();
+  context.elrMemo = elrMemo; // write back so subsequent C3 calls can inherit it
+  const memoGetELR = (researchLevels: Record<string, number>) => {
+    const key = JSON.stringify(
+      Object.entries(researchLevels)
+        .filter(([id]) => ELR_RELEVANT_RESEARCH_IDS.has(id))
+        .sort(([a], [b]) => a.localeCompare(b))
+    );
+    let result = elrMemo.get(key);
+    if (!result) {
+      result = evaluateELRForStructure(bestELRStructure!, elrPool!, {
+        commonResearch: researchLevels,
+        epicResearchLevels: context.epicResearchLevels,
+        colleggtibleModifiers: context.colleggtibleModifiers,
+      });
+      elrMemo.set(key, result);
+    }
+    return result;
+  };
+
+  // Unified helper: uses the locked structure + pool when available, falls back
+  // to the current artifact loadout for the no-backup case.
+  const computeELRStats = (researchLevels: Record<string, number>) => {
+    if (bestELRStructure && elrPool) return memoGetELR(researchLevels);
+    const mods = calculateArtifactModifiers(currentState.artifactLoadout);
+    const raw = computeRealisticELR(researchLevels, mods, context.epicResearchLevels, context.colleggtibleModifiers);
+    return { layRate: raw.layRate, shippingRate: raw.shippingRate, effectiveRate: raw.effectiveRate };
+  };
+
+  let elrActive = true;
+  while (elrActive && getAbsTime() < buildPhaseEnd) {
+    const absTime = getAbsTime();
+
+    const nextBoostStart = getNextEarningsBoostStart(absTime);
+    const nextBoostEnd = getNextEarningsBoostEnd(absTime);
+    
+    const boundaries = [
+      getNextSaleStart(absTime),
+      getNextSaleEnd(absTime),
+      nextBoostStart,
+      nextBoostEnd,
+      buildPhaseEnd
+    ].filter(b => b > absTime).sort((a, b) => a - b);
+    
+    const nextBoundary = boundaries[0];
+
+    const currentSnap = computeSnapshot(currentState, context, { skipGrowth: true });
+    const isSale = isResearchSaleActive(absTime);
+    const mods = getModifiers(currentSnap);
+
+    const baselineELR = computeELRStats(currentState.researchLevels).effectiveRate;
+
+    if (baselineELR <= 0) {
+      advanceTime(nextBoundary - absTime);
+      continue;
+    }
+
+    const elrCandidatesAll = getCommonResearches()
+      .filter(r => (currentState.researchLevels[r.id] || 0) < r.levels)
+      .filter(r => isTierUnlocked(currentState.researchLevels, r.tier))
+      .map(r => {
+        const level = currentState.researchLevels[r.id] || 0;
+        const price = getDiscountedVirtuePrice(r, level, mods, isSale);
+
+        const tempLevels = { ...currentState.researchLevels, [r.id]: level + 1 };
+        const stats = computeELRStats(tempLevels);
+        const impact = (stats.effectiveRate - baselineELR) / baselineELR;
+
+        const secondsToBuyNoBank = currentSnap.offlineEarnings > 0 ? price / currentSnap.offlineEarnings : Infinity;
+        const hoursToBuy = secondsToBuyNoBank / 3600;
+        const hpp = impact > 0 ? hoursToBuy / (impact * 100) : Infinity;
+
+        // Lookahead: if +1 level has no impact, find the minimum N levels that unlock positive impact.
+        // C3 will then buy one level at a time — re-evaluation each loop keeps the research in
+        // the candidate list until all N levels are bought or time runs out.
+        let lookahead: { minLevels: number; impact: number; hpp: number } | undefined;
+        if (impact <= 0 && level + 1 < r.levels) {
+          for (let n = 2; n <= r.levels - level; n++) {
+            const laLevels = { ...currentState.researchLevels, [r.id]: level + n };
+            const laStats = computeELRStats(laLevels);
+            const laImpact = (laStats.effectiveRate - baselineELR) / baselineELR;
+            if (laImpact > 0) {
+              let totalPriceForN = 0;
+              for (let l = level; l < level + n; l++) {
+                totalPriceForN += getDiscountedVirtuePrice(r, l, mods, isSale);
+              }
+              const totalHoursForN = currentSnap.offlineEarnings > 0 ? totalPriceForN / currentSnap.offlineEarnings / 3600 : Infinity;
+              lookahead = {
+                minLevels: n,
+                impact: laImpact,
+                hpp: totalHoursForN / (laImpact * 100),
+              };
+              break;
+            }
+          }
+        }
+
+        return {
+          research: r,
+          price,
+          impact,
+          // Use lookahead HPP for sorting so zero-impact-but-worthwhile items rank correctly.
+          hpp: lookahead ? lookahead.hpp : hpp,
+          lookahead,
+          layRate: stats.layRate,
+          shippingRate: stats.shippingRate,
+          timeToBuySeconds: Math.max(0, (price - currentSnap.bankValue) / currentSnap.offlineEarnings)
+        };
+      });
+
+    const elrCandidates = elrCandidatesAll
+      .filter(c => (c.impact > 0 || c.lookahead !== undefined) && c.timeToBuySeconds !== Infinity && (absTime + c.timeToBuySeconds <= buildPhaseEnd))
+      .sort((a, b) => a.hpp - b.hpp);
+
+    if (elrCandidates.length > 0) {
+      const best = elrCandidates[0];
+      const purchaseTime = absTime + best.timeToBuySeconds;
+
+      if (purchaseTime <= nextBoundary) {
+        buyResearch(best.research.id, best.price);
+      } else {
+        advanceTime(nextBoundary - absTime);
+      }
+    } else {
+      if (nextBoundary === buildPhaseEnd) {
+        // Nothing left to buy before the sale ends, so we can exit C3 early!
+        elrActive = false;
+      } else {
+        advanceTime(nextBoundary - absTime);
+      }
+    }
+  }
+
+  return {
+    actions,
+    elapsedSeconds,
+    endState: currentState,
+  };
+}

--- a/wasmegg/ascension-planner/src/auto/shifts/h1.ts
+++ b/wasmegg/ascension-planner/src/auto/shifts/h1.ts
@@ -1,0 +1,89 @@
+import type { EngineState, SimulationContext, ShiftResult } from '../types';
+import { getOptimalELRSet } from '@/lib/artifacts/virtue';
+import type { Action } from '@/types/actions/meta';
+import { createSimAction } from '@/types/actions/meta';
+import { shiftCost } from 'lib';
+import { computeSnapshot } from '../../engine/compute';
+import { applyAction } from '../../engine/apply';
+
+/**
+ * H1: Shift to Humility and switch to optimal ELR artifacts.
+ */
+export function runH1(state: EngineState, context: SimulationContext): ShiftResult {
+  const backup = context.rawBackup;
+  if (!backup) {
+    return {
+      actions: [],
+      elapsedSeconds: 0,
+      endState: state,
+    };
+  }
+
+  // Compute optimal ELR set based on current state
+  const optimalSet = getOptimalELRSet(backup, {
+    commonResearch: state.researchLevels,
+    epicResearchLevels: context.epicResearchLevels,
+    colleggtibleModifiers: context.colleggtibleModifiers,
+    assumeMaxHabsVehicles: true, // H1 is near the end, we likely have CU and max vehicles
+  });
+
+  const actions: Action[] = [];
+
+  // 1. Shift to Humility
+  const sCost = shiftCost(state.soulEggs, state.shiftCount);
+  const shiftAction = createSimAction(
+    'shift',
+    {
+      fromEgg: state.currentEgg,
+      toEgg: 'humility',
+      newShiftCount: state.shiftCount + 1,
+    },
+    sCost
+  );
+
+  let currentState = applyAction(state, shiftAction);
+  
+  // Decoration
+  const finalSnap1 = computeSnapshot(currentState, context, { skipGrowth: true });
+  shiftAction.endState = finalSnap1;
+  shiftAction.totalTimeSeconds = 0;
+
+  actions.push(shiftAction);
+
+  // 2. Update ELR Set
+  const updateAction = createSimAction('update_artifact_set', {
+    setName: 'elr',
+    newLoadout: optimalSet,
+  });
+
+  currentState = applyAction(currentState, updateAction);
+  
+  // Decoration
+  const finalSnap2 = computeSnapshot(currentState, context, { skipGrowth: true });
+  updateAction.endState = finalSnap2;
+  updateAction.totalTimeSeconds = 0;
+
+  actions.push(updateAction);
+
+  // 3. Equip ELR Set
+  const equipAction = createSimAction('equip_artifact_set', {
+    setName: 'elr',
+  });
+
+  currentState = applyAction(currentState, equipAction);
+  
+  // Decoration
+  const finalSnap3 = computeSnapshot(currentState, context, { skipGrowth: true });
+  equipAction.endState = finalSnap3;
+  equipAction.totalTimeSeconds = 0;
+
+  actions.push(equipAction);
+
+  // console.log('H1 Finished: New artifacts equipped');
+
+  return {
+    actions,
+    elapsedSeconds: 0, // Swapping artifacts is instantaneous
+    endState: currentState,
+  };
+}

--- a/wasmegg/ascension-planner/src/auto/shifts/i1.ts
+++ b/wasmegg/ascension-planner/src/auto/shifts/i1.ts
@@ -1,0 +1,141 @@
+import type { Action } from '@/types/actions/meta';
+import type { EngineState, SimulationContext, ShiftResult } from '../types';
+import { computeSnapshot } from '../../engine/compute';
+import { applyAction } from '../../engine/apply';
+import { createSimAction } from '@/types/actions/meta';
+import { shiftCost } from 'lib';
+import {
+  getHabById,
+  getDiscountedHabPrice,
+  type HabId,
+} from '../../lib/habs';
+import { formatNumber } from '@/lib/format';
+
+/**
+ * I1 Shift Strategy:
+ * 1. Shift to Integrity.
+ * 2. Buy at least one intermediate hab to quickly increase earnings.
+ * 3. Buy 4 Chicken Universe habs (ID 18).
+ */
+export function runI1(
+  startState: EngineState,
+  context: SimulationContext,
+  timeLimit: number = 7200 // Giving plenty of time for 4 CUs
+): ShiftResult {
+  // console.log('--- Starting I1 Shift Simulation ---');
+  let currentState = { ...startState };
+  let elapsedSeconds = 0;
+  const actions: Action[] = [];
+
+  const advanceTime = (seconds: number) => {
+    if (seconds <= 0) return;
+    const snap = computeSnapshot(currentState, context, { skipGrowth: true });
+    const waitAction = createSimAction('wait_for_time', { totalTimeSeconds: seconds });
+    
+    currentState = applyAction(currentState, waitAction);
+    // applyAction doesn't update bankValue or lastStepTime for wait actions, so we credit them manually
+    currentState = { ...currentState, lastStepTime: (currentState.lastStepTime || 0) + seconds, bankValue: (currentState.bankValue || 0) + snap.offlineEarnings * seconds };
+    
+    // Decoration for the action store
+    const finalSnap = computeSnapshot(currentState, context, { skipGrowth: true });
+    waitAction.endState = finalSnap;
+    waitAction.totalTimeSeconds = seconds;
+    waitAction.bankDelta = snap.offlineEarnings * seconds;
+    
+    actions.push(waitAction);
+    elapsedSeconds += seconds;
+  };
+
+  const getModifiers = () => ({
+    cheaperContractorsLevel: context.epicResearchLevels['cheaper_contractors'] || 0,
+    flameRetardantMultiplier: context.colleggtibleModifiers.habCost || 1,
+  });
+
+  const buyHab = (slotIndex: number, habId: number): boolean => {
+    const currentSnap = computeSnapshot(currentState, context, { skipGrowth: true });
+    const countBefore = currentState.habIds.filter(id => id === habId).length;
+    const price = getDiscountedHabPrice(getHabById(habId as HabId), countBefore, getModifiers(), false);
+
+    if (currentSnap.offlineEarnings <= 0) return false;
+    const timeToSave = Math.max(0, (price - currentSnap.bankValue) / currentSnap.offlineEarnings);
+    
+    // We allow exceeding the timeLimit to buy Chicken Universes if necessary,
+    // but we can have a safety check so it doesn't wait forever
+    if (elapsedSeconds + timeToSave > timeLimit * 10) return false;
+
+    advanceTime(timeToSave);
+    const action = createSimAction('buy_hab', { slotIndex, habId }, price);
+    currentState = applyAction(currentState, action);
+    
+    // Decoration
+    const finalSnap = computeSnapshot(currentState, context, { skipGrowth: true });
+    action.endState = finalSnap;
+    action.totalTimeSeconds = 0;
+    action.bankDelta = -price;
+
+    actions.push(action);
+    return true;
+  };
+
+  // 1. Shift to Integrity
+  const sCost = shiftCost(currentState.soulEggs, currentState.shiftCount);
+  const shiftAction = createSimAction('shift', {
+    fromEgg: currentState.currentEgg,
+    toEgg: 'integrity',
+    newShiftCount: currentState.shiftCount + 1,
+  }, sCost);
+  
+  currentState = applyAction(currentState, shiftAction);
+  
+  // Decoration
+  const finalSnap = computeSnapshot(currentState, context, { skipGrowth: true });
+  shiftAction.endState = finalSnap;
+  shiftAction.totalTimeSeconds = 0;
+
+  actions.push(shiftAction);
+  // console.log(`  Shifted to Integrity. Cost: ${formatNumber(sCost, 3)} SE`);
+
+  // 2. Buy intermediate hab if needed
+  // console.log('Phase 1: Intermediate Hab check...');
+  const initialSnap = computeSnapshot(currentState, context, { skipGrowth: true });
+  const countCUBefore = currentState.habIds.filter(id => id === 18).length;
+  const cuPrice = getDiscountedHabPrice(getHabById(18), countCUBefore, getModifiers(), false);
+  
+  const timeToSaveCU = initialSnap.offlineEarnings > 0 
+    ? Math.max(0, (cuPrice - initialSnap.bankValue) / initialSnap.offlineEarnings) 
+    : Infinity;
+
+  if (timeToSaveCU > 10) {
+    // Find the biggest hab we can buy in < 10s
+    for (let hId = 17; hId >= 1; hId--) {
+      const snap = computeSnapshot(currentState, context, { skipGrowth: true });
+      const cBefore = currentState.habIds.filter(id => id === hId).length;
+      const price = getDiscountedHabPrice(getHabById(hId as HabId), cBefore, getModifiers(), false);
+      const timeToSave = snap.offlineEarnings > 0 
+        ? Math.max(0, (price - snap.bankValue) / snap.offlineEarnings)
+        : Infinity;
+        
+      if (timeToSave < 10) {
+        // console.log(`  Buying intermediate hab ${hId} to boost earnings...`);
+        buyHab(0, hId);
+        break;
+      }
+    }
+  }
+
+  // 3. Buy 4 Chicken Universes
+  // console.log('Phase 2: Buying 4 Chicken Universes...');
+  for (let slot = 0; slot < 4; slot++) {
+    if (currentState.habIds[slot] !== 18) {
+      buyHab(slot, 18);
+    }
+  }
+
+  // console.log(`I1 Finished: ${actions.filter(a => a.type === 'buy_hab').length} hab actions, total time ${elapsedSeconds}s`);
+
+  return {
+    actions,
+    elapsedSeconds,
+    endState: currentState,
+  };
+}

--- a/wasmegg/ascension-planner/src/auto/shifts/index.ts
+++ b/wasmegg/ascension-planner/src/auto/shifts/index.ts
@@ -1,0 +1,28 @@
+import { runC1 } from './c1';
+import { runK1 } from './k1';
+import { runI1 } from './i1';
+import { runC2 } from './c2';
+import { runK2 } from './k2';
+import { runR1 } from './r1';
+import { runC3 } from './c3';
+import { runH1 } from './h1';
+import { runK3 } from './k3';
+import { runC4, runI2, runR2, runH2, distributeTargetTE } from './te-wait';
+
+export {
+  runC1,
+  runK1,
+  runI1,
+  runC2,
+  runK2,
+  runR1,
+  runC3,
+  runH1,
+  runK3,
+  runC4,
+  runI2,
+  runR2,
+  runH2,
+  distributeTargetTE,
+};
+

--- a/wasmegg/ascension-planner/src/auto/shifts/k1.ts
+++ b/wasmegg/ascension-planner/src/auto/shifts/k1.ts
@@ -1,0 +1,285 @@
+import type { Action } from '@/types/actions/meta';
+import type { EngineState, SimulationContext, ShiftResult } from '../types';
+import { computeSnapshot } from '../../engine/compute';
+import { applyAction } from '../../engine/apply';
+import { createSimAction } from '@/types/actions/meta';
+import { shiftCost } from 'lib';
+import {
+  getDiscountedVehiclePrice,
+  getDiscountedTrainCarPrice,
+} from '../../lib/vehicles';
+import { isResearchSaleActive } from '../calendar';
+import { calculateMaxVehicleSlots, calculateMaxTrainLength } from '../../calculations/shippingCapacity';
+import { formatNumber } from '@/lib/format';
+
+/**
+ * K1 Shift Strategy:
+ * 1. Shift to Kindness.
+ * 2. Buy minimum vehicles to get shipping ≥ lay rate.
+ * 3. Buy largest affordable vehicles/trains with remaining time (≤ 30 min total).
+ */
+export function runK1(
+  startState: EngineState,
+  context: SimulationContext,
+  timeLimit: number = 1800
+): ShiftResult {
+  // console.log('--- Starting K1 Shift Simulation ---');
+  let currentState = { ...startState };
+  let elapsedSeconds = 0;
+  const actions: Action[] = [];
+
+  const getAbsTime = () => context.ascensionStartTime + context.planStartOffset + (startState.lastStepTime || 0) + elapsedSeconds;
+
+  const advanceTime = (seconds: number) => {
+    if (seconds <= 0) return;
+    const snap = computeSnapshot(currentState, context, { skipGrowth: true });
+    const waitAction = createSimAction('wait_for_time', { totalTimeSeconds: seconds });
+    
+    currentState = applyAction(currentState, waitAction);
+    // applyAction doesn't update bankValue or lastStepTime for wait actions, so we credit them manually
+    currentState = { ...currentState, lastStepTime: (currentState.lastStepTime || 0) + seconds, bankValue: (currentState.bankValue || 0) + snap.offlineEarnings * seconds };
+    
+    // Decoration for the action store
+    const finalSnap = computeSnapshot(currentState, context, { skipGrowth: true });
+    waitAction.endState = finalSnap;
+    waitAction.totalTimeSeconds = seconds;
+    waitAction.bankDelta = snap.offlineEarnings * seconds;
+    
+    actions.push(waitAction);
+    elapsedSeconds += seconds;
+  };
+
+  const getModifiers = () => ({
+    bustUnionsLevel: context.epicResearchLevels['cheaper_vehicles'] || 0,
+    lithiumMultiplier: context.colleggtibleModifiers.vehicleCost || 1,
+  });
+
+  const buyVehicle = (slotIndex: number, vehicleId: number): boolean => {
+    const currentSnap = computeSnapshot(currentState, context, { skipGrowth: true });
+    // Use count of vehicles of THIS type currently owned to determine price step
+    const countBefore = currentState.vehicles.filter(v => v.vehicleId === vehicleId).length;
+    const price = getDiscountedVehiclePrice(vehicleId, countBefore, getModifiers(), isResearchSaleActive(getAbsTime()));
+
+    if (currentSnap.offlineEarnings <= 0) return false;
+    const timeToSave = Math.max(0, (price - currentSnap.bankValue) / currentSnap.offlineEarnings);
+    if (elapsedSeconds + timeToSave > timeLimit) return false;
+
+    advanceTime(timeToSave);
+    const action = createSimAction('buy_vehicle', { slotIndex, vehicleId }, price);
+    currentState = applyAction(currentState, action);
+    
+    // Decoration
+    const finalSnap = computeSnapshot(currentState, context, { skipGrowth: true });
+    action.endState = finalSnap;
+    action.totalTimeSeconds = 0;
+    action.bankDelta = -price;
+
+    actions.push(action);
+    return true;
+  };
+
+  const buyTrainCar = (slotIndex: number): boolean => {
+    const vehicle = currentState.vehicles[slotIndex];
+    if (!vehicle || vehicle.vehicleId !== 11) return false;
+    const maxLen = calculateMaxTrainLength(currentState.researchLevels);
+    if (vehicle.trainLength >= maxLen) return false;
+
+    const currentSnap = computeSnapshot(currentState, context, { skipGrowth: true });
+    const price = getDiscountedTrainCarPrice(vehicle.trainLength, getModifiers(), isResearchSaleActive(getAbsTime()));
+
+    if (currentSnap.offlineEarnings <= 0) return false;
+    const timeToSave = Math.max(0, (price - currentSnap.bankValue) / currentSnap.offlineEarnings);
+    if (elapsedSeconds + timeToSave > timeLimit) return false;
+
+    advanceTime(timeToSave);
+    const action = createSimAction('buy_train_car', { 
+      slotIndex, 
+      fromLength: vehicle.trainLength, 
+      toLength: vehicle.trainLength + 1 
+    }, price);
+    currentState = applyAction(currentState, action);
+    
+    // Decoration
+    const finalSnap = computeSnapshot(currentState, context, { skipGrowth: true });
+    action.endState = finalSnap;
+    action.totalTimeSeconds = 0;
+    action.bankDelta = -price;
+
+    actions.push(action);
+    return true;
+  };
+
+  // 1. Shift to Kindness
+  const sCost = shiftCost(currentState.soulEggs, currentState.shiftCount);
+  const shiftAction = createSimAction('shift', {
+    fromEgg: currentState.currentEgg,
+    toEgg: 'kindness',
+    newShiftCount: currentState.shiftCount + 1,
+  }, sCost);
+  
+  currentState = applyAction(currentState, shiftAction);
+  
+  // Decoration
+  const finalSnap = computeSnapshot(currentState, context, { skipGrowth: true });
+  shiftAction.endState = finalSnap;
+  shiftAction.totalTimeSeconds = 0;
+
+  actions.push(shiftAction);
+  // console.log(`  Shifted to Kindness. Cost: ${formatNumber(sCost, 3)} SE`);
+
+  // Phase 1: Buy the most expensive vehicle affordable in <10s until shipping ≥ lay rate
+  // console.log('Phase 1: Getting shipping ≥ lay rate...');
+  let phase1Success = false;
+  while (elapsedSeconds < timeLimit) {
+    const snapshot = computeSnapshot(currentState, context, { skipGrowth: true });
+    if (snapshot.shippingCapacity >= snapshot.layRate) {
+      // console.log(`  Phase 1 complete: shipping ${formatNumber(snapshot.shippingCapacity)}/s ≥ lay rate ${formatNumber(snapshot.layRate)}/s`);
+      phase1Success = true;
+      break;
+    }
+
+    // Find first empty slot
+    const maxSlots = calculateMaxVehicleSlots(currentState.researchLevels);
+    let targetSlot = -1;
+    for (let i = 0; i < maxSlots; i++) {
+      if (!currentState.vehicles[i] || currentState.vehicles[i].vehicleId === null) {
+        targetSlot = i;
+        break;
+      }
+    }
+
+    if (targetSlot === -1) {
+      // All slots full but still under lay rate — nothing Phase 1 can do
+      // console.log('  Phase 1: All slots full but shipping still under lay rate.');
+      break;
+    }
+
+    // Buy the most expensive vehicle we can afford in <10s
+    let bought = false;
+    for (let vid = 11; vid >= 0; vid--) {
+      const currentSnap = computeSnapshot(currentState, context, { skipGrowth: true });
+      if (currentSnap.offlineEarnings <= 0) break;
+      const countBefore = currentState.vehicles.filter(v => v.vehicleId === vid).length;
+      const price = getDiscountedVehiclePrice(vid, countBefore, getModifiers(), isResearchSaleActive(getAbsTime()));
+      const timeToSave = Math.max(0, (price - currentSnap.bankValue) / currentSnap.offlineEarnings);
+
+      if (timeToSave < 10) {
+        // console.log(`  Phase 1: Buying vehicle ID ${vid} for slot ${targetSlot} (${timeToSave.toFixed(1)}s to afford)`);
+        if (buyVehicle(targetSlot, vid)) {
+          bought = true;
+          break;
+        }
+      }
+    }
+
+    if (!bought) {
+      // Nothing affordable in <10s, just buy the cheapest thing (Trike) and move on
+      // console.log(`  Phase 1: Nothing affordable in <10s, buying Trike for slot ${targetSlot}`);
+      if (!buyVehicle(targetSlot, 0)) break;
+    }
+  }
+
+  if (!phase1Success) {
+    // console.log('  Phase 1: Could not reach shipping ≥ lay rate.');
+  }
+
+  // Phase 2: Maximize shipping capacity
+  // console.log('Phase 2: Maximizing shipping capacity...');
+  const maxSlots = calculateMaxVehicleSlots(currentState.researchLevels);
+  const maxLen = calculateMaxTrainLength(currentState.researchLevels);
+
+  // Phase 2A: Buy Hyperloop Trains and cars until we can't afford them
+  // console.log('  Phase 2A: Hyperloop Trains and cars...');
+  let hyperloopsDone = false;
+  while (elapsedSeconds < timeLimit && !hyperloopsDone) {
+    // Find a slot that needs a Hyperloop upgrade, or an existing Hyperloop that needs cars
+    let bestAction: { type: 'buy_hyperloop' | 'buy_car'; slot: number; timeToSave: number } | null = null;
+
+    for (let i = 0; i < maxSlots; i++) {
+      const vehicle = currentState.vehicles[i];
+      const vid = vehicle?.vehicleId ?? -1;
+
+      if (vid !== 11) {
+        // This slot doesn't have a Hyperloop — consider buying one
+        const currentSnap = computeSnapshot(currentState, context, { skipGrowth: true });
+        if (currentSnap.offlineEarnings <= 0) continue;
+        const countBefore = currentState.vehicles.filter(v => v.vehicleId === 11).length;
+        const price = getDiscountedVehiclePrice(11, countBefore, getModifiers(), isResearchSaleActive(getAbsTime()));
+        const timeToSave = Math.max(0, (price - currentSnap.bankValue) / currentSnap.offlineEarnings);
+        if (elapsedSeconds + timeToSave <= timeLimit) {
+          if (!bestAction || timeToSave < bestAction.timeToSave) {
+            bestAction = { type: 'buy_hyperloop', slot: i, timeToSave };
+          }
+        }
+      } else if ((vehicle?.trainLength || 0) < maxLen) {
+        // This slot has a Hyperloop — consider adding a car
+        const currentSnap = computeSnapshot(currentState, context, { skipGrowth: true });
+        if (currentSnap.offlineEarnings <= 0) continue;
+        const price = getDiscountedTrainCarPrice(vehicle!.trainLength, getModifiers(), isResearchSaleActive(getAbsTime()));
+        const timeToSave = Math.max(0, (price - currentSnap.bankValue) / currentSnap.offlineEarnings);
+        if (elapsedSeconds + timeToSave <= timeLimit) {
+          if (!bestAction || timeToSave < bestAction.timeToSave) {
+            bestAction = { type: 'buy_car', slot: i, timeToSave };
+          }
+        }
+      }
+    }
+
+    if (bestAction) {
+      // console.log(`  Phase 2A: ${bestAction.type} for slot ${bestAction.slot} (${bestAction.timeToSave.toFixed(1)}s to afford)`);
+      if (bestAction.type === 'buy_hyperloop') {
+        if (!buyVehicle(bestAction.slot, 11)) { hyperloopsDone = true; }
+      } else {
+        if (!buyTrainCar(bestAction.slot)) { hyperloopsDone = true; }
+      }
+    } else {
+      // console.log('  Phase 2A: No more affordable Hyperloop upgrades.');
+      hyperloopsDone = true;
+    }
+  }
+
+  // Phase 2B: Buy Quantum Transporters for any remaining non-Hyperloop slots
+  // console.log('  Phase 2B: Quantum Transporters...');
+  for (let i = 0; i < maxSlots && elapsedSeconds < timeLimit; i++) {
+    const vid = currentState.vehicles[i]?.vehicleId ?? -1;
+    if (vid < 10) {
+      // console.log(`  Phase 2B: Buying Quantum Transporter for slot ${i}`);
+      if (!buyVehicle(i, 10)) {
+        // console.log(`  Phase 2B: Can't afford Quantum Transporter for slot ${i}, stopping.`);
+        break;
+      }
+    }
+  }
+
+  // Phase 2C: Fill any remaining empty slots with the best affordable vehicle
+  // console.log('  Phase 2C: Filling remaining empty slots...');
+  for (let i = 0; i < maxSlots && elapsedSeconds < timeLimit; i++) {
+    if (!currentState.vehicles[i] || currentState.vehicles[i].vehicleId === null) {
+      // Find best affordable vehicle for this slot
+      let bought = false;
+      for (let vid = 11; vid >= 0; vid--) {
+        const currentSnap = computeSnapshot(currentState, context, { skipGrowth: true });
+        if (currentSnap.offlineEarnings <= 0) break;
+        const countBefore = currentState.vehicles.filter(v => v.vehicleId === vid).length;
+        const price = getDiscountedVehiclePrice(vid, countBefore, getModifiers(), isResearchSaleActive(getAbsTime()));
+        const timeToSave = Math.max(0, (price - currentSnap.bankValue) / currentSnap.offlineEarnings);
+        if (elapsedSeconds + timeToSave <= timeLimit) {
+          // console.log(`  Phase 2C: Buying vehicle ID ${vid} for empty slot ${i}`);
+          if (buyVehicle(i, vid)) { bought = true; break; }
+        }
+      }
+      if (!bought) {
+        // console.log(`  Phase 2C: Can't afford any vehicle for slot ${i}, stopping.`);
+        break;
+      }
+    }
+  }
+
+  // console.log(`K1 Finished: ${actions.filter(a => a.type === 'buy_vehicle' || a.type === 'buy_train_car').length} vehicle actions, total time ${elapsedSeconds.toFixed(1)}s`);
+
+  return {
+    actions,
+    elapsedSeconds,
+    endState: currentState,
+  };
+}

--- a/wasmegg/ascension-planner/src/auto/shifts/k2.ts
+++ b/wasmegg/ascension-planner/src/auto/shifts/k2.ts
@@ -1,0 +1,160 @@
+import type { Action } from '@/types/actions/meta';
+import type { EngineState, SimulationContext, ShiftResult } from '../types';
+import { computeSnapshot } from '../../engine/compute';
+import { applyAction } from '../../engine/apply';
+import { createSimAction } from '@/types/actions/meta';
+import { shiftCost } from 'lib';
+import {
+  getDiscountedVehiclePrice,
+  getDiscountedTrainCarPrice,
+} from '../../lib/vehicles';
+import { isResearchSaleActive } from '../calendar';
+import { calculateMaxVehicleSlots, calculateMaxTrainLength } from '../../calculations/shippingCapacity';
+import { formatNumber } from '@/lib/format';
+
+/**
+ * K2 Shift Strategy:
+ * 1. Shift to Kindness.
+ * 2. Max all vehicle slots with best vehicles (Hyperloops, ID 11).
+ * 3. Max train lengths.
+ */
+export function runK2(
+  startState: EngineState,
+  context: SimulationContext
+): ShiftResult {
+  // console.log('--- Starting K2 Shift Simulation ---');
+  let currentState = { ...startState };
+  let elapsedSeconds = 0;
+  const actions: Action[] = [];
+
+  const getAbsTime = () => context.ascensionStartTime + context.planStartOffset + (startState.lastStepTime || 0) + elapsedSeconds;
+
+  const advanceTime = (seconds: number) => {
+    if (seconds <= 0) return;
+    const snap = computeSnapshot(currentState, context, { skipGrowth: true });
+    const waitAction = createSimAction('wait_for_time', { totalTimeSeconds: seconds });
+    
+    currentState = applyAction(currentState, waitAction);
+    // applyAction doesn't update bankValue or lastStepTime for wait actions, so we credit them manually
+    currentState = { ...currentState, lastStepTime: (currentState.lastStepTime || 0) + seconds, bankValue: (currentState.bankValue || 0) + snap.offlineEarnings * seconds };
+    
+    // Decoration for the action store
+    const finalSnap = computeSnapshot(currentState, context, { skipGrowth: true });
+    waitAction.endState = finalSnap;
+    waitAction.totalTimeSeconds = seconds;
+    waitAction.bankDelta = snap.offlineEarnings * seconds;
+    
+    actions.push(waitAction);
+    elapsedSeconds += seconds;
+  };
+
+  const getModifiers = () => ({
+    bustUnionsLevel: context.epicResearchLevels['cheaper_vehicles'] || 0,
+    lithiumMultiplier: context.colleggtibleModifiers.vehicleCost || 1,
+  });
+
+  const buyVehicle = (slotIndex: number, vehicleId: number): boolean => {
+    const currentSnap = computeSnapshot(currentState, context, { skipGrowth: true });
+    const countBefore = currentState.vehicles.filter(v => v?.vehicleId === vehicleId).length;
+    const price = getDiscountedVehiclePrice(vehicleId, countBefore, getModifiers(), isResearchSaleActive(getAbsTime()));
+
+    if (currentSnap.offlineEarnings <= 0) return false;
+    const timeToSave = Math.max(0, (price - currentSnap.bankValue) / currentSnap.offlineEarnings);
+
+    advanceTime(timeToSave);
+    const action = createSimAction('buy_vehicle', { slotIndex, vehicleId }, price);
+    currentState = applyAction(currentState, action);
+    
+    // Decoration
+    const finalSnap = computeSnapshot(currentState, context, { skipGrowth: true });
+    action.endState = finalSnap;
+    action.totalTimeSeconds = 0;
+    action.bankDelta = -price;
+
+    actions.push(action);
+    return true;
+  };
+
+  const buyTrainCar = (slotIndex: number): boolean => {
+    const vehicle = currentState.vehicles[slotIndex];
+    if (!vehicle || vehicle.vehicleId !== 11) return false;
+    const maxLen = calculateMaxTrainLength(currentState.researchLevels);
+    if (vehicle.trainLength >= maxLen) return false;
+
+    const currentSnap = computeSnapshot(currentState, context, { skipGrowth: true });
+    const price = getDiscountedTrainCarPrice(vehicle.trainLength, getModifiers(), isResearchSaleActive(getAbsTime()));
+
+    if (currentSnap.offlineEarnings <= 0) return false;
+    const timeToSave = Math.max(0, (price - currentSnap.bankValue) / currentSnap.offlineEarnings);
+
+    advanceTime(timeToSave);
+    const action = createSimAction('buy_train_car', { 
+      slotIndex, 
+      fromLength: vehicle.trainLength, 
+      toLength: vehicle.trainLength + 1 
+    }, price);
+    currentState = applyAction(currentState, action);
+    
+    // Decoration
+    const finalSnap = computeSnapshot(currentState, context, { skipGrowth: true });
+    action.endState = finalSnap;
+    action.totalTimeSeconds = 0;
+    action.bankDelta = -price;
+
+    actions.push(action);
+    return true;
+  };
+
+  // 1. Shift to Kindness
+  const sCost = shiftCost(currentState.soulEggs, currentState.shiftCount);
+  const shiftAction = createSimAction('shift', {
+    fromEgg: currentState.currentEgg,
+    toEgg: 'kindness',
+    newShiftCount: currentState.shiftCount + 1,
+  }, sCost);
+  
+  currentState = applyAction(currentState, shiftAction);
+  
+  // Decoration
+  const finalSnap = computeSnapshot(currentState, context, { skipGrowth: true });
+  shiftAction.endState = finalSnap;
+  shiftAction.totalTimeSeconds = 0;
+
+  actions.push(shiftAction);
+  // console.log(`  Shifted to Kindness. Cost: ${formatNumber(sCost, 3)} SE`);
+
+  // 2. Max all vehicle slots with Hyperloop (ID 11)
+  // console.log('Phase 1: Buying Hyperloop for all slots...');
+  const maxSlots = calculateMaxVehicleSlots(currentState.researchLevels);
+  for (let slot = 0; slot < maxSlots; slot++) {
+    const currentVid = currentState.vehicles[slot]?.vehicleId;
+    if (currentVid !== 11) {
+      if (!buyVehicle(slot, 11)) {
+         break;
+      }
+    }
+  }
+
+  // 3. Max train lengths
+  // console.log('Phase 2: Maxing train lengths...');
+  const maxLen = calculateMaxTrainLength(currentState.researchLevels);
+  for (let slot = 0; slot < maxSlots; slot++) {
+    while (true) {
+      const vehicle = currentState.vehicles[slot];
+      if (!vehicle || vehicle.vehicleId !== 11 || vehicle.trainLength >= maxLen) {
+        break;
+      }
+      if (!buyTrainCar(slot)) {
+        break;
+      }
+    }
+  }
+
+  // console.log(`K2 Finished: ${actions.filter(a => a.type === 'buy_vehicle' || a.type === 'buy_train_car').length} vehicle actions, total time ${elapsedSeconds}s`);
+
+  return {
+    actions,
+    elapsedSeconds,
+    endState: currentState,
+  };
+}

--- a/wasmegg/ascension-planner/src/auto/shifts/k3.ts
+++ b/wasmegg/ascension-planner/src/auto/shifts/k3.ts
@@ -1,0 +1,228 @@
+import type { Action } from '@/types/actions/meta';
+import type { EngineState, SimulationContext, ShiftResult } from '../types';
+import { computeSnapshot } from '../../engine/compute';
+import { applyAction } from '../../engine/apply';
+import { createSimAction } from '@/types/actions/meta';
+import { shiftCost } from 'lib';
+import {
+  getDiscountedVehiclePrice,
+  getDiscountedTrainCarPrice,
+} from '../../lib/vehicles';
+import { isResearchSaleActive } from '../calendar';
+import { calculateMaxVehicleSlots, calculateMaxTrainLength } from '../../calculations/shippingCapacity';
+import { computeRealisticELR } from '../../calculations/realisticELR';
+import { calculateArtifactModifiers } from '@/lib/artifacts';
+import { formatNumber } from '@/lib/format';
+import { countTEThresholdsPassed } from '@/lib/truthEggs';
+import { computeTEEarned, timeToEarnTE } from '../te-thresholds';
+
+/**
+ * K3 Shift Strategy:
+ * 1. Shift to Kindness.
+ * 2. Buy any remaining vehicles/trains unlocked by C3.
+ * 3. Compute peak ELR.
+ * 4. Wait until buildPhaseEnd.
+ */
+export function runK3(
+  startState: EngineState,
+  context: SimulationContext,
+  buildPhaseEnd: number = 0,
+  targetTEForEgg?: number
+): ShiftResult {
+  let currentState: EngineState = { ...startState };
+  let elapsedSeconds = 0;
+  const actions: Action[] = [];
+
+  const getAbsTime = () => context.ascensionStartTime + context.planStartOffset + (startState.lastStepTime || 0) + elapsedSeconds;
+
+  const advanceTime = (seconds: number, metadata?: any) => {
+    if (seconds <= 0) return;
+    const snap = computeSnapshot(currentState, context, { skipGrowth: true });
+    const waitAction = createSimAction('wait_for_time', { totalTimeSeconds: seconds, ...metadata });
+    
+    currentState = applyAction(currentState, waitAction);
+    // applyAction doesn't update bankValue or lastStepTime for wait actions, so we credit them manually
+    currentState = { ...currentState, lastStepTime: (currentState.lastStepTime || 0) + seconds, bankValue: (currentState.bankValue || 0) + snap.offlineEarnings * seconds };
+
+    // Decoration for the action store
+    const finalSnap = computeSnapshot(currentState, context, { skipGrowth: true });
+    waitAction.endState = finalSnap;
+    waitAction.totalTimeSeconds = seconds;
+    waitAction.bankDelta = snap.offlineEarnings * seconds;
+    
+    actions.push(waitAction);
+    elapsedSeconds += seconds;
+  };
+
+  const getModifiers = () => ({
+    bustUnionsLevel: context.epicResearchLevels['cheaper_vehicles'] || 0,
+    lithiumMultiplier: context.colleggtibleModifiers.vehicleCost || 1,
+  });
+
+  const buyVehicle = (slotIndex: number, vehicleId: number): boolean => {
+    const currentSnap = computeSnapshot(currentState, context, { skipGrowth: true });
+    const countBefore = currentState.vehicles.filter(v => v?.vehicleId === vehicleId).length;
+    const price = getDiscountedVehiclePrice(vehicleId, countBefore, getModifiers(), isResearchSaleActive(getAbsTime()));
+
+    if (currentSnap.offlineEarnings <= 0) return false;
+    const timeToSave = Math.max(0, (price - currentSnap.bankValue) / currentSnap.offlineEarnings);
+
+    advanceTime(timeToSave);
+    const action = createSimAction('buy_vehicle', { slotIndex, vehicleId }, price);
+    currentState = applyAction(currentState, action);
+    
+    // Decoration
+    const finalSnap = computeSnapshot(currentState, context, { skipGrowth: true });
+    action.endState = finalSnap;
+    action.totalTimeSeconds = 0;
+    action.bankDelta = -price;
+
+    actions.push(action);
+    return true;
+  };
+
+  const buyTrainCar = (slotIndex: number): boolean => {
+    const vehicle = currentState.vehicles[slotIndex];
+    if (!vehicle || vehicle.vehicleId !== 11) return false;
+    const maxLen = calculateMaxTrainLength(currentState.researchLevels);
+    if (vehicle.trainLength >= maxLen) return false;
+
+    const currentSnap = computeSnapshot(currentState, context, { skipGrowth: true });
+    const price = getDiscountedTrainCarPrice(vehicle.trainLength, getModifiers(), isResearchSaleActive(getAbsTime()));
+
+    if (currentSnap.offlineEarnings <= 0) return false;
+    const timeToSave = Math.max(0, (price - currentSnap.bankValue) / currentSnap.offlineEarnings);
+
+    advanceTime(timeToSave);
+    const action = createSimAction('buy_train_car', { 
+      slotIndex, 
+      fromLength: vehicle.trainLength, 
+      toLength: vehicle.trainLength + 1 
+    }, price);
+    currentState = applyAction(currentState, action);
+    
+    // Decoration
+    const finalSnap = computeSnapshot(currentState, context, { skipGrowth: true });
+    action.endState = finalSnap;
+    action.totalTimeSeconds = 0;
+    action.bankDelta = -price;
+
+    actions.push(action);
+    return true;
+  };
+
+  // 1. Shift to Kindness
+  const sCost = shiftCost(currentState.soulEggs, currentState.shiftCount);
+  const shiftAction = createSimAction('shift', {
+    fromEgg: currentState.currentEgg,
+    toEgg: 'kindness',
+    newShiftCount: currentState.shiftCount + 1,
+  }, sCost);
+  
+  currentState = applyAction(currentState, shiftAction);
+  
+  // Decoration
+  const finalSnap = computeSnapshot(currentState, context, { skipGrowth: true });
+  shiftAction.endState = finalSnap;
+  shiftAction.totalTimeSeconds = 0;
+
+  actions.push(shiftAction);
+
+  // 2. Buy any remaining vehicles/trains
+  const maxSlots = calculateMaxVehicleSlots(currentState.researchLevels);
+  for (let slot = 0; slot < maxSlots; slot++) {
+    const currentVid = currentState.vehicles[slot]?.vehicleId;
+    if (currentVid !== 11) {
+      if (!buyVehicle(slot, 11)) break;
+    }
+  }
+
+  const maxLen = calculateMaxTrainLength(currentState.researchLevels);
+  for (let slot = 0; slot < maxSlots; slot++) {
+    while (true) {
+      const vehicle = currentState.vehicles[slot];
+      if (!vehicle || vehicle.vehicleId !== 11 || vehicle.trainLength >= maxLen) break;
+      if (!buyTrainCar(slot)) break;
+    }
+  }
+
+  // 3. Compute peak ELR
+  const artMods = calculateArtifactModifiers(currentState.artifactLoadout);
+  const elrResult = computeRealisticELR(
+    currentState.researchLevels,
+    artMods,
+    context.epicResearchLevels,
+    context.colleggtibleModifiers
+  );
+  
+  const peakELR = elrResult.effectiveRate;
+  currentState.maxELR = peakELR;
+
+  // Attach peakELR to the shift action (the first action) so the UI summary can find it easily
+  if (actions.length > 0 && actions[0].type === 'shift') {
+    actions[0].payload.peakELR = peakELR;
+  }
+
+  // 4. Wait
+  const absTimeAfterPurchases = getAbsTime();
+  let waitDuration = Math.max(0, buildPhaseEnd - absTimeAfterPurchases);
+  
+  if (targetTEForEgg !== undefined) {
+    const currentEggsDelivered = currentState.eggsDelivered['kindness'] || 0;
+    const currentTE = countTEThresholdsPassed(currentEggsDelivered);
+    const neededTE = Math.max(0, targetTEForEgg - currentTE);
+    
+    if (neededTE > 0) {
+      const teWaitTime = timeToEarnTE(currentEggsDelivered, peakELR, neededTE);
+      // We wait until buildPhaseEnd (end of sale) but extend it if more TE is needed.
+      waitDuration = Math.max(waitDuration, teWaitTime);
+    }
+  }
+  
+  if (waitDuration > 0) {
+    const currentEggsDelivered = currentState.eggsDelivered['kindness'] || 0;
+    const currentTE = countTEThresholdsPassed(currentEggsDelivered);
+
+    const teResult = computeTEEarned(
+      currentEggsDelivered,
+      peakELR,
+      waitDuration
+    );
+    
+    const waitAction = createSimAction('wait_for_te', { 
+      egg: 'kindness',
+      targetTE: currentTE + teResult.teEarned,
+      teGained: teResult.teEarned,
+      eggsToLay: teResult.finalEggsDelivered - currentEggsDelivered,
+      timeSeconds: waitDuration,
+      startEggsDelivered: currentEggsDelivered,
+      startTE: currentTE
+    });
+    
+    currentState = applyAction(currentState, waitAction);
+    
+    const snap = computeSnapshot(currentState, context, { skipGrowth: true });
+    currentState.bankValue += snap.offlineEarnings * waitDuration;
+
+    currentState.eggsDelivered['kindness'] = teResult.finalEggsDelivered;
+    currentState.teEarned['kindness'] = (currentState.teEarned['kindness'] || 0) + teResult.teEarned;
+    currentState.te = Object.values(currentState.teEarned).reduce((a, b) => (a as number) + (b as number), 0);
+    
+    // Decoration
+    const finalSnap = computeSnapshot(currentState, context, { skipGrowth: true });
+    waitAction.endState = finalSnap;
+    waitAction.totalTimeSeconds = waitDuration;
+    waitAction.bankDelta = snap.offlineEarnings * waitDuration;
+
+    actions.push(waitAction);
+    elapsedSeconds += waitDuration;
+  }
+
+  // console.log(`K3 Finished: Peak ELR ${formatNumber(peakELR * 3600, 3)}/hr. TE earned in wait: ${currentState.teEarned[currentState.currentEgg]}`);
+
+  return {
+    actions,
+    elapsedSeconds,
+    endState: currentState,
+  };
+}

--- a/wasmegg/ascension-planner/src/auto/shifts/quickWins.ts
+++ b/wasmegg/ascension-planner/src/auto/shifts/quickWins.ts
@@ -1,0 +1,143 @@
+/**
+ * Fast-path research buyer for cheap items (≤ thresholdSeconds of waiting).
+ *
+ * Both C1 and C2 use this pattern. Extracted here to avoid duplication.
+ *
+ * Why a standalone function instead of a closure:
+ *   The algorithm mutates three values owned by the caller (currentState, elapsedSeconds,
+ *   offlineEarnings). Since these are JS primitives / reassigned references, we can't
+ *   mutate them through a shared object without wrappers. Instead we accept them as inputs
+ *   and return the updated values; the caller reassigns its own locals from the result.
+ *
+ * Why this is fast:
+ *  - applyAction for 'wait_for_time' is a no-op — advanceTime's manual bank update is
+ *    replicated here without calling computeSnapshot.
+ *  - mods (artifact/epic/colleggtible multipliers) are constant during research buys.
+ *  - offlineEarnings only changes when earnings-category research is bought; cached otherwise.
+ *  - Sale/boost boundaries occur at most weekly. Skipping per-item boundary detection inside
+ *    a ≤3s wait is inconsequential; we re-check isSale each iteration so the first buy after
+ *    a sale toggle still uses the correct price.
+ *  - bankValue is read from currentState.bankValue, which applyAction keeps in sync.
+ *
+ * Snapshot recomputes are limited to once per earnings-affecting purchase.
+ */
+
+import type { Action } from '@/types/actions/meta';
+import type { EngineState, SimulationContext } from '../types';
+import {
+  getCommonResearches,
+  getDiscountedVirtuePrice,
+  isTierUnlocked,
+  type ResearchCostModifiers,
+} from '../../calculations/commonResearch';
+import { computeSnapshot } from '../../engine/compute';
+import { applyAction } from '../../engine/apply';
+import { createSimAction } from '@/types/actions/meta';
+import { isResearchSaleActive } from '../calendar';
+
+export const QUICK_BUY_THRESHOLD_SECONDS = 3;
+
+export interface QuickWinsResult {
+  /** Number of research items purchased. */
+  count: number;
+  /** Updated engine state (currentState is replaced, not mutated). */
+  currentState: EngineState;
+  /** Updated elapsed simulation seconds. */
+  elapsedSeconds: number;
+  /** Updated cached earnings rate (may change if earnings research was bought). */
+  offlineEarnings: number;
+}
+
+/**
+ * Buy all research purchasable within `thresholdSeconds` of waiting.
+ *
+ * @param currentState     Current engine state.
+ * @param actions          Action log array — pushed to in place.
+ * @param elapsedSeconds   Elapsed simulation seconds so far.
+ * @param offlineEarnings  Cached earnings rate (Virtue/s).
+ * @param mods             Pre-computed cost modifiers (constant for a given shift).
+ * @param context          Simulation context.
+ * @param getAbsTime       Returns the current absolute simulation time.
+ * @param approximateSnap  Snapshot used as endState for generated actions (approximate is fine).
+ * @param timeLimit        Hard ceiling on elapsedSeconds.
+ * @param earningsCategories Research categories that affect offlineEarnings (triggers recompute).
+ * @param thresholdSeconds Maximum wait-time per item (default: QUICK_BUY_THRESHOLD_SECONDS).
+ */
+export function runQuickWins(
+  currentState: EngineState,
+  actions: Action[],
+  elapsedSeconds: number,
+  offlineEarnings: number,
+  mods: ResearchCostModifiers,
+  context: SimulationContext,
+  getAbsTime: () => number,
+  approximateSnap: any,
+  timeLimit: number,
+  earningsCategories: readonly string[],
+  thresholdSeconds: number = QUICK_BUY_THRESHOLD_SECONDS,
+): QuickWinsResult {
+  let count = 0;
+  if (offlineEarnings <= 0) return { count, currentState, elapsedSeconds, offlineEarnings };
+
+  while (elapsedSeconds <= timeLimit) {
+    const isSale = isResearchSaleActive(getAbsTime());
+    const bankValue = currentState.bankValue || 0;
+
+    // Find cheapest available research within the wait-time threshold.
+    const candidate = getCommonResearches()
+      .filter(r => (currentState.researchLevels[r.id] || 0) < r.levels)
+      .filter(r => isTierUnlocked(currentState.researchLevels, r.tier))
+      .map(r => ({
+        r,
+        price: getDiscountedVirtuePrice(r, currentState.researchLevels[r.id] || 0, mods, isSale),
+      }))
+      .filter(({ price }) => {
+        const timeToSave = Math.max(0, (price - bankValue) / offlineEarnings);
+        return timeToSave <= thresholdSeconds && elapsedSeconds + timeToSave <= timeLimit;
+      })
+      .sort((a, b) => a.price - b.price)[0];
+
+    if (!candidate) break;
+
+    const { r, price } = candidate;
+    const currentLevel = currentState.researchLevels[r.id] || 0;
+    const timeToSave = Math.max(0, (price - bankValue) / offlineEarnings);
+
+    // Fast wait: skip advanceTime (its applyAction for wait_for_time is a no-op anyway)
+    // and skip boundary detection (inconsequential inside ≤3s per user preference).
+    if (timeToSave > 0) {
+      const waitAction = createSimAction('wait_for_time', { totalTimeSeconds: timeToSave });
+      currentState = {
+        ...currentState,
+        lastStepTime: (currentState.lastStepTime || 0) + timeToSave,
+        bankValue: bankValue + offlineEarnings * timeToSave,
+      };
+      waitAction.endState = approximateSnap;
+      waitAction.totalTimeSeconds = timeToSave;
+      waitAction.bankDelta = offlineEarnings * timeToSave;
+      actions.push(waitAction);
+      elapsedSeconds += timeToSave;
+    }
+
+    // Buy directly — skip the buyResearch wrapper and its redundant snapshot calls.
+    const action = createSimAction('buy_research', {
+      researchId: r.id,
+      fromLevel: currentLevel,
+      toLevel: currentLevel + 1,
+    }, price);
+    currentState = applyAction(currentState, action);
+    action.totalTimeSeconds = 0;
+    action.bankDelta = -price;
+    action.endState = approximateSnap;
+    actions.push(action);
+    count++;
+
+    // Only recompute offlineEarnings when earnings-category research was bought.
+    if (earningsCategories.some(cat => r.categories.includes(cat))) {
+      const updatedSnap = computeSnapshot(currentState, context, { skipGrowth: true });
+      offlineEarnings = updatedSnap.offlineEarnings;
+    }
+  }
+
+  return { count, currentState, elapsedSeconds, offlineEarnings };
+}

--- a/wasmegg/ascension-planner/src/auto/shifts/r1.ts
+++ b/wasmegg/ascension-planner/src/auto/shifts/r1.ts
@@ -1,0 +1,104 @@
+import type { Action } from '@/types/actions/meta';
+import type { EngineState, SimulationContext, ShiftResult } from '../types';
+import { computeSnapshot } from '../../engine/compute';
+import { applyAction } from '../../engine/apply';
+import { createSimAction } from '@/types/actions/meta';
+import { shiftCost } from 'lib';
+import { nextSiloCost, MAX_SILOS } from '../../stores/silos';
+import { formatNumber } from '@/lib/format';
+
+/**
+ * R1 Shift Strategy:
+ * 1. Shift to Resilience.
+ * 2. Buy as many silos as possible within 1 hour.
+ */
+export function runR1(
+  startState: EngineState,
+  context: SimulationContext,
+  timeLimit: number = 3600
+): ShiftResult {
+  // console.log('--- Starting R1 Shift Simulation ---');
+  let currentState = { ...startState };
+  let elapsedSeconds = 0;
+  const actions: Action[] = [];
+
+  const advanceTime = (seconds: number) => {
+    if (seconds <= 0) return;
+    const snap = computeSnapshot(currentState, context, { skipGrowth: true });
+    const waitAction = createSimAction('wait_for_time', { totalTimeSeconds: seconds });
+    
+    currentState = applyAction(currentState, waitAction);
+    // applyAction doesn't update bankValue or lastStepTime for wait actions, so we credit them manually
+    currentState = { ...currentState, lastStepTime: (currentState.lastStepTime || 0) + seconds, bankValue: (currentState.bankValue || 0) + snap.offlineEarnings * seconds };
+    
+    // Decoration for the action store
+    const finalSnap = computeSnapshot(currentState, context, { skipGrowth: true });
+    waitAction.endState = finalSnap;
+    waitAction.totalTimeSeconds = seconds;
+    waitAction.bankDelta = snap.offlineEarnings * seconds;
+    
+    actions.push(waitAction);
+    elapsedSeconds += seconds;
+  };
+
+  // 1. Shift to Resilience
+  const sCost = shiftCost(currentState.soulEggs, currentState.shiftCount);
+  const shiftAction = createSimAction('shift', {
+    fromEgg: currentState.currentEgg,
+    toEgg: 'resilience',
+    newShiftCount: currentState.shiftCount + 1,
+  }, sCost);
+  
+  currentState = applyAction(currentState, shiftAction);
+  
+  // Decoration
+  const finalSnap = computeSnapshot(currentState, context, { skipGrowth: true });
+  shiftAction.endState = finalSnap;
+  shiftAction.totalTimeSeconds = 0;
+
+  actions.push(shiftAction);
+  // console.log(`  Shifted to Resilience. Cost: ${formatNumber(sCost, 3)} SE`);
+
+  // 2. Buy as many silos as possible within 1 hour
+  // console.log('Phase 1: Buying silos...');
+  while (currentState.siloCount < MAX_SILOS) {
+    const currentSnap = computeSnapshot(currentState, context, { skipGrowth: true });
+    const cost = nextSiloCost(currentState.siloCount);
+
+    if (currentSnap.offlineEarnings <= 0) break;
+    const timeToSave = Math.max(0, (cost - currentSnap.bankValue) / currentSnap.offlineEarnings);
+
+    if (!Number.isFinite(timeToSave)) {
+      // console.log(`  [Silo ${currentState.siloCount + 1}] Stalling: Cannot afford. Earnings: ${formatNumber(currentSnap.offlineEarnings, 3)}/s, Cost: ${formatNumber(cost, 3)}`);
+      break;
+    }
+
+    if (elapsedSeconds + timeToSave > timeLimit) {
+      break;
+    }
+
+    advanceTime(timeToSave);
+    const action = createSimAction('buy_silo', {
+      fromCount: currentState.siloCount,
+      toCount: currentState.siloCount + 1,
+    }, cost);
+    currentState = applyAction(currentState, action);
+    
+    // Decoration
+    const finalSnap = computeSnapshot(currentState, context, { skipGrowth: true });
+    action.endState = finalSnap;
+    action.totalTimeSeconds = 0;
+    action.bankDelta = -cost;
+
+    actions.push(action);
+    // console.log(`  [Silo ${currentState.siloCount}] BOUGHT. Total time: ${elapsedSeconds.toFixed(1)}s`);
+  }
+
+  // console.log(`R1 Finished: ${actions.filter(a => a.type === 'buy_silo').length} silo actions, total time ${elapsedSeconds}s`);
+
+  return {
+    actions,
+    elapsedSeconds,
+    endState: currentState,
+  };
+}

--- a/wasmegg/ascension-planner/src/auto/shifts/te-wait.ts
+++ b/wasmegg/ascension-planner/src/auto/shifts/te-wait.ts
@@ -1,0 +1,202 @@
+import type { Action } from '@/types/actions/meta';
+import type { EngineState, SimulationContext, ShiftResult } from '../types';
+import { computeSnapshot } from '../../engine/compute';
+import { applyAction } from '../../engine/apply';
+import { createSimAction } from '@/types/actions/meta';
+import { shiftCost } from 'lib';
+import { TE_BREAKPOINTS, countTEThresholdsPassed, getThresholdForTE } from '@/lib/truthEggs';
+import { computeTEEarned, timeToEarnTE } from '../te-thresholds';
+import type { VirtueEgg } from '@/types/actions/virtue';
+
+/**
+ * Distributes a target total TE across the 5 virtue eggs in a way that
+ * minimizes total time (by aiming for equalized TE counts).
+ * 
+ * @param currentTEs - Map of current TE per egg
+ * @param targetTotalTE - Goal total TE for the entire ascension
+ * @returns Map of target TE per egg
+ */
+export function distributeTargetTE(
+  currentTEs: Record<VirtueEgg, number>,
+  targetTotalTE: number
+): Record<VirtueEgg, number> {
+  const targets: Record<VirtueEgg, number> = { ...currentTEs };
+  const eggs: VirtueEgg[] = ['curiosity', 'integrity', 'resilience', 'humility', 'kindness'];
+
+  let currentTotal = Object.values(targets).reduce((a, b) => a + b, 0);
+  
+  while (currentTotal < targetTotalTE) {
+    // Find the egg where the next TE is "cheapest" (lowest threshold)
+    let bestEgg: VirtueEgg | null = null;
+    let minThreshold = Infinity;
+
+    for (const egg of eggs) {
+      const currentTE = targets[egg];
+      if (currentTE < TE_BREAKPOINTS.length) {
+        const threshold = TE_BREAKPOINTS[currentTE]; // Threshold for TE #(currentTE + 1)
+        if (threshold < minThreshold) {
+          minThreshold = threshold;
+          bestEgg = egg;
+        }
+      }
+    }
+
+    if (!bestEgg) break; // Should not happen unless target > max total TE
+
+    targets[bestEgg]++;
+    currentTotal++;
+  }
+
+  return targets;
+}
+
+/**
+ * Finds the maximum total TE goal that can be reached within a given time budget.
+ * Uses a greedy approach similar to distributeTargetTE but constrained by time.
+ */
+export function solveTEForTimeBudget(
+  currentTEs: Record<VirtueEgg, number>,
+  currentEggsDelivered: Record<VirtueEgg, number>,
+  peakELR: number,
+  timeBudgetSeconds: number
+): number {
+  if (timeBudgetSeconds <= 0) return Object.values(currentTEs).reduce((a, b) => a + b, 0);
+  if (peakELR <= 0) return Object.values(currentTEs).reduce((a, b) => a + b, 0);
+
+  const targets = { ...currentTEs };
+  const eggsDelivered = { ...currentEggsDelivered };
+  const eggs: VirtueEgg[] = ['curiosity', 'integrity', 'resilience', 'humility', 'kindness'];
+  let remainingTime = timeBudgetSeconds;
+  
+  while (remainingTime > 0) {
+    let bestEgg: VirtueEgg | null = null;
+    let minTime = Infinity;
+
+    for (const egg of eggs) {
+      const currentTE = targets[egg];
+      if (currentTE < TE_BREAKPOINTS.length) {
+        // How long to reach the NEXT TE for this egg?
+        const time = timeToEarnTE(eggsDelivered[egg] || 0, peakELR, 1);
+        if (time < minTime) {
+          minTime = time;
+          bestEgg = egg;
+        }
+      }
+    }
+
+    if (!bestEgg || minTime > remainingTime) break;
+
+    remainingTime -= minTime;
+    targets[bestEgg]++;
+    // Update eggsDelivered to the threshold we just hit
+    eggsDelivered[bestEgg] = getThresholdForTE(targets[bestEgg]);
+  }
+
+  const finalTotal = Object.values(targets).reduce((a, b) => a + b, 0);
+  return finalTotal;
+}
+
+/**
+ * Runs a TE-earning shift for a specific egg.
+ * Waits until the target TE for that egg is reached at peak ELR.
+ */
+export function runTEWaitShift(
+  state: EngineState,
+  context: SimulationContext,
+  egg: VirtueEgg,
+  targetTEForEgg: number,
+  peakELR: number
+): ShiftResult {
+  let currentState = { ...state };
+  let elapsedSeconds = 0;
+  const actions: Action[] = [];
+
+  // Skip entirely if this egg already has enough TE
+  const currentTECheck = countTEThresholdsPassed(currentState.eggsDelivered[egg] || 0);
+  if (targetTEForEgg <= currentTECheck) {
+    return { actions: [], elapsedSeconds: 0, endState: state };
+  }
+
+  // 1. Shift to target egg if not already there
+  if (currentState.currentEgg !== egg) {
+    const sCost = shiftCost(currentState.soulEggs, currentState.shiftCount);
+    const shiftAction = createSimAction('shift', {
+      fromEgg: currentState.currentEgg,
+      toEgg: egg,
+      newShiftCount: currentState.shiftCount + 1,
+    }, sCost);
+    
+    currentState = applyAction(currentState, shiftAction);
+    
+    // Decoration
+    const finalSnap = computeSnapshot(currentState, context, { skipGrowth: true });
+    shiftAction.endState = finalSnap;
+    shiftAction.totalTimeSeconds = 0;
+
+    actions.push(shiftAction);
+  }
+
+  // 2. Wait until target TE is reached
+  const currentEggsDelivered = currentState.eggsDelivered[egg] || 0;
+  const currentTE = countTEThresholdsPassed(currentEggsDelivered);
+  const neededTE = Math.max(0, targetTEForEgg - currentTE);
+
+
+  if (neededTE > 0) {
+    const waitTime = timeToEarnTE(currentEggsDelivered, peakELR, neededTE);
+    if (waitTime > 0 && waitTime !== Infinity) {
+      const teResult = computeTEEarned(currentEggsDelivered, peakELR, waitTime);
+      
+      const waitAction = createSimAction('wait_for_te', { 
+        egg,
+        targetTE: currentTE + neededTE,
+        teGained: teResult.teEarned,
+        eggsToLay: teResult.finalEggsDelivered - currentEggsDelivered,
+        timeSeconds: waitTime,
+        startEggsDelivered: currentEggsDelivered,
+        startTE: currentTE
+      });
+      
+      // Update state manually because applyAction doesn't know about TE tracking or time
+      currentState = applyAction(currentState, waitAction);
+      const snap = computeSnapshot(currentState, context, { skipGrowth: true });
+      currentState.lastStepTime = (currentState.lastStepTime || 0) + waitTime;
+      currentState.bankValue += snap.offlineEarnings * waitTime;
+      
+      currentState.eggsDelivered[egg] = teResult.finalEggsDelivered;
+      currentState.teEarned[egg] = (currentState.teEarned[egg] || 0) + teResult.teEarned;
+      currentState.te += teResult.teEarned;
+      
+      // Decoration
+      const finalSnap = computeSnapshot(currentState, context, { skipGrowth: true });
+      waitAction.endState = finalSnap;
+      waitAction.totalTimeSeconds = waitTime;
+      waitAction.bankDelta = snap.offlineEarnings * waitTime;
+
+      actions.push(waitAction);
+      elapsedSeconds += waitTime;
+    }
+  }
+
+  return {
+    actions,
+    elapsedSeconds,
+    endState: currentState,
+  };
+}
+
+export function runC4(state: EngineState, context: SimulationContext, targetTEForEgg: number = 0, peakELR: number = 0): ShiftResult {
+  return runTEWaitShift(state, context, 'curiosity', targetTEForEgg, peakELR);
+}
+
+export function runI2(state: EngineState, context: SimulationContext, targetTEForEgg: number = 0, peakELR: number = 0): ShiftResult {
+  return runTEWaitShift(state, context, 'integrity', targetTEForEgg, peakELR);
+}
+
+export function runR2(state: EngineState, context: SimulationContext, targetTEForEgg: number = 0, peakELR: number = 0): ShiftResult {
+  return runTEWaitShift(state, context, 'resilience', targetTEForEgg, peakELR);
+}
+
+export function runH2(state: EngineState, context: SimulationContext, targetTEForEgg: number = 0, peakELR: number = 0): ShiftResult {
+  return runTEWaitShift(state, context, 'humility', targetTEForEgg, peakELR);
+}

--- a/wasmegg/ascension-planner/src/auto/te-thresholds.ts
+++ b/wasmegg/ascension-planner/src/auto/te-thresholds.ts
@@ -1,0 +1,70 @@
+import { TE_BREAKPOINTS, countTEThresholdsPassed, getThresholdForTE } from '@/lib/truthEggs';
+
+/**
+ * Given a constant ELR, how many TE are earned in a given time?
+ */
+export function computeTEEarned(
+  currentEggsDelivered: number,
+  elrPerSecond: number,
+  durationSeconds: number,
+): { teEarned: number; finalEggsDelivered: number } {
+  const finalEggsDelivered = currentEggsDelivered + elrPerSecond * durationSeconds;
+  const startTE = countTEThresholdsPassed(currentEggsDelivered);
+  const endTE = countTEThresholdsPassed(finalEggsDelivered);
+  
+  return {
+    teEarned: endTE - startTE,
+    finalEggsDelivered,
+  };
+}
+
+/**
+ * How long to earn N more TE at a constant ELR?
+ */
+export function timeToEarnTE(
+  currentEggsDelivered: number,
+  elrPerSecond: number,
+  targetAdditionalTE: number,
+): number {
+  if (targetAdditionalTE <= 0) return 0;
+  if (elrPerSecond <= 0) return Infinity;
+
+  const currentTE = countTEThresholdsPassed(currentEggsDelivered);
+  const targetTE = currentTE + targetAdditionalTE;
+  
+  // If target exceeds max TE per egg
+  if (targetTE > TE_BREAKPOINTS.length) return Infinity;
+
+  const targetThreshold = getThresholdForTE(targetTE);
+  const needed = targetThreshold - currentEggsDelivered;
+  
+  // Add a tiny buffer (1ms) to ensure we cross the threshold despite floating point noise.
+  // This prevents rounding errors where computeTEEarned might report targetTE - 1
+  // because the final egg count was 3.4029999999999998e19 instead of 3.403e19.
+  return Math.max(0, needed / elrPerSecond + 0.001);
+}
+
+/**
+ * Given a variable ELR (changes at specific timestamps), track TE earned.
+ */
+export function computeTEEarnedVariableRate(
+  currentEggsDelivered: number,
+  elrSegments: { startTime: number; endTime: number; elrPerSecond: number }[],
+): { teEarned: number; finalEggsDelivered: number } {
+  let eggsDelivered = currentEggsDelivered;
+  const startTE = countTEThresholdsPassed(currentEggsDelivered);
+
+  for (const segment of elrSegments) {
+    const duration = segment.endTime - segment.startTime;
+    if (duration > 0) {
+      eggsDelivered += segment.elrPerSecond * duration;
+    }
+  }
+
+  const endTE = countTEThresholdsPassed(eggsDelivered);
+  
+  return {
+    teEarned: endTE - startTE,
+    finalEggsDelivered: eggsDelivered,
+  };
+}

--- a/wasmegg/ascension-planner/src/auto/types.ts
+++ b/wasmegg/ascension-planner/src/auto/types.ts
@@ -1,0 +1,65 @@
+import type { Action } from '@/types/actions/meta';
+import type { EngineState, SimulationContext } from '@/engine/types';
+export type { EngineState, SimulationContext };
+import type { VirtueEgg } from '@/types/actions/virtue';
+
+export interface AscensionSummary {
+  id: string;
+  
+  // Timing
+  startTime: number;                      // Unix timestamp (seconds)
+  endTime: number;                        // Unix timestamp (seconds)
+  totalDurationSeconds: number;
+  
+  // Build phase info
+  buildPhaseEndTime: number;              // When build phase ended (sale boundary)
+  buildPhaseSaleCount: 1 | 2;             // Which sale boundary was used
+  
+  // Key metrics at END of ascension
+  startTE: number;
+  endTE: number;
+  teGained: number;
+  maxELR: number;                         // Peak ELR after K3 purchases (eggs/second)
+  
+  // SE tracking
+  startSoulEggs: number;
+  endSoulEggs: number;                    // After 12 shifts deducted (may be negative)
+  startShiftCount: number;
+  endShiftCount: number;                  // startShiftCount + 12
+  totalShiftCost: number;                 // Sum of 12 shift costs
+  
+  // Per-egg summary
+  eggsDelivered: Record<VirtueEgg, number>;
+  teEarned: Record<VirtueEgg, number>;    // Gained during this ascension
+  finalTE: Record<VirtueEgg, number>;     // Total after ascension
+  
+  // Strategy label for display
+  strategyLabel: string;                  // e.g., "1-sale build, 20 TE"
+  
+  // Max ELR milestone flag
+  isMaxELRAscension: boolean;             // True if this is the ~300 TE collapse
+}
+
+export interface AutoPlanGoal {
+  targetTE: number;
+}
+
+export interface AutoPlanInput {
+  backup: any;
+  goal: AutoPlanGoal;
+  startTime: number;
+  timezone?: string;
+}
+
+export interface ShiftResult {
+  actions: Action[];
+  elapsedSeconds: number;
+  endState: EngineState;
+}
+
+export interface BuildPhaseResult {
+  actions: Action[];
+  durationSeconds: number;
+  endState: EngineState;
+  maxELR: number;
+}

--- a/wasmegg/ascension-planner/src/auto/useAscensionGenerator.ts
+++ b/wasmegg/ascension-planner/src/auto/useAscensionGenerator.ts
@@ -537,6 +537,34 @@ export function useAscensionGenerator() {
     }
   };
 
+  const savingIndex = ref<number | null>(null);
+  const savedIndex = ref<number | null>(null);
+
+  const saveSingleAscensionToLibrary = async (idx: number) => {
+    if (!partitionHash.value) return;
+    savingIndex.value = idx;
+    try {
+      const plan = buildExportedPlan();
+      const datePrefix = new Date().toISOString().split('T')[0];
+      const plansToSave = buildLibraryPlansFromExport(plan, datePrefix);
+      const p = plansToSave[idx];
+      if (!p) return;
+      const entry: PlanData = {
+        id: crypto.randomUUID(),
+        name: p.name,
+        timestamp: Date.now(),
+        data: p.data,
+      };
+      await savePlanToLibrary(partitionHash.value, entry);
+      actionsStore.libraryUpdateTick++;
+      broadcastLibraryUpdate();
+      savedIndex.value = idx;
+      setTimeout(() => { if (savedIndex.value === idx) savedIndex.value = null; }, 2000);
+    } finally {
+      savingIndex.value = null;
+    }
+  };
+
   const copySummary = async () => {
     if (ascensionChain.value.length === 0) return;
 
@@ -600,6 +628,9 @@ export function useAscensionGenerator() {
     copySummary,
     exportCurrentPlan,
     saveToLibrary,
+    savingIndex,
+    savedIndex,
+    saveSingleAscensionToLibrary,
     handleSetPlanVariant,
   };
 }

--- a/wasmegg/ascension-planner/src/auto/useAscensionGenerator.ts
+++ b/wasmegg/ascension-planner/src/auto/useAscensionGenerator.ts
@@ -19,6 +19,7 @@ import { usePersistence } from '@/composables/usePersistence';
 import type { AscensionSummary } from '@/auto/types';
 import type { Action } from '@/types/actions/meta';
 import type { VirtueEgg } from '@/types';
+import type { ChainedAscension, PlanVariant } from '@/stores/autoPlanner';
 
 
 const VIRTUE_EGGS_MAP: Record<number, VirtueEgg> = {
@@ -28,6 +29,20 @@ const VIRTUE_EGGS_MAP: Record<number, VirtueEgg> = {
   53: 'resilience',
   54: 'kindness',
 };
+
+function pickVariantSummary(
+  item: ChainedAscension,
+  overrides: Record<number, PlanVariant>,
+): AscensionSummary {
+  const override = overrides[item.index];
+  if (override === 'continue' && item.result3) return item.result3.summary;
+  if (override === '1-sale') return item.result1.summary;
+  if (override === '2-sale') return item.result2.summary;
+  const candidates = [item.result1, item.result2, ...(item.result3 ? [item.result3] : [])];
+  return candidates.reduce((a, b) =>
+    a.summary.totalDurationSeconds <= b.summary.totalDurationSeconds ? a : b,
+  ).summary;
+}
 
 export function useAscensionGenerator() {
   const isGenerating = ref(false);
@@ -97,13 +112,14 @@ export function useAscensionGenerator() {
         candidates.push({ result: item.result3, label: item.result3.summary.strategyLabel });
       }
 
+      const override = autoPlannerStore.planVariantOverrides[item.index];
       let bestIdx = 0;
-      if (item.index === 0 && autoPlannerStore.a1ForceMode) {
-        if (autoPlannerStore.a1ForceMode === 'continue' && item.result3) {
-          bestIdx = candidates.length - 1;
-        } else {
-          bestIdx = item.result1.summary.totalDurationSeconds <= item.result2.summary.totalDurationSeconds ? 0 : 1;
-        }
+      if (override === 'continue' && item.result3) {
+        bestIdx = candidates.length - 1;
+      } else if (override === '1-sale') {
+        bestIdx = 0;
+      } else if (override === '2-sale') {
+        bestIdx = 1;
       } else {
         for (let i = 1; i < candidates.length; i++) {
           if (candidates[i].result.summary.totalDurationSeconds < candidates[bestIdx].result.summary.totalDurationSeconds) {
@@ -124,14 +140,6 @@ export function useAscensionGenerator() {
         .filter(c => c.daysFaster > 0.01)
         .sort((a, b) => b.daysFaster - a.daysFaster);
 
-      if (item.result3SkippedReason === 'startTimeTooFar') {
-        comparisons.push({
-          message: 'Select a time within 1 hour of the current time if you want to continue your ascension',
-          otherPlanLabel: '',
-          daysFaster: 0,
-        });
-      }
-
       const alternativeELRs = candidates
         .filter((_, i) => i !== bestIdx)
         .map(other => ({
@@ -151,6 +159,7 @@ export function useAscensionGenerator() {
         },
         targetTE: item.goal.te,
         result3Available: !!item.result3,
+        result3SkippedReason: item.result3SkippedReason,
       };
     });
   });
@@ -243,9 +252,11 @@ export function useAscensionGenerator() {
         firstDiffIdx = matchCount;
       }
 
-      // Force mode changes A1's effective end time, so A2+ must be recomputed
-      if (firstDiffIdx >= 1 && autoPlannerStore.a1ForceMode && ascensionChain.value.length > 1) {
-        firstDiffIdx = 1;
+      // A variant override changes the effective end time of that ascension, so all later ones must be recomputed.
+      for (const k of Object.keys(autoPlannerStore.planVariantOverrides).map(Number)) {
+        if (firstDiffIdx > k + 1 && ascensionChain.value.length > k + 1) {
+          firstDiffIdx = k + 1;
+        }
       }
 
       let currentBaseState: any;
@@ -259,14 +270,7 @@ export function useAscensionGenerator() {
           newChain.push(ascensionChain.value[i]);
         }
         const lastValid = newChain[firstDiffIdx - 1];
-        const naturalBestSummary =
-          lastValid.result1.summary.totalDurationSeconds <= lastValid.result2.summary.totalDurationSeconds
-            ? lastValid.result1.summary
-            : lastValid.result2.summary;
-        const lastValidSummary =
-          lastValid.index === 0 && autoPlannerStore.a1ForceMode === 'continue' && lastValid.result3
-            ? lastValid.result3.summary
-            : naturalBestSummary;
+        const lastValidSummary = pickVariantSummary(lastValid, autoPlannerStore.planVariantOverrides);
 
         const baseBackupState = createBaseEngineState(null);
         currentBaseState = deriveNextStartState(lastValidSummary, baseBackupState);
@@ -403,13 +407,14 @@ export function useAscensionGenerator() {
         }
 
         const candidates = [result1, result2, ...(result3 ? [result3] : [])];
+        const variantOverride = autoPlannerStore.planVariantOverrides[i];
         let best;
-        if (i === 0 && autoPlannerStore.a1ForceMode) {
-          if (autoPlannerStore.a1ForceMode === 'continue' && result3) {
-            best = result3;
-          } else {
-            best = result1.summary.totalDurationSeconds <= result2.summary.totalDurationSeconds ? result1 : result2;
-          }
+        if (variantOverride === 'continue' && result3) {
+          best = result3;
+        } else if (variantOverride === '1-sale') {
+          best = result1;
+        } else if (variantOverride === '2-sale') {
+          best = result2;
         } else {
           best = candidates.reduce((a, b) => (a.summary.totalDurationSeconds <= b.summary.totalDurationSeconds ? a : b));
         }
@@ -464,7 +469,7 @@ export function useAscensionGenerator() {
     exportedAt: new Date().toISOString(),
     startTime: getLocalTimestampInTimezone(startDate.value, startTime.value, timezone.value),
     timezone: timezone.value,
-    a1ForceMode: autoPlannerStore.a1ForceMode,
+    planVariantOverrides: { ...autoPlannerStore.planVariantOverrides },
     initialState: {
       epicResearchLevels: { ...initialStateStore.epicResearchLevels },
       colleggtibleTiers: { ...initialStateStore.colleggtibleTiers },
@@ -539,10 +544,9 @@ export function useAscensionGenerator() {
       ? Object.values(ascensionChain.value[0].initialParams.teEarned).reduce((a: number, b: any) => a + b, 0)
       : currentTE.value;
 
-    const bestPlans = ascensionChain.value.filter(item => !item.forcedTarget490).map(item => {
-      const candidates = [item.result1, item.result2, ...(item.result3 ? [item.result3] : [])];
-      return candidates.reduce((a, b) => (a.summary.totalDurationSeconds <= b.summary.totalDurationSeconds ? a : b)).summary;
-    });
+    const bestPlans = ascensionChain.value
+      .filter(item => !item.forcedTarget490)
+      .map(item => pickVariantSummary(item, autoPlannerStore.planVariantOverrides));
 
     const finalTE = bestPlans[bestPlans.length - 1].endTE;
     let totalSeconds = 0;
@@ -572,8 +576,11 @@ export function useAscensionGenerator() {
     }
   };
 
-  const handleToggleForceMode = (mode: 'continue' | 'prestige') => {
-    autoPlannerStore.a1ForceMode = mode;
+  const handleSetPlanVariant = (idx: number, variant: 'continue' | '1-sale' | '2-sale') => {
+    autoPlannerStore.planVariantOverrides = {
+      ...autoPlannerStore.planVariantOverrides,
+      [idx]: variant,
+    };
     generate();
   };
 
@@ -593,6 +600,6 @@ export function useAscensionGenerator() {
     copySummary,
     exportCurrentPlan,
     saveToLibrary,
-    handleToggleForceMode,
+    handleSetPlanVariant,
   };
 }

--- a/wasmegg/ascension-planner/src/auto/useAscensionGenerator.ts
+++ b/wasmegg/ascension-planner/src/auto/useAscensionGenerator.ts
@@ -1,0 +1,598 @@
+import { ref, computed, nextTick } from 'vue';
+import { storeToRefs } from 'pinia';
+import { useInitialStateStore } from '@/stores/initialState';
+import { useActionsStore } from '@/stores/actions';
+import { useTruthEggsStore } from '@/stores/truthEggs';
+import { useAutoPlannerStore } from '@/stores/autoPlanner';
+import { formatNumber } from '@/lib/format';
+import { getSimulationContext, createBaseEngineState } from '@/engine/adapter';
+import { computeSnapshot } from '@/engine/compute';
+import { getLocalTimestampInTimezone } from '@/lib/events';
+import { runAscension, runUntilShift, deriveNextStartState, runContinueCurrent } from '@/auto/ascension';
+import { getNextSaleEnd } from '@/auto/calendar';
+import { rollUpPendingTE } from '@/lib/modes';
+import { getArtifactLoadoutFromBackup, getOptimalEarningsSet } from '@/lib/artifacts';
+import { triggerPlanExport, type ExportedPlan } from '@/auto/export';
+import { buildLibraryPlansFromExport } from '@/auto/buildLibraryPlans';
+import { savePlanToLibrary, type PlanData } from '@/lib/storage/db';
+import { usePersistence } from '@/composables/usePersistence';
+import type { AscensionSummary } from '@/auto/types';
+import type { Action } from '@/types/actions/meta';
+import type { VirtueEgg } from '@/types';
+
+
+const VIRTUE_EGGS_MAP: Record<number, VirtueEgg> = {
+  50: 'curiosity',
+  51: 'integrity',
+  52: 'humility',
+  53: 'resilience',
+  54: 'kindness',
+};
+
+export function useAscensionGenerator() {
+  const isGenerating = ref(false);
+  const generateProgress = ref('');
+  const simulationError = ref<string | null>(null);
+  const isValidationErrorOpen = ref(false);
+  const validationErrorMessage = ref('');
+  const copySuccess = ref(false);
+
+  const autoPlannerStore = useAutoPlannerStore();
+  const truthEggsStore = useTruthEggsStore();
+  const initialStateStore = useInitialStateStore();
+  const actionsStore = useActionsStore();
+
+  const { ascensionChain, targetTE, timezone, startDate, startTime } = storeToRefs(autoPlannerStore);
+
+  const getTargets = () => {
+    if (!targetTE.value) return [];
+    return targetTE.value
+      .trim()
+      .split(/\s+/)
+      .map(Number)
+      .filter(n => !isNaN(n) && n > 0);
+  };
+
+  const currentTE = computed(() => {
+    const snapshot = actionsStore.effectiveSnapshot;
+    if (!snapshot?.teEarned) return 0;
+    return Object.values(snapshot.teEarned).reduce((a, b) => a + b, 0);
+  });
+
+  const isA1Dirty = computed(() => {
+    if (ascensionChain.value.length === 0) return true;
+    const last = ascensionChain.value[0];
+    if (!last.initialParams) return true;
+
+    const initialParamsDirty =
+      startDate.value !== last.initialParams.startDate ||
+      startTime.value !== last.initialParams.startTime ||
+      JSON.stringify(truthEggsStore.teEarned) !== JSON.stringify(last.initialParams.teEarned);
+
+    if (initialParamsDirty) return true;
+
+    const targets = getTargets();
+    // The chain may have a silent forced-490 item appended; exclude it from the length comparison.
+    const hasForced490 =
+      ascensionChain.value.length > 0 &&
+      !!ascensionChain.value[ascensionChain.value.length - 1].forcedTarget490;
+    const visibleChainLength = ascensionChain.value.length - (hasForced490 ? 1 : 0);
+
+    if (targets.length !== visibleChainLength) return true;
+
+    for (let i = 0; i < targets.length; i++) {
+      if (targets[i] !== ascensionChain.value[i].goal.te) return true;
+    }
+
+    return false;
+  });
+
+  const bestResults = computed(() => {
+    return ascensionChain.value.map(item => {
+      const candidates = [
+        { result: item.result1, label: item.result1.summary.strategyLabel },
+        { result: item.result2, label: item.result2.summary.strategyLabel },
+      ];
+      if (item.result3) {
+        candidates.push({ result: item.result3, label: item.result3.summary.strategyLabel });
+      }
+
+      let bestIdx = 0;
+      if (item.index === 0 && autoPlannerStore.a1ForceMode) {
+        if (autoPlannerStore.a1ForceMode === 'continue' && item.result3) {
+          bestIdx = candidates.length - 1;
+        } else {
+          bestIdx = item.result1.summary.totalDurationSeconds <= item.result2.summary.totalDurationSeconds ? 0 : 1;
+        }
+      } else {
+        for (let i = 1; i < candidates.length; i++) {
+          if (candidates[i].result.summary.totalDurationSeconds < candidates[bestIdx].result.summary.totalDurationSeconds) {
+            bestIdx = i;
+          }
+        }
+      }
+
+      const best = candidates[bestIdx].result;
+      const bestDuration = best.summary.totalDurationSeconds;
+
+      const comparisons: { daysFaster: number; otherPlanLabel: string; message?: string }[] = candidates
+        .filter((_, i) => i !== bestIdx)
+        .map(other => ({
+          daysFaster: (other.result.summary.totalDurationSeconds - bestDuration) / 86400,
+          otherPlanLabel: `the ${other.label.replace(' build', '')} plan`,
+        }))
+        .filter(c => c.daysFaster > 0.01)
+        .sort((a, b) => b.daysFaster - a.daysFaster);
+
+      if (item.result3SkippedReason === 'startTimeTooFar') {
+        comparisons.push({
+          message: 'Select a time within 1 hour of the current time if you want to continue your ascension',
+          otherPlanLabel: '',
+          daysFaster: 0,
+        });
+      }
+
+      const alternativeELRs = candidates
+        .filter((_, i) => i !== bestIdx)
+        .map(other => ({
+          elr: other.result.summary.maxELR,
+          label: other.result.summary.strategyLabel
+            .replace(' build', '')
+            .replace('Continue current', 'Continue'),
+        }));
+
+      return {
+        ...best,
+        summary: {
+          ...best.summary,
+          comparisons,
+          comparison: comparisons[0] || undefined,
+          alternativeELRs,
+        },
+        targetTE: item.goal.te,
+        result3Available: !!item.result3,
+      };
+    });
+  });
+
+  const generate = async (onComplete?: () => void) => {
+    if (isGenerating.value) return;
+    isGenerating.value = true;
+    simulationError.value = null;
+    generateProgress.value = 'Initializing simulation...';
+
+    await new Promise(resolve => setTimeout(resolve, 30));
+
+    try {
+      const targets = getTargets();
+      if (targets.length === 0) {
+        throw new Error('Please specify at least one Target TE');
+      }
+
+      for (let i = 1; i < targets.length; i++) {
+        if (targets[i] <= targets[i - 1]) {
+          validationErrorMessage.value = `Target TE #${i + 1} (${targets[i]}) must be greater than the preceding Target TE (${targets[i - 1]})`;
+          isValidationErrorOpen.value = true;
+          throw new Error('validation_error');
+        }
+      }
+
+      // Silently append a 490-TE ascension when the user's final target isn't already 490.
+      const forced490 = targets[targets.length - 1] !== 490 && targets[targets.length - 1] < 490;
+      const effectiveTargets = forced490 ? [...targets, 490] : targets;
+
+      const teEarned = truthEggsStore.teEarned;
+      const currentTotal = Object.values(teEarned).reduce((a, b) => a + b, 0);
+
+      const startEgg = initialStateStore.currentFarmState
+        ? VIRTUE_EGGS_MAP[initialStateStore.currentFarmState.eggType] || 'curiosity'
+        : 'curiosity';
+
+      const otherEggsSum = Object.entries(teEarned).reduce(
+        (sum, [egg, val]) => sum + (egg !== startEgg ? (val as number) : 0),
+        0
+      );
+
+      if (targets[0] <= otherEggsSum) {
+        validationErrorMessage.value = `First Target TE (${targets[0]}) must be greater than the sum of TE from other eggs (${otherEggsSum}).`;
+        isValidationErrorOpen.value = true;
+        throw new Error('validation_error');
+      }
+
+      if (targets[0] <= currentTotal) {
+        validationErrorMessage.value = `First Target TE (${targets[0]}) must be greater than your current total TE (${currentTotal}). It is not possible to generate a plan gaining 0 or negative TE.`;
+        isValidationErrorOpen.value = true;
+        throw new Error('validation_error');
+      }
+
+      rollUpPendingTE();
+
+      const context = getSimulationContext();
+      const baseState = createBaseEngineState(null);
+      const initialSnapshot = computeSnapshot(baseState, context);
+      // Pass silent:true so this snapshot update doesn't trigger the manual-mode
+      // RecalculationOverlay — the auto planner uses its own progress indicator.
+      actionsStore.setInitialSnapshot(initialSnapshot, { silent: true });
+
+      const absStartTime = getLocalTimestampInTimezone(startDate.value, startTime.value, timezone.value);
+
+      const initialParamsToSave = {
+        startDate: startDate.value,
+        startTime: startTime.value,
+        teEarned: { ...truthEggsStore.teEarned },
+      };
+
+      const lastA1 = ascensionChain.value[0];
+      const initialParamsDirty =
+        !lastA1 ||
+        !lastA1.initialParams ||
+        startDate.value !== lastA1.initialParams.startDate ||
+        startTime.value !== lastA1.initialParams.startTime ||
+        JSON.stringify(truthEggsStore.teEarned) !== JSON.stringify(lastA1.initialParams.teEarned);
+
+      let firstDiffIdx = 0;
+      if (!initialParamsDirty) {
+        let matchCount = 0;
+        for (let i = 0; i < effectiveTargets.length; i++) {
+          if (i < ascensionChain.value.length && effectiveTargets[i] === ascensionChain.value[i].goal.te) {
+            matchCount++;
+          } else {
+            break;
+          }
+        }
+        firstDiffIdx = matchCount;
+      }
+
+      // Force mode changes A1's effective end time, so A2+ must be recomputed
+      if (firstDiffIdx >= 1 && autoPlannerStore.a1ForceMode && ascensionChain.value.length > 1) {
+        firstDiffIdx = 1;
+      }
+
+      let currentBaseState: any;
+      let currentStartTime: number;
+      let currentSummary: AscensionSummary | null = null;
+      const newChain: any[] = [];
+      const loops = effectiveTargets.length;
+
+      if (firstDiffIdx > 0) {
+        for (let i = 0; i < firstDiffIdx; i++) {
+          newChain.push(ascensionChain.value[i]);
+        }
+        const lastValid = newChain[firstDiffIdx - 1];
+        const naturalBestSummary =
+          lastValid.result1.summary.totalDurationSeconds <= lastValid.result2.summary.totalDurationSeconds
+            ? lastValid.result1.summary
+            : lastValid.result2.summary;
+        const lastValidSummary =
+          lastValid.index === 0 && autoPlannerStore.a1ForceMode === 'continue' && lastValid.result3
+            ? lastValid.result3.summary
+            : naturalBestSummary;
+
+        const baseBackupState = createBaseEngineState(null);
+        currentBaseState = deriveNextStartState(lastValidSummary, baseBackupState);
+        currentStartTime = lastValidSummary.endTime;
+        currentSummary = lastValidSummary;
+
+        if (firstDiffIdx < loops && effectiveTargets[firstDiffIdx] <= currentSummary!.endTE) {
+          throw new Error(
+            `Target TE (${effectiveTargets[firstDiffIdx]}) for A${firstDiffIdx + 1} must be greater than A${firstDiffIdx} end TE (${currentSummary!.endTE})`
+          );
+        }
+      } else {
+        baseState.currentEgg = 'curiosity';
+        baseState.population = 1;
+        baseState.bankValue = 0;
+        baseState.researchLevels = {};
+        currentBaseState = baseState;
+        currentStartTime = absStartTime;
+      }
+
+      for (let i = firstDiffIdx; i < loops; i++) {
+        const stepTargetTE: number | undefined = effectiveTargets[i] || undefined;
+        const stepEndTime: number | undefined = undefined;
+        const t_asc = performance.now();
+
+        const buildPhaseEnd1 = getNextSaleEnd(currentStartTime);
+        const buildPhaseEnd2 = getNextSaleEnd(buildPhaseEnd1 + 1);
+
+        const currentContext = getSimulationContext();
+        currentContext.ascensionStartTime = currentStartTime;
+        currentContext.planStartOffset = 0;
+
+        generateProgress.value = `Simulating A${i + 1} of ${loops} (1-sale Build)...`;
+        await new Promise(resolve => setTimeout(resolve, 15));
+
+        const precomputed = runUntilShift(currentBaseState, currentContext, 'C3');
+        const resumeData1 = {
+          actions: precomputed.actions,
+          state: precomputed.state,
+          elapsedSeconds: precomputed.elapsedSeconds,
+          resumeShiftName: 'C3' as const,
+        };
+
+        const result1 = runAscension(
+          currentBaseState, currentContext, buildPhaseEnd1, currentStartTime,
+          `asc_${i}`, stepTargetTE, stepEndTime, resumeData1
+        );
+
+        generateProgress.value = `Simulating A${i + 1} of ${loops} (2-sale Build)...`;
+        await new Promise(resolve => setTimeout(resolve, 15));
+
+        const baseState2 = JSON.parse(JSON.stringify(currentBaseState));
+        const context2 = getSimulationContext();
+        context2.ascensionStartTime = currentStartTime;
+        context2.planStartOffset = 0;
+        // Share the ELR memo from the 1-sale run — same inventory + epic research means
+        // all cached states are valid for the 2-sale run.
+        if (currentContext.elrMemo) context2.elrMemo = currentContext.elrMemo;
+
+        const resumeData2 = {
+          actions: JSON.parse(JSON.stringify(precomputed.actions)),
+          state: JSON.parse(JSON.stringify(precomputed.state)),
+          elapsedSeconds: precomputed.elapsedSeconds,
+          resumeShiftName: 'C3' as const,
+        };
+
+        const result2 = runAscension(
+          baseState2, context2, buildPhaseEnd2, currentStartTime,
+          `asc_${i}`, stepTargetTE, stepEndTime, resumeData2
+        );
+
+        let result3: { summary: AscensionSummary; actions: Action[] } | undefined;
+        let result3SkippedReason: string | null = null;
+
+        if (i === 0 && stepTargetTE && initialStateStore.currentFarmState) {
+          const nowSecs = Date.now() / 1000;
+          if (absStartTime > nowSecs + 3600) {
+            result3SkippedReason = 'startTimeTooFar';
+          } else {
+            generateProgress.value = `Simulating A${i + 1} of ${loops} (Continue Current)...`;
+            await new Promise(resolve => setTimeout(resolve, 15));
+
+            const farmState = initialStateStore.currentFarmState;
+            const rawLoadout = initialStateStore.rawBackup
+              ? getArtifactLoadoutFromBackup(initialStateStore.rawBackup)
+              : currentBaseState.artifactLoadout;
+
+            const optimalEarnings = initialStateStore.rawBackup
+              ? getOptimalEarningsSet(initialStateStore.rawBackup)
+              : currentBaseState.artifactSets.earnings || null;
+
+            const continueState: import('@/engine/types').EngineState = {
+              currentEgg: (VIRTUE_EGGS_MAP[farmState.eggType] || 'curiosity') as VirtueEgg,
+              shiftCount: currentBaseState.shiftCount,
+              te: currentBaseState.te,
+              soulEggs: currentBaseState.soulEggs,
+              vehicles: farmState.vehicles || [{ vehicleId: 0, trainLength: 1 }],
+              habIds: farmState.habs || [0, null, null, null],
+              researchLevels: { ...farmState.commonResearches },
+              siloCount: farmState.numSilos || 1,
+              tankLevel: currentBaseState.tankLevel,
+              artifactLoadout: rawLoadout.map((slot: any) => ({
+                artifactId: slot.artifactId,
+                stones: [...slot.stones],
+              })),
+              activeArtifactSet: 'elr',
+              artifactSets: {
+                earnings: optimalEarnings ? JSON.parse(JSON.stringify(optimalEarnings)) : null,
+                elr: JSON.parse(JSON.stringify(rawLoadout)),
+              },
+              fuelTankAmounts: { ...currentBaseState.fuelTankAmounts },
+              eggsDelivered: { ...currentBaseState.eggsDelivered },
+              teEarned: { ...currentBaseState.teEarned },
+              population: farmState.population || 0,
+              lastStepTime: farmState.lastStepTime || 0,
+              bankValue: farmState.cash || 0,
+              activeSales: { research: false, hab: false, vehicle: false },
+              earningsBoost: { active: false, multiplier: 1 },
+            };
+
+            const continueContext = getSimulationContext();
+            continueContext.ascensionStartTime = currentStartTime;
+            continueContext.planStartOffset = 0;
+            const continueSnapshot = computeSnapshot(continueState, continueContext, { skipGrowth: true });
+            const realELR = continueSnapshot.elr;
+
+            if (realELR > 0) {
+              result3 = runContinueCurrent(
+                continueState, continueContext, currentStartTime,
+                realELR, stepTargetTE, `asc_${i}_continue`
+              );
+            }
+          }
+        }
+
+        const candidates = [result1, result2, ...(result3 ? [result3] : [])];
+        let best;
+        if (i === 0 && autoPlannerStore.a1ForceMode) {
+          if (autoPlannerStore.a1ForceMode === 'continue' && result3) {
+            best = result3;
+          } else {
+            best = result1.summary.totalDurationSeconds <= result2.summary.totalDurationSeconds ? result1 : result2;
+          }
+        } else {
+          best = candidates.reduce((a, b) => (a.summary.totalDurationSeconds <= b.summary.totalDurationSeconds ? a : b));
+        }
+
+        const goalToSave = { type: 'te' as const, te: stepTargetTE || null, date: '', time: '' };
+        const chainItem: any = { index: i, result1, result2, goal: goalToSave };
+        if (result3) chainItem.result3 = result3;
+        if (result3SkippedReason) chainItem.result3SkippedReason = result3SkippedReason;
+        if (i === 0) chainItem.initialParams = initialParamsToSave;
+        // Tag the last item when it was silently added to cover the 490-TE milestone.
+        if (forced490 && i === loops - 1) chainItem.forcedTarget490 = true;
+        newChain.push(chainItem);
+
+        currentSummary = best.summary;
+
+        if (i < loops - 1) {
+          const baseBackupState = createBaseEngineState(null);
+          currentBaseState = deriveNextStartState(currentSummary, baseBackupState);
+          currentStartTime = currentSummary.endTime;
+
+          if (effectiveTargets[i + 1] <= currentSummary.endTE) {
+            throw new Error(
+              `Target TE (${effectiveTargets[i + 1]}) for A${i + 2} must be greater than A${i + 1} end TE (${currentSummary.endTE})`
+            );
+          }
+        }
+
+        console.log(`[A${i+1} total time] ${(performance.now()-t_asc).toFixed(1)}ms`);
+      }
+
+      if (newChain.length > 0) {
+        targetTE.value = targets.join(' ');
+      }
+
+      ascensionChain.value = newChain;
+    } catch (err: any) {
+      if (err.message !== 'validation_error') {
+        console.error('Simulation error:', err);
+        simulationError.value = err.message || 'An unknown error occurred during simulation.';
+      }
+    } finally {
+      isGenerating.value = false;
+      generateProgress.value = '';
+      onComplete?.();
+    }
+  };
+
+  const { partitionHash, broadcastLibraryUpdate } = usePersistence();
+
+  const buildExportedPlan = (): ExportedPlan => ({
+    version: 1,
+    exportedAt: new Date().toISOString(),
+    startTime: getLocalTimestampInTimezone(startDate.value, startTime.value, timezone.value),
+    timezone: timezone.value,
+    a1ForceMode: autoPlannerStore.a1ForceMode,
+    initialState: {
+      epicResearchLevels: { ...initialStateStore.epicResearchLevels },
+      colleggtibleTiers: { ...initialStateStore.colleggtibleTiers },
+      artifactLoadout: JSON.parse(JSON.stringify(initialStateStore.artifactLoadout)),
+      soulEggs: initialStateStore.soulEggs,
+      isUltra: initialStateStore.isUltra,
+      initialTankLevel: initialStateStore.initialTankLevel,
+      initialFuelAmounts: { ...initialStateStore.initialFuelAmounts },
+      initialEggsDelivered: { ...initialStateStore.initialEggsDelivered },
+      initialTeEarned: { ...initialStateStore.initialTeEarned },
+    },
+    ascensions: ascensionChain.value.filter(item => !item.forcedTarget490).map((item, idx) => {
+      const asc: ExportedPlan['ascensions'][number] = {
+        index: idx,
+        targetTE: item.goal.te || item.result1.summary.endTE,
+        result1: item.result1,
+        result2: item.result2,
+        goal: item.goal,
+      };
+      if (item.result3) asc.result3 = item.result3;
+      return asc;
+    }),
+  });
+
+  const isExporting = ref(false);
+
+  const exportCurrentPlan = async () => {
+    if (ascensionChain.value.length === 0) return;
+    isExporting.value = true;
+    await nextTick();
+    await new Promise<void>(resolve => requestAnimationFrame(() => requestAnimationFrame(() => resolve())));
+    try {
+      triggerPlanExport(buildExportedPlan());
+    } finally {
+      isExporting.value = false;
+    }
+  };
+
+  const isSavingToLibrary = ref(false);
+  const saveToLibrarySuccess = ref(false);
+
+  const saveToLibrary = async () => {
+    if (ascensionChain.value.length === 0 || !partitionHash.value) return;
+    isSavingToLibrary.value = true;
+    try {
+      const plan = buildExportedPlan();
+      const datePrefix = new Date().toISOString().split('T')[0];
+      const plansToSave = buildLibraryPlansFromExport(plan, datePrefix);
+      for (const p of plansToSave) {
+        const entry: PlanData = {
+          id: crypto.randomUUID(),
+          name: p.name,
+          timestamp: Date.now(),
+          data: p.data,
+        };
+        await savePlanToLibrary(partitionHash.value, entry);
+      }
+      // Increment tick directly so this tab refreshes too (BroadcastChannel skips the sender)
+      actionsStore.libraryUpdateTick++;
+      broadcastLibraryUpdate();
+      saveToLibrarySuccess.value = true;
+      setTimeout(() => { saveToLibrarySuccess.value = false; }, 2000);
+    } finally {
+      isSavingToLibrary.value = false;
+    }
+  };
+
+  const copySummary = async () => {
+    if (ascensionChain.value.length === 0) return;
+
+    const startTE = ascensionChain.value[0].initialParams?.teEarned
+      ? Object.values(ascensionChain.value[0].initialParams.teEarned).reduce((a: number, b: any) => a + b, 0)
+      : currentTE.value;
+
+    const bestPlans = ascensionChain.value.filter(item => !item.forcedTarget490).map(item => {
+      const candidates = [item.result1, item.result2, ...(item.result3 ? [item.result3] : [])];
+      return candidates.reduce((a, b) => (a.summary.totalDurationSeconds <= b.summary.totalDurationSeconds ? a : b)).summary;
+    });
+
+    const finalTE = bestPlans[bestPlans.length - 1].endTE;
+    let totalSeconds = 0;
+    let totalSE = 0;
+    const lines = [`Ascension Plan - Starting TE: ${startTE}`];
+
+    bestPlans.forEach((plan, idx) => {
+      const ascStartTE = idx === 0 ? startTE : bestPlans[idx - 1].endTE;
+      const saleStr = plan.strategyLabel.replace(' build', '');
+      const durationDays = Math.floor(plan.totalDurationSeconds / 86400);
+      const durationHours = Math.floor((plan.totalDurationSeconds % 86400) / 3600);
+      lines.push(
+        `  A${idx + 1}: ${ascStartTE} → ${plan.endTE} TE (${saleStr}, ${durationDays}d ${durationHours}h, ${formatNumber(plan.maxELR * 3600, 3)}/hr)`
+      );
+      totalSeconds += plan.totalDurationSeconds;
+      totalSE += plan.startSoulEggs - plan.endSoulEggs;
+    });
+
+    lines.push(`Total: ${startTE} → ${finalTE} TE in ~${(totalSeconds / 86400).toFixed(1)} days, ${formatNumber(totalSE)} SE consumed`);
+
+    try {
+      await navigator.clipboard.writeText(lines.join('\n'));
+      copySuccess.value = true;
+      setTimeout(() => { copySuccess.value = false; }, 2000);
+    } catch (err) {
+      console.error('Failed to copy text: ', err);
+    }
+  };
+
+  const handleToggleForceMode = (mode: 'continue' | 'prestige') => {
+    autoPlannerStore.a1ForceMode = mode;
+    generate();
+  };
+
+  return {
+    isGenerating,
+    isExporting,
+    isSavingToLibrary,
+    saveToLibrarySuccess,
+    generateProgress,
+    simulationError,
+    isValidationErrorOpen,
+    validationErrorMessage,
+    copySuccess,
+    isA1Dirty,
+    bestResults,
+    generate,
+    copySummary,
+    exportCurrentPlan,
+    saveToLibrary,
+    handleToggleForceMode,
+  };
+}

--- a/wasmegg/ascension-planner/src/calculations/realisticELR.ts
+++ b/wasmegg/ascension-planner/src/calculations/realisticELR.ts
@@ -1,0 +1,56 @@
+import { calculateHabCapacity_Full } from './habCapacity';
+import { calculateLayRate } from './layRate';
+import { calculateMaxVehicleSlots, calculateMaxTrainLength, calculateShippingCapacity } from './shippingCapacity';
+import { calculateArtifactModifiers } from '@/lib/artifacts';
+import type { ColleggtibleModifiers } from '@/lib/colleggtibles';
+
+/**
+ * Compute ELR using the full pipeline with given research levels, artifact mods, max habs/vehicles.
+ * This is a "realistic" calculation because it assumes optimal deployment (4x CU, max vehicles).
+ */
+export function computeRealisticELR(
+  researchLevels: Record<string, number>,
+  artifactMods: ReturnType<typeof calculateArtifactModifiers>,
+  epicResearchLevels: Record<string, number>,
+  colleggtibleModifiers: ColleggtibleModifiers,
+): { layRate: number; shippingRate: number; effectiveRate: number } {
+  const habCapOutput = calculateHabCapacity_Full({
+    habIds: [18, 18, 18, 18] as (number | null)[],
+    researchLevels,
+    peggMultiplier: colleggtibleModifiers.habCap,
+    artifactMultiplier: artifactMods.habCapacity.totalMultiplier,
+    artifactEffects: artifactMods.habCapacity.effects,
+  });
+  const population = habCapOutput.totalFinalCapacity;
+
+  const layRateOutput = calculateLayRate({
+    researchLevels,
+    epicComfyNestsLevel: epicResearchLevels['epic_egg_laying'] || 0,
+    siliconMultiplier: colleggtibleModifiers.elr,
+    population,
+    artifactMultiplier: artifactMods.eggLayingRate.totalMultiplier,
+    artifactEffects: artifactMods.eggLayingRate.effects,
+  });
+
+  const totalSlots = calculateMaxVehicleSlots(researchLevels);
+  const maxTrainLen = calculateMaxTrainLength(researchLevels);
+  const vehicles = Array(totalSlots).fill(null).map(() => ({ vehicleId: 11, trainLength: maxTrainLen }));
+
+  const shippingOutput = calculateShippingCapacity({
+    vehicles,
+    researchLevels,
+    transportationLobbyistLevel: epicResearchLevels['transportation_lobbyist'] || 0,
+    colleggtibleMultiplier: colleggtibleModifiers.shippingCap,
+    artifactMultiplier: artifactMods.shippingRate.totalMultiplier,
+    artifactEffects: artifactMods.shippingRate.effects,
+  });
+
+  const layRate = layRateOutput.totalRatePerSecond;
+  const shippingRate = shippingOutput.totalFinalCapacity;
+
+  return {
+    layRate,
+    shippingRate,
+    effectiveRate: Math.min(layRate, shippingRate),
+  };
+}

--- a/wasmegg/ascension-planner/src/calculations/researchROI.ts
+++ b/wasmegg/ascension-planner/src/calculations/researchROI.ts
@@ -1,0 +1,105 @@
+import type { CommonResearch } from './commonResearch';
+import type { CalculationsSnapshot } from '@/types';
+import type { SimulationContext } from '@/engine/types';
+import { createBaseEngineState } from '@/engine/adapter';
+import { applyAction, getTimeToSave, calculateEarningsForTime } from '@/engine/apply';
+import { computeSnapshot } from '@/engine/compute';
+import { createSimAction } from '@/types/actions/meta';
+
+export interface ROICalculationInput {
+  research: CommonResearch;
+  level: number;
+  price: number;
+  snapshot: CalculationsSnapshot;
+  context: SimulationContext;
+  eventTiming: {
+    absoluteSimTime: number;
+    nextSaleStart: number;
+    eventExpirationSeconds: number;
+    researchSaleDeadline: number;
+    isSaleActive: boolean;
+  };
+}
+
+export interface ROICalculationResult {
+  roiSeconds: number;
+  totalRoiSeconds: number;
+  earningsDelta: number;
+  showSaleWarning: boolean;
+  showDeadlineWarning: boolean;
+  timeToBuySeconds: number;
+  nextSnapshot: CalculationsSnapshot;
+}
+
+/**
+ * Calculate the Return on Investment (ROI) for a specific research purchase.
+ * This predicts how long it will take for the research to pay for itself
+ * in terms of increased earnings.
+ */
+export function calculateResearchROI(input: ROICalculationInput): ROICalculationResult {
+  const { research, level, price, snapshot, context, eventTiming } = input;
+  const { absoluteSimTime, nextSaleStart, eventExpirationSeconds, researchSaleDeadline, isSaleActive } = eventTiming;
+
+  const timeToBuySeconds = getTimeToSave(price, snapshot);
+  const baseState = createBaseEngineState(snapshot);
+
+  const tempAction = createSimAction('buy_research', {
+    researchId: research.id,
+    fromLevel: level,
+    toLevel: level + 1,
+  }, price);
+
+  // Project the farm state forward to the actual time of purchase to get accurate ROI 
+  // predictions based on expected population growth while saving.
+  const stateAtBuy = timeToBuySeconds > 0 && isFinite(timeToBuySeconds)
+    ? applyAction(baseState, createSimAction('wait_for_time', { totalTimeSeconds: timeToBuySeconds }))
+    : baseState;
+  const snapshotAtBuy = timeToBuySeconds > 0 && isFinite(timeToBuySeconds)
+    ? computeSnapshot(stateAtBuy, context)
+    : snapshot;
+
+  const nextStateAtBuy = applyAction(stateAtBuy, tempAction);
+  const nextSnapshot = computeSnapshot(nextStateAtBuy, context);
+  
+  const relativeExpirationAtBuy = eventExpirationSeconds - timeToBuySeconds;
+
+  let roiSeconds = Infinity;
+  const maxTime = 1e9; // ~31 years
+  const getExtra = (t: number) => 
+    calculateEarningsForTime(t, nextSnapshot, relativeExpirationAtBuy) - 
+    calculateEarningsForTime(t, snapshotAtBuy, relativeExpirationAtBuy);
+
+  if (getExtra(maxTime) >= price) {
+    let low = 0;
+    let high = maxTime;
+    for (let i = 0; i < 60; i++) {
+      const mid = (low + high) / 2;
+      if (getExtra(mid) >= price) {
+        high = mid;
+      } else {
+        low = mid;
+      }
+    }
+    roiSeconds = high;
+  }
+
+  const earningsDelta = roiSeconds !== Infinity && roiSeconds > 0 ? price / roiSeconds : 0;
+  const totalRoiSeconds = timeToBuySeconds + roiSeconds;
+
+  const showSaleWarning = !isSaleActive && (
+    (absoluteSimTime + timeToBuySeconds >= nextSaleStart) ||
+    (earningsDelta * (nextSaleStart - (absoluteSimTime + timeToBuySeconds)) < 0.7 * price)
+  );
+  
+  const showDeadlineWarning = isSaleActive && (absoluteSimTime + timeToBuySeconds > researchSaleDeadline);
+
+  return {
+    roiSeconds,
+    totalRoiSeconds,
+    earningsDelta,
+    showSaleWarning,
+    showDeadlineWarning,
+    timeToBuySeconds,
+    nextSnapshot,
+  };
+}

--- a/wasmegg/ascension-planner/src/components/ActionHistoryItem.vue
+++ b/wasmegg/ascension-planner/src/components/ActionHistoryItem.vue
@@ -280,7 +280,7 @@ const actionIconPath = computed(() => {
     return payload.setName === 'elr' ? 'egginc/afx_quantum_metronome_4.png' : 'egginc/afx_lunar_totem_4.png';
   }
   if (props.action.type === 'wait_for_time') {
-    return 'egginc/tiny_indicator_waiting.png';
+    return props.action.totalTimeSeconds > 3600 ? 'egginc/egg_truth.png' : 'egginc/tiny_indicator_waiting.png';
   }
   if (props.action.type === 'wait_for_missions') {
     return 'egginc/icon_afx_mission.png';
@@ -314,6 +314,9 @@ const eggName = computed(() => {
 });
 
 const displayName = computed(() => {
+  if (props.action.type === 'wait_for_time' && props.action.totalTimeSeconds > 3600) {
+    return 'Offline Accumulation';
+  }
   const executor = getExecutor(props.action.type);
   return executor.getDisplayName(props.action.payload);
 });

--- a/wasmegg/ascension-planner/src/components/AutoPlanImportDialog.vue
+++ b/wasmegg/ascension-planner/src/components/AutoPlanImportDialog.vue
@@ -1,0 +1,77 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+
+const props = defineProps<{
+  planName: string;
+  ascensionCount: number;
+}>();
+
+const emit = defineEmits<{
+  (e: 'resolve', resolution: 'restore' | 'individual'): void;
+  (e: 'cancel'): void;
+}>();
+</script>
+
+<template>
+  <!-- Modal Backdrop -->
+  <div class="fixed inset-0 bg-slate-900/60 backdrop-blur-sm z-[100] flex items-center justify-center p-4">
+    <!-- Dialog Card -->
+    <div class="bg-white rounded-[2rem] shadow-2xl w-full max-w-md overflow-hidden animate-in fade-in zoom-in duration-300">
+      <div class="p-8">
+        <div class="w-16 h-16 bg-indigo-100 rounded-2xl flex items-center justify-center text-indigo-600 mb-6">
+          <svg class="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z" />
+          </svg>
+        </div>
+        
+        <h3 class="text-xl font-black text-slate-900 uppercase tracking-tight mb-2">Roadmap Detected</h3>
+        <p class="text-slate-500 text-sm leading-relaxed mb-8">
+          The file "<span class="font-bold text-slate-700">{{ planName }}</span>" contains a sequential roadmap with 
+          <span class="font-bold text-indigo-600">{{ ascensionCount }} ascensions</span>. 
+          How would you like to import it?
+        </p>
+
+        <div class="space-y-3">
+          <button 
+            @click="emit('resolve', 'restore')"
+            class="w-full flex items-center gap-4 p-4 rounded-2xl border-2 border-indigo-100 bg-indigo-50/50 hover:bg-indigo-50 hover:border-indigo-200 transition-all text-left group"
+          >
+            <div class="w-10 h-10 bg-white rounded-xl flex items-center justify-center text-indigo-500 shadow-sm group-hover:scale-110 transition-transform">
+              <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+              </svg>
+            </div>
+            <div>
+              <div class="text-sm font-black text-slate-900 uppercase tracking-wider">Restore to Auto Planner</div>
+              <div class="text-[10px] font-medium text-slate-500">Resumes the full sequential simulation.</div>
+            </div>
+          </button>
+
+          <button 
+            @click="emit('resolve', 'individual')"
+            class="w-full flex items-center gap-4 p-4 rounded-2xl border-2 border-slate-100 bg-slate-50/50 hover:bg-slate-50 hover:border-slate-200 transition-all text-left group"
+          >
+            <div class="w-10 h-10 bg-white rounded-xl flex items-center justify-center text-slate-400 shadow-sm group-hover:scale-110 transition-transform">
+              <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" />
+              </svg>
+            </div>
+            <div>
+              <div class="text-sm font-black text-slate-900 uppercase tracking-wider">Import into Library</div>
+              <div class="text-[10px] font-medium text-slate-500">Adds {{ ascensionCount }} separate plans to your library.</div>
+            </div>
+          </button>
+        </div>
+
+        <div class="mt-8 flex justify-center">
+          <button 
+            @click="emit('cancel')"
+            class="text-xs font-black text-slate-400 uppercase tracking-widest hover:text-slate-600 transition-colors"
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/wasmegg/ascension-planner/src/components/AvailableActions.vue
+++ b/wasmegg/ascension-planner/src/components/AvailableActions.vue
@@ -132,7 +132,7 @@ const isEditingStartGroup = computed(() => {
 });
 
 // The effective egg to use (from effective snapshot when editing, otherwise current)
-const effectiveEgg = computed(() => actionsStore.effectiveSnapshot.currentEgg);
+const effectiveEgg = computed(() => actionsStore.effectiveSnapshot?.currentEgg ?? 'curiosity');
 
 // All available tabs
 const allTabs = [

--- a/wasmegg/ascension-planner/src/components/PlanFinalSummary.vue
+++ b/wasmegg/ascension-planner/src/components/PlanFinalSummary.vue
@@ -185,69 +185,7 @@
     </Teleport>
 
     <!-- TE Modal -->
-    <Teleport to="body">
-      <div v-if="showTeModal" class="fixed inset-0 z-[2000] flex items-center justify-center p-4">
-        <!-- Backdrop -->
-        <div class="absolute inset-0 bg-slate-900/60 backdrop-blur-sm transition-all" @click="showTeModal = false" />
-
-        <!-- Dialog -->
-        <div class="card-glass relative w-full max-w-sm overflow-hidden shadow-2xl rounded-2xl border border-white/50 bg-white/95 transition-all duration-300 animate-in fade-in zoom-in-95">
-          <div class="bg-gradient-to-r from-slate-50 to-white px-6 py-4 border-b border-slate-100 flex items-center gap-3">
-            <div class="p-1.5 bg-slate-100 rounded-lg text-slate-600">
-              <img :src="iconURL('egginc/egg_truth.png', 64)" class="w-5 h-5 drop-shadow-[0_2px_4px_rgba(0,0,0,0.3)]" alt="Truth" />
-            </div>
-            <h3 class="text-xs font-black text-slate-800 uppercase tracking-widest">TE Breakdown</h3>
-          </div>
-
-          <div class="p-4 flex flex-col gap-2">
-            <div
-              v-for="stat in teStatsList"
-              :key="stat.id"
-              class="flex items-center justify-between p-3 rounded-xl border transition-all"
-              :class="{
-                'bg-indigo-50/50 border-indigo-100 shadow-sm': stat.id === 'truth',
-                'bg-white border-slate-100': stat.id !== 'truth'
-              }"
-            >
-              <div class="flex items-center gap-3">
-                <div class="w-8 h-8 flex items-center justify-center bg-white rounded-lg shadow-sm border border-slate-50 drop-shadow-sm">
-                  <img :src="stat.icon" class="w-6 h-6 object-contain" :alt="stat.name" />
-                </div>
-                <span class="text-sm font-black" :class="{ 'text-indigo-700': stat.id === 'truth', 'text-slate-700': stat.id !== 'truth' }">
-                  {{ stat.name }}
-                </span>
-              </div>
-              <div class="flex items-center gap-2 font-mono-premium text-sm">
-                <span class="text-slate-400">{{ stat.start }}</span>
-                <span class="text-slate-300">→</span>
-                <span class="font-bold" :class="{ 'text-indigo-900': stat.id === 'truth', 'text-slate-700': stat.id !== 'truth' }">
-                  {{ stat.end }}
-                </span>
-                <span 
-                  class="ml-1 w-10 text-right font-black text-[10px]"
-                  :class="{
-                    'text-indigo-600': stat.id === 'truth' && stat.delta > 0,
-                    'text-emerald-500': stat.id !== 'truth' && stat.delta > 0,
-                    'text-slate-300': stat.delta === 0
-                  }"
-                >
-                  <template v-if="stat.delta > 0">+</template>{{ stat.delta }}
-                </span>
-              </div>
-            </div>
-          </div>
-
-          <div class="px-6 py-4 bg-slate-50 border-t border-slate-100 flex justify-end">
-            <button
-              class="px-6 py-2 text-[10px] font-black uppercase tracking-widest bg-white border border-slate-200 text-slate-600 hover:bg-slate-100 hover:text-slate-900 transition-all rounded-xl hover:shadow-sm"
-              @click="showTeModal = false"
-            >
-              Close
-            </button>
-          </div>
-        </div>
-      </div>
-    </Teleport>
+    <TeBreakdownModal :show="showTeModal" :stats="teStatsList" @close="showTeModal = false" />
   </div>
 </template>
 
@@ -261,6 +199,7 @@ import { type CalculationsSnapshot, type VirtueEgg } from '@/types';
 import { countTEThresholdsPassed } from '@/lib/truthEggs';
 import { formatNumber } from '@/lib/format';
 import { iconURL } from 'lib';
+import TeBreakdownModal from '@/components/TeBreakdownModal.vue';
 
 const actionsStore = useActionsStore();
 const initialStateStore = useInitialStateStore();
@@ -339,8 +278,14 @@ const initialClaimedTE = computed(() => Object.values(initialStateStore.initialT
 const teGained = computed(() => currentTE.value - initialClaimedTE.value);
 
 const teStatsList = computed(() => {
-  const stats: { id: string; name: string; start: number; end: number; delta: number; icon: string }[] = [];
-  
+  const stats: { id: string; name: string; start: number; end: number; delta: number; icon: string; delivered: number }[] = [];
+
+  const virtueEggs: VirtueEgg[] = ['curiosity', 'integrity', 'humility', 'resilience', 'kindness'];
+
+  const totalDelivered = virtueEggs.reduce((sum, egg) => {
+    return sum + (actionsStore.currentSnapshot.eggsDelivered?.[egg] || 0);
+  }, 0);
+
   stats.push({
     id: 'truth',
     name: 'Total TE',
@@ -348,15 +293,16 @@ const teStatsList = computed(() => {
     end: currentTE.value,
     delta: teGained.value,
     icon: iconURL('egginc/egg_truth.png', 64),
+    delivered: totalDelivered,
   });
 
-  const virtueEggs: VirtueEgg[] = ['curiosity', 'integrity', 'humility', 'resilience', 'kindness'];
   for (const egg of virtueEggs) {
     const start = initialStateStore.initialTeEarned[egg] || 0;
-    const thresholdsPassed = countTEThresholdsPassed(actionsStore.currentSnapshot.eggsDelivered?.[egg] || 0);
+    const delivered = actionsStore.currentSnapshot.eggsDelivered?.[egg] || 0;
+    const thresholdsPassed = countTEThresholdsPassed(delivered);
     const claimed = actionsStore.currentSnapshot.teEarned?.[egg] || 0;
     const end = Math.max(claimed, thresholdsPassed);
-    
+
     stats.push({
       id: egg,
       name: egg.charAt(0).toUpperCase() + egg.slice(1),
@@ -364,6 +310,7 @@ const teStatsList = computed(() => {
       end,
       delta: end - start,
       icon: iconURL(`egginc/egg_${egg}.png`, 64),
+      delivered,
     });
   }
   return stats;

--- a/wasmegg/ascension-planner/src/components/PlanLibrary.vue
+++ b/wasmegg/ascension-planner/src/components/PlanLibrary.vue
@@ -4,18 +4,35 @@ import { useActionsStore } from '@/stores/actions';
 import { usePersistence } from '@/composables/usePersistence';
 import { loadLibraryPlans, deletePlanFromLibrary, savePlanToLibrary, type PlanData } from '@/lib/storage/db';
 import { downloadFile } from '@/utils/export';
-import { initLoadPlan } from '@/lib/modes';
+import { formatNumber, formatDuration, formatUnixToDateInput, formatUnixToTimeInput } from '@/lib/format';
+import { initLoadPlan, initPlanFuture } from '@/lib/modes';
+import { useAutoPlannerStore, type ChainedAscension } from '@/stores/autoPlanner';
+import { useInitialStateStore } from '@/stores/initialState';
+import { useTruthEggsStore } from '@/stores/truthEggs';
+import { useUIStore } from '@/stores/ui';
 import ConfirmationDialog from '@/components/ConfirmationDialog.vue';
 import ImportCollisionDialog from '@/components/ImportCollisionDialog.vue';
+import AutoPlanImportDialog from '@/components/AutoPlanImportDialog.vue';
 import PlanAlreadyOpenWarning from '@/components/PlanAlreadyOpenWarning.vue';
+import { createEmptySnapshot } from '@/types';
+import { buildLibraryPlansFromExport } from '@/auto/buildLibraryPlans';
 
 const actionsStore = useActionsStore();
+const autoPlannerStore = useAutoPlannerStore();
+const initialStateStore = useInitialStateStore();
+const truthEggsStore = useTruthEggsStore();
+const uiStore = useUIStore();
 const { partitionHash, broadcastLibraryUpdate, broadcastPresence, busyPlanIds } = usePersistence();
 
 const plans = ref<PlanData[]>([]);
 const isLoading = ref(true);
 const showDeleteConfirm = ref(false);
 const planToDelete = ref<PlanData | null>(null);
+
+// Bulk select state
+const bulkSelectMode = ref(false);
+const selectedPlanIds = ref<Set<string>>(new Set());
+const showBulkDeleteConfirm = ref(false);
 const editingPlanId = ref<string | null>(null);
 const newName = ref('');
 const showCopyPrompt = ref(false);
@@ -34,6 +51,13 @@ let collisionResolver: ((resolution: 'overwrite' | 'keep-both' | 'skip' | 'cance
 
 // Import progress
 const importProgress = ref<{ current: number; total: number } | null>(null);
+
+// Auto-plan import state
+const showAutoPlanDialog = ref(false);
+const autoPlanToImport = ref<any>(null);
+const autoPlanName = ref('');
+const autoPlanAscensionCount = ref(0);
+let autoPlanResolver: ((resolution: 'restore' | 'individual' | 'cancel') => void) | null = null;
 
 async function refreshPlans() {
   if (!partitionHash.value) return;
@@ -62,6 +86,7 @@ async function loadPlan(plan: PlanData) {
     await initLoadPlan(plan);
     emit('plan-loaded');
   } catch (err) {
+    console.error('[PlanLibrary] Error loading plan:', err);
     alert('Failed to load plan: ' + err);
   }
 }
@@ -105,6 +130,36 @@ async function executeDelete() {
   }
   showDeleteConfirm.value = false;
   planToDelete.value = null;
+}
+
+function toggleBulkSelectMode() {
+  bulkSelectMode.value = !bulkSelectMode.value;
+  selectedPlanIds.value = new Set();
+}
+
+function togglePlanSelection(id: string) {
+  const next = new Set(selectedPlanIds.value);
+  if (next.has(id)) {
+    next.delete(id);
+  } else {
+    next.add(id);
+  }
+  selectedPlanIds.value = next;
+}
+
+async function executeBulkDelete() {
+  if (!partitionHash.value) return;
+  for (const id of selectedPlanIds.value) {
+    await deletePlanFromLibrary(partitionHash.value, id);
+    if (actionsStore.activePlanId === id) {
+      actionsStore.activePlanId = null;
+    }
+  }
+  broadcastLibraryUpdate();
+  await refreshPlans();
+  selectedPlanIds.value = new Set();
+  bulkSelectMode.value = false;
+  showBulkDeleteConfirm.value = false;
 }
 
 function startRename(plan: PlanData) {
@@ -232,6 +287,113 @@ async function handleImport(event: Event) {
       } else if (imported.type === 'plan' && imported.data) {
         // Single plan export (from our new format)
         plansToImport = [{ name: imported.name || file.name.replace('.json', ''), data: imported.data }];
+      } else if (imported.version && imported.ascensions && imported.initialState) {
+        // Sequential Roadmap (Auto-Plan)
+        showAutoPlanDialog.value = true;
+        autoPlanToImport.value = imported;
+        autoPlanName.value = file.name.replace('.json', '');
+        autoPlanAscensionCount.value = imported.ascensions.length;
+
+        const resolution = await new Promise<'restore' | 'individual' | 'cancel'>(resolve => {
+          autoPlanResolver = resolve;
+        });
+
+        if (resolution === 'cancel') return;
+
+        if (resolution === 'restore') {
+          // 1. Switch tab
+          uiStore.plannerTab = 'automatic';
+          uiStore.isHeaderCollapsed = true;
+
+          // 2. Load fresh backup first (ensures we have latest epic research/artifacts as a baseline)
+          //    We do this because switching to the Auto Planner tab normally triggers a backup fetch.
+          uiStore.loading = true;
+          try {
+            if (initialStateStore.playerId) {
+              await initPlanFuture(initialStateStore.playerId);
+            }
+
+            // 3. Restore to Auto Planner (now overwriting the fresh backup state)
+            const importedA1ForceMode: 'continue' | 'prestige' | null = imported.a1ForceMode || null;
+
+            // Pick the best result for an imported ascension, respecting a1ForceMode
+            const getBestImportResult = (a: any, aIdx: number) => {
+              if (aIdx === 0 && importedA1ForceMode === 'continue' && a.result3) return a.result3;
+              const r1 = a.result1;
+              const r2 = a.result2;
+              return r1.summary.totalDurationSeconds <= r2.summary.totalDurationSeconds ? r1 : r2;
+            };
+
+            const chain: ChainedAscension[] = imported.ascensions.map((a: any) => {
+              const item: ChainedAscension = {
+                index: a.index,
+                result1: a.result1,
+                result2: a.result2,
+                goal: a.goal,
+              };
+              if (a.result3) item.result3 = a.result3;
+              if (a.result3SkippedReason) item.result3SkippedReason = a.result3SkippedReason;
+              return item;
+            });
+
+            const nextGoalsMap: Record<number, { te: number | null, date: string, time: string }> = {};
+            imported.ascensions.forEach((a: any, idx: number) => {
+              // Populate with the original goal
+              nextGoalsMap[idx] = { ...a.goal };
+
+              // If it was a TE goal, pre-fill the date/time fields with the actual result for better UX
+              if (a.goal.type === 'te' || !a.goal.date) {
+                const bestResult = getBestImportResult(a, idx);
+                nextGoalsMap[idx].date = formatUnixToDateInput(bestResult.summary.endTime, imported.timezone);
+                nextGoalsMap[idx].time = formatUnixToTimeInput(bestResult.summary.endTime, imported.timezone);
+              }
+            });
+            // Add the next step goal (empty placeholder for new ascension)
+            const lastImportedA = imported.ascensions[imported.ascensions.length - 1];
+            const lastBestResult = getBestImportResult(lastImportedA, imported.ascensions.length - 1);
+            nextGoalsMap[chain.length] = {
+              te: Math.min(490, lastBestResult.summary.endTE + 30),
+              date: '',
+              time: ''
+            };
+
+            const firstA = imported.ascensions[0];
+            const bestFirstA = getBestImportResult(firstA, 0);
+            const a1EndTime = bestFirstA.summary.endTime;
+
+            autoPlannerStore.setPlan({
+              ascensionChain: chain,
+              timezone: imported.timezone,
+              startDate: formatUnixToDateInput(imported.startTime, imported.timezone),
+              startTime: formatUnixToTimeInput(imported.startTime, imported.timezone),
+              targetTE: imported.ascensions.map((a: any) => a.goal.te || a.result1.summary.endTE).join(' '),
+              // Always populate date/time fields with results for visibility
+              targetEndDate: formatUnixToDateInput(a1EndTime, imported.timezone),
+              targetEndTime: formatUnixToTimeInput(a1EndTime, imported.timezone),
+              nextGoals: nextGoalsMap,
+              a1ForceMode: importedA1ForceMode,
+            });
+
+            // Hydrate stores so the form shows the correct numbers from the plan
+            initialStateStore.hydrate(imported.initialState);
+            truthEggsStore.hydrate(imported.initialState);
+          } catch (e) {
+            console.error('Failed to restore roadmap:', e);
+            alert('Failed to restore roadmap simulation state.');
+          } finally {
+            uiStore.loading = false;
+          }
+        }
+
+        if (resolution === 'individual') {
+          // 2. Import Individual Ascensions into Library
+          const exportDate = new Date(imported.exportedAt).toISOString().split('T')[0];
+          
+          plansToImport = buildLibraryPlansFromExport(imported, exportDate);
+        } else {
+          // Restore only — we're done
+          return;
+        }
       } else if (imported.version && imported.actions && imported.initialState) {
         // Raw plan data (old format — the plan data itself, not wrapped)
         plansToImport = [{ name: file.name.replace('.json', ''), data: imported }];
@@ -335,6 +497,22 @@ async function handleImport(event: Event) {
   }
 }
 
+function handleAutoPlanResolve(resolution: 'restore' | 'individual') {
+  showAutoPlanDialog.value = false;
+  if (autoPlanResolver) {
+    autoPlanResolver(resolution);
+    autoPlanResolver = null;
+  }
+}
+
+function handleAutoPlanCancel() {
+  showAutoPlanDialog.value = false;
+  if (autoPlanResolver) {
+    autoPlanResolver('cancel');
+    autoPlanResolver = null;
+  }
+}
+
 const emit = defineEmits(['plan-loaded']);
 </script>
 
@@ -358,16 +536,33 @@ const emit = defineEmits(['plan-loaded']);
           {{ plans.length }}
         </span>
       </h3>
-      <div class="flex space-x-2">
+      <div class="flex items-center space-x-2">
         <button
-          class="text-xs text-indigo-600 hover:text-indigo-800 font-medium disabled:opacity-40 disabled:cursor-not-allowed"
+          v-if="bulkSelectMode && selectedPlanIds.size > 0"
+          class="px-2.5 py-1 text-xs font-medium rounded border border-red-300 text-red-600 hover:bg-red-50 transition-colors"
+          @click="showBulkDeleteConfirm = true"
+        >
+          Delete ({{ selectedPlanIds.size }})
+        </button>
+        <button
+          v-if="plans.length > 0"
+          class="px-2.5 py-1 text-xs font-medium rounded border transition-colors"
+          :class="bulkSelectMode
+            ? 'border-gray-300 text-gray-600 hover:bg-gray-50'
+            : 'border-indigo-300 text-indigo-600 hover:bg-indigo-50'"
+          @click="toggleBulkSelectMode"
+        >
+          {{ bulkSelectMode ? 'Cancel' : 'Multi-Select' }}
+        </button>
+        <button
+          class="px-2.5 py-1 text-xs font-medium rounded border border-indigo-300 text-indigo-600 hover:bg-indigo-50 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
           :disabled="plans.length === 0"
           @click="exportAll"
         >
           Export All
         </button>
-        <label class="text-xs text-indigo-600 hover:text-indigo-800 font-medium cursor-pointer">
-          Import...
+        <label class="px-2.5 py-1 text-xs font-medium rounded border border-indigo-300 text-indigo-600 hover:bg-indigo-50 transition-colors cursor-pointer">
+          Import
           <input type="file" class="hidden" accept=".json" @change="handleImport" />
         </label>
       </div>
@@ -421,7 +616,15 @@ const emit = defineEmits(['plan-loaded']);
                 </svg>
               </button>
             </div>
-            <div v-else class="flex items-center cursor-pointer" @click="loadPlan(plan)">
+            <div v-else class="flex items-center cursor-pointer" @click="bulkSelectMode ? togglePlanSelection(plan.id) : loadPlan(plan)">
+              <input
+                v-if="bulkSelectMode"
+                type="checkbox"
+                class="mr-2 h-4 w-4 flex-shrink-0 rounded border-gray-300 text-indigo-600 cursor-pointer"
+                :checked="selectedPlanIds.has(plan.id)"
+                @click.stop
+                @change="togglePlanSelection(plan.id)"
+              />
               <span class="text-sm font-medium text-gray-900 truncate" :title="plan.name">{{ plan.name }}</span>
               <span
                 v-if="actionsStore.activePlanId === plan.id"
@@ -440,16 +643,6 @@ const emit = defineEmits(['plan-loaded']);
             <span class="hidden sm:inline text-[10px] text-gray-400 whitespace-nowrap mr-1">
               Updated {{ new Date(plan.timestamp).toLocaleString(undefined, { year: 'numeric', month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' }) }}
             </span>
-            <button class="p-0.5 sm:p-1 text-gray-400 hover:text-indigo-600" v-tippy="'Load this plan'" @click="loadPlan(plan)">
-              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  d="M5 19a2 2 0 01-2-2V7a2 2 0 012-2h4l2 2h4a2 2 0 012 2v1M5 19h14a2 2 0 002-2v-5a2 2 0 00-2-2H9a2 2 0 00-2 2v5a2 2 0 01-2 2z"
-                />
-              </svg>
-            </button>
             <button class="p-0.5 sm:p-1 text-gray-400 hover:text-indigo-600" v-tippy="'Export this plan (JSON)'" @click="exportPlan(plan)">
               <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path
@@ -519,6 +712,16 @@ const emit = defineEmits(['plan-loaded']);
     "
   />
 
+  <ConfirmationDialog
+    v-if="showBulkDeleteConfirm"
+    title="Delete Plans"
+    :message="`Are you sure you want to delete ${selectedPlanIds.size} plan${selectedPlanIds.size > 1 ? 's' : ''}? This cannot be undone.`"
+    confirm-label="Delete"
+    variant="danger"
+    @confirm="executeBulkDelete"
+    @cancel="showBulkDeleteConfirm = false"
+  />
+
   <ImportCollisionDialog
     v-if="showCollisionDialog"
     ref="collisionDialogRef"
@@ -549,4 +752,12 @@ const emit = defineEmits(['plan-loaded']);
   </ConfirmationDialog>
 
   <PlanAlreadyOpenWarning v-if="showAlreadyOpenWarning" @dismiss="showAlreadyOpenWarning = false" />
+
+  <AutoPlanImportDialog
+    v-if="showAutoPlanDialog"
+    :plan-name="autoPlanName"
+    :ascension-count="autoPlanAscensionCount"
+    @resolve="handleAutoPlanResolve"
+    @cancel="handleAutoPlanCancel"
+  />
 </template>

--- a/wasmegg/ascension-planner/src/components/PlanLibrary.vue
+++ b/wasmegg/ascension-planner/src/components/PlanLibrary.vue
@@ -314,11 +314,16 @@ async function handleImport(event: Event) {
             }
 
             // 3. Restore to Auto Planner (now overwriting the fresh backup state)
-            const importedA1ForceMode: 'continue' | 'prestige' | null = imported.a1ForceMode || null;
+            const importedOverrides: Record<number, string> = imported.planVariantOverrides ?? (
+              imported.a1ForceMode === 'continue' ? { 0: 'continue' } : {}
+            );
 
-            // Pick the best result for an imported ascension, respecting a1ForceMode
+            // Pick the best result for an imported ascension, respecting planVariantOverrides
             const getBestImportResult = (a: any, aIdx: number) => {
-              if (aIdx === 0 && importedA1ForceMode === 'continue' && a.result3) return a.result3;
+              const override = importedOverrides[aIdx];
+              if (override === 'continue' && a.result3) return a.result3;
+              if (override === '1-sale') return a.result1;
+              if (override === '2-sale') return a.result2;
               const r1 = a.result1;
               const r2 = a.result2;
               return r1.summary.totalDurationSeconds <= r2.summary.totalDurationSeconds ? r1 : r2;
@@ -371,7 +376,7 @@ async function handleImport(event: Event) {
               targetEndDate: formatUnixToDateInput(a1EndTime, imported.timezone),
               targetEndTime: formatUnixToTimeInput(a1EndTime, imported.timezone),
               nextGoals: nextGoalsMap,
-              a1ForceMode: importedA1ForceMode,
+              planVariantOverrides: importedOverrides as Record<number, 'continue' | '1-sale' | '2-sale'>,
             });
 
             // Hydrate stores so the form shows the correct numbers from the plan

--- a/wasmegg/ascension-planner/src/components/TeBreakdownModal.vue
+++ b/wasmegg/ascension-planner/src/components/TeBreakdownModal.vue
@@ -1,0 +1,100 @@
+<template>
+  <Teleport to="body">
+    <div v-if="show" class="fixed inset-0 z-[2000] flex items-center justify-center p-4">
+      <!-- Backdrop -->
+      <div class="absolute inset-0 bg-slate-900/60 backdrop-blur-sm transition-all" @click="$emit('close')" />
+
+      <!-- Dialog -->
+      <div class="card-glass relative w-full max-w-sm overflow-hidden shadow-2xl rounded-2xl border border-white/50 bg-white/95 transition-all duration-300 animate-in fade-in zoom-in-95">
+        <div class="bg-gradient-to-r from-slate-50 to-white px-6 py-4 border-b border-slate-100 flex items-center gap-3">
+          <div class="p-1.5 bg-slate-100 rounded-lg text-slate-600">
+            <img :src="iconURL('egginc/egg_truth.png', 64)" class="w-5 h-5 drop-shadow-[0_2px_4px_rgba(0,0,0,0.3)]" alt="Truth" />
+          </div>
+          <h3 class="text-xs font-black text-slate-800 uppercase tracking-widest">TE Breakdown</h3>
+        </div>
+
+        <div class="p-4 flex flex-col gap-2">
+          <div
+            v-for="stat in stats"
+            :key="stat.id"
+            class="flex items-center justify-between p-3 rounded-xl border transition-all"
+            :class="{
+              'bg-indigo-50/50 border-indigo-100 shadow-sm': stat.id === 'truth',
+              'bg-white border-slate-100': stat.id !== 'truth'
+            }"
+          >
+            <div class="flex items-center gap-3">
+              <div class="w-8 h-8 flex items-center justify-center bg-white rounded-lg shadow-sm border border-slate-50 drop-shadow-sm">
+                <img :src="stat.icon" class="w-6 h-6 object-contain" :alt="stat.name" />
+              </div>
+              <div class="flex flex-col">
+                <span class="text-sm font-black" :class="{ 'text-indigo-700': stat.id === 'truth', 'text-slate-700': stat.id !== 'truth' }">
+                  {{ stat.name }}
+                </span>
+                <span class="text-[10px] text-slate-400 font-medium leading-tight">
+                  {{ formatNumber(stat.delivered) }} delivered
+                </span>
+              </div>
+            </div>
+            <div class="flex items-center gap-2 font-mono-premium text-sm">
+              <span class="text-slate-400">{{ stat.start }}</span>
+              <span class="text-slate-300">→</span>
+              <span class="font-bold" :class="{ 'text-indigo-900': stat.id === 'truth', 'text-slate-700': stat.id !== 'truth' }">
+                {{ stat.end }}
+              </span>
+              <span
+                class="ml-1 w-10 text-right font-black text-[10px]"
+                :class="{
+                  'text-indigo-600': stat.id === 'truth' && stat.delta > 0,
+                  'text-emerald-500': stat.id !== 'truth' && stat.delta > 0,
+                  'text-slate-300': stat.delta === 0
+                }"
+              >
+                <template v-if="stat.delta > 0">+</template>{{ stat.delta }}
+              </span>
+            </div>
+          </div>
+        </div>
+
+        <div class="px-6 py-4 bg-slate-50 border-t border-slate-100 flex justify-end">
+          <button
+            class="px-6 py-2 text-[10px] font-black uppercase tracking-widest bg-white border border-slate-200 text-slate-600 hover:bg-slate-100 hover:text-slate-900 transition-all rounded-xl hover:shadow-sm"
+            @click="$emit('close')"
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import { formatNumber } from '@/lib/format';
+import { iconURL } from 'lib';
+
+export interface TeStat {
+  id: string;
+  name: string;
+  start: number;
+  end: number;
+  delta: number;
+  icon: string;
+  delivered: number;
+}
+
+defineProps<{
+  show: boolean;
+  stats: TeStat[];
+}>();
+
+defineEmits<{ close: [] }>();
+</script>
+
+<style scoped>
+.font-mono-premium { font-family: 'JetBrains Mono', 'Roboto Mono', monospace; }
+
+.animate-in {
+  animation-duration: 200ms;
+}
+</style>

--- a/wasmegg/ascension-planner/src/components/actions/ResearchFlatView.vue
+++ b/wasmegg/ascension-planner/src/components/actions/ResearchFlatView.vue
@@ -38,6 +38,7 @@
         :extra-seconds="item.extraSeconds"
         :hpp="item.hpp"
         :realistic-stats="item.realisticStats"
+        :lookahead="item.lookahead"
         :recommendation-note="item.recommendationNote"
         :show-sale-warning="item.showSaleWarning"
         :show-deadline-warning="item.showDeadlineWarning"
@@ -95,6 +96,7 @@ interface SortedResearchItem {
   extraSeconds?: number;
   hpp?: number;
   realisticStats?: { layRate: number; shippingRate: number; elr: number; elrDelta: number };
+  lookahead?: { minLevels: number; impact: number; hpp: number };
   recommendationNote?: string;
   showSaleWarning?: boolean;
   showDeadlineWarning?: boolean;

--- a/wasmegg/ascension-planner/src/components/actions/ResearchItem.vue
+++ b/wasmegg/ascension-planner/src/components/actions/ResearchItem.vue
@@ -40,6 +40,21 @@
         {{ research.description }}
         
         <div
+          v-if="lookahead"
+          class="mt-1.5 p-1.5 inline-block bg-amber-50 border border-amber-100 rounded text-[9px] text-amber-800 leading-tight shadow-sm"
+        >
+          <div class="flex items-start gap-1">
+            <svg class="w-3 h-3 text-amber-500 shrink-0 mt-px" fill="currentColor" viewBox="0 0 20 20">
+              <path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd" />
+            </svg>
+            <span>
+              <span class="font-bold uppercase tracking-tight mr-1">Lookahead:</span>
+              Needs {{ lookahead.minLevels }} levels for +{{ (lookahead.impact * 100).toFixed(3) }}% ELR ({{ lookahead.hpp.toFixed(1) }} hr/%)
+            </span>
+          </div>
+        </div>
+
+        <div
           v-if="recommendationNote"
           class="mt-1.5 p-1.5 inline-block bg-blue-50 border border-blue-100 rounded text-[9px] text-blue-800 leading-tight shadow-sm"
         >
@@ -231,6 +246,7 @@ const props = defineProps<{
   buyToHereTooltip?: string;
   extraSeconds?: number;
   realisticStats?: { layRate: number; shippingRate: number; elr: number; elrDelta: number };
+  lookahead?: { minLevels: number; impact: number; hpp: number };
   showSaleWarning?: boolean;
   showDeadlineWarning?: boolean;
 }>();

--- a/wasmegg/ascension-planner/src/components/actions/UpgradeDropdown.vue
+++ b/wasmegg/ascension-planner/src/components/actions/UpgradeDropdown.vue
@@ -4,7 +4,7 @@
     <button
       type="button"
       class="w-full bg-slate-50 border border-slate-200 rounded-xl p-3 text-left shadow-sm focus:outline-none hover:bg-slate-100 transition-all group"
-      @click="isOpen = !isOpen"
+      @click="toggleOpen"
     >
       <div v-if="selectedOption" class="flex gap-3 items-center">
         <div class="w-10 h-10 bg-white rounded-lg shadow-sm border border-slate-100 flex-shrink-0 p-1.5 group-hover:scale-105 transition-transform">
@@ -50,7 +50,8 @@
     <!-- Dropdown Modal Context -->
     <div
       v-if="isOpen"
-      class="absolute z-50 mt-2 w-full sm:w-[450px] right-0 sm:right-auto sm:left-0 bg-white rounded-2xl shadow-xl border border-slate-100 overflow-hidden animate-in fade-in slide-in-from-top-2"
+      class="absolute z-50 w-full sm:w-[450px] right-0 sm:right-auto sm:left-0 bg-white rounded-2xl shadow-xl border border-slate-100 overflow-hidden animate-in fade-in"
+      :class="openUpward ? 'bottom-full mb-2 slide-in-from-bottom-2' : 'mt-2 slide-in-from-top-2'"
     >
       <div class="max-h-[60vh] overflow-y-auto custom-scrollbar divide-y divide-slate-50">
         <button
@@ -123,7 +124,18 @@ const emit = defineEmits<{
 }>();
 
 const isOpen = ref(false);
+const openUpward = ref(false);
 const containerRef = ref<HTMLElement | null>(null);
+
+function toggleOpen() {
+  if (!isOpen.value && containerRef.value) {
+    const rect = containerRef.value.getBoundingClientRect();
+    // PlanFinalSummary is ~80px tall; leave extra breathing room
+    const spaceBelow = window.innerHeight - rect.bottom - 100;
+    openUpward.value = spaceBelow < 420;
+  }
+  isOpen.value = !isOpen.value;
+}
 
 const selectedOption = computed(() => props.options.find(o => o.id === props.modelValue));
 

--- a/wasmegg/ascension-planner/src/components/auto/AscensionOverview.vue
+++ b/wasmegg/ascension-planner/src/components/auto/AscensionOverview.vue
@@ -55,29 +55,67 @@
             </svg>
           </button>
 
-          <button
-            v-if="index === 0"
-            @click="$emit('forceModeChange', summary.strategyLabel === 'Continue current' ? 'prestige' : 'continue')"
-            :disabled="summary.strategyLabel !== 'Continue current' && !result3Available"
-            class="flex items-center gap-1 px-2.5 py-1 rounded-lg text-[9px] font-black transition-colors uppercase tracking-wider group shadow-sm flex-shrink-0 border"
-            :class="[
-              summary.strategyLabel === 'Continue current'
-                ? 'bg-rose-50 border-rose-200 text-rose-600 hover:bg-rose-100'
-                : 'bg-emerald-50 border-emerald-200 text-emerald-600 hover:bg-emerald-100 disabled:opacity-50 disabled:grayscale disabled:cursor-not-allowed',
-            ]"
-          >
-            <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path
-                v-if="summary.strategyLabel === 'Continue current'"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="3"
-                d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6"
-              />
-              <path v-else stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="M5 13l4 4L19 7" />
-            </svg>
-            <span>{{ summary.strategyLabel === 'Continue current' ? 'Prestige Now' : 'Continue Ascension' }}</span>
-          </button>
+          <!-- Plan variant dropdown -->
+          <div class="relative flex-shrink-0" ref="dropdownRef">
+            <button
+              @click.stop="isDropdownOpen = !isDropdownOpen"
+              class="flex items-center gap-1 px-2.5 py-1 bg-slate-50 hover:bg-indigo-50 border border-slate-200/80 hover:border-indigo-200/50 rounded-lg text-[9px] font-black text-slate-500 hover:text-indigo-600 transition-colors uppercase tracking-wider shadow-sm"
+            >
+              <span>{{ activeVariantShortLabel }}</span>
+              <svg class="w-3 h-3 transition-transform duration-200" :class="isDropdownOpen ? 'rotate-180' : ''" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="M19 9l-7 7-7-7" />
+              </svg>
+            </button>
+
+            <div
+              v-if="isDropdownOpen"
+              class="absolute right-0 top-full mt-1 z-50 bg-white border border-slate-200 rounded-xl shadow-lg py-1 min-w-[148px]"
+            >
+              <button
+                v-for="opt in saleOptions"
+                :key="opt.value"
+                @click="selectVariant(opt.value)"
+                class="w-full text-left px-3 py-1.5 text-[9px] font-black uppercase tracking-wider transition-colors flex items-center gap-1.5"
+                :class="opt.value === activeVariant ? 'bg-indigo-50 text-indigo-600' : 'text-slate-600 hover:bg-slate-50'"
+              >
+                <svg v-if="opt.value === activeVariant" class="w-2.5 h-2.5 flex-shrink-0" fill="currentColor" viewBox="0 0 24 24">
+                  <path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"/>
+                </svg>
+                <span v-else class="w-2.5 flex-shrink-0" />
+                {{ opt.label }}
+              </button>
+
+              <!-- Continue Ascension (A1 only) -->
+              <template v-if="index === 0">
+                <div class="border-t border-slate-100 my-1" />
+                <span
+                  v-if="!result3Available"
+                  v-tippy="continueDisabledTooltip"
+                  class="block"
+                >
+                  <button
+                    disabled
+                    class="w-full text-left px-3 py-1.5 text-[9px] font-black uppercase tracking-wider flex items-center gap-1.5 opacity-40 cursor-not-allowed text-slate-500"
+                  >
+                    <span class="w-2.5 flex-shrink-0" />
+                    Continue Asc.
+                  </button>
+                </span>
+                <button
+                  v-else
+                  @click="selectVariant('continue')"
+                  class="w-full text-left px-3 py-1.5 text-[9px] font-black uppercase tracking-wider transition-colors flex items-center gap-1.5"
+                  :class="activeVariant === 'continue' ? 'bg-indigo-50 text-indigo-600' : 'text-slate-600 hover:bg-slate-50'"
+                >
+                  <svg v-if="activeVariant === 'continue'" class="w-2.5 h-2.5 flex-shrink-0" fill="currentColor" viewBox="0 0 24 24">
+                    <path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"/>
+                  </svg>
+                  <span v-else class="w-2.5 flex-shrink-0" />
+                  Continue Asc.
+                </button>
+              </template>
+            </div>
+          </div>
         </div>
       </div>
 
@@ -238,7 +276,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed } from 'vue';
+import { ref, computed, onMounted, onBeforeUnmount } from 'vue';
 import { formatNumber, formatDuration } from '@/lib/format';
 import { iconURL } from 'lib';
 import type { AscensionSummary } from '@/auto/types';
@@ -267,13 +305,53 @@ const props = defineProps<{
   total: number;
   targetTE: number | null;
   result3Available?: boolean;
+  result3SkippedReason?: string;
 }>();
 
-defineEmits<{
-  (e: 'forceModeChange', mode: 'continue' | 'prestige'): void;
+const emit = defineEmits<{
+  (e: 'setPlanVariant', variant: 'continue' | '1-sale' | '2-sale'): void;
 }>();
 
 const isExpanded = ref(false);
+const isDropdownOpen = ref(false);
+const dropdownRef = ref<HTMLElement | null>(null);
+
+const handleClickOutside = (e: MouseEvent) => {
+  if (dropdownRef.value && !dropdownRef.value.contains(e.target as Node)) {
+    isDropdownOpen.value = false;
+  }
+};
+onMounted(() => document.addEventListener('click', handleClickOutside));
+onBeforeUnmount(() => document.removeEventListener('click', handleClickOutside));
+
+const activeVariant = computed<'1-sale' | '2-sale' | 'continue'>(() => {
+  const label = props.summary.strategyLabel;
+  if (label.includes('1-sale')) return '1-sale';
+  if (label.includes('2-sale')) return '2-sale';
+  return 'continue';
+});
+
+const activeVariantShortLabel = computed(() => {
+  if (activeVariant.value === 'continue') return 'Continue';
+  return activeVariant.value;
+});
+
+const saleOptions = [
+  { value: '1-sale' as const, label: '1-sale build' },
+  { value: '2-sale' as const, label: '2-sale build' },
+];
+
+const continueDisabledTooltip = computed(() => {
+  if (props.result3SkippedReason === 'startTimeTooFar') {
+    return 'Start time must be within 1 hour of now to use Continue Ascension';
+  }
+  return 'No farm backup loaded — upload a backup to use Continue Ascension';
+});
+
+const selectVariant = (variant: 'continue' | '1-sale' | '2-sale') => {
+  isDropdownOpen.value = false;
+  emit('setPlanVariant', variant);
+};
 const eggs: VirtueEgg[] = ['curiosity', 'integrity', 'humility', 'resilience', 'kindness'];
 
 const displayComparisons = computed(() => {  

--- a/wasmegg/ascension-planner/src/components/auto/AscensionOverview.vue
+++ b/wasmegg/ascension-planner/src/components/auto/AscensionOverview.vue
@@ -116,6 +116,26 @@
               </template>
             </div>
           </div>
+
+          <!-- Save single ascension to library -->
+          <button
+            @click="emit('saveSingleToLibrary')"
+            :disabled="isSavingSingle"
+            v-tippy="saveSingleSuccess ? 'Saved to plan library!' : 'Save to plan library'"
+            class="flex items-center gap-1 px-2.5 py-1 bg-slate-50 hover:bg-indigo-50 border border-slate-200/80 hover:border-indigo-200/50 rounded-lg text-[9px] font-black text-slate-500 hover:text-indigo-600 transition-colors uppercase tracking-wider shadow-sm flex-shrink-0 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            <svg v-if="isSavingSingle" class="w-3 h-3 animate-spin" fill="none" viewBox="0 0 24 24">
+              <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
+              <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+            </svg>
+            <svg v-else-if="saveSingleSuccess" class="w-3 h-3 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+            </svg>
+            <svg v-else class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7H5a2 2 0 00-2 2v9a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-3m-1 4l-3 3m0 0l-3-3m3 3V4" />
+            </svg>
+            {{ isSavingSingle ? 'Saving...' : saveSingleSuccess ? 'Saved!' : 'Save' }}
+          </button>
         </div>
       </div>
 
@@ -306,10 +326,13 @@ const props = defineProps<{
   targetTE: number | null;
   result3Available?: boolean;
   result3SkippedReason?: string;
+  isSavingSingle?: boolean;
+  saveSingleSuccess?: boolean;
 }>();
 
 const emit = defineEmits<{
   (e: 'setPlanVariant', variant: 'continue' | '1-sale' | '2-sale'): void;
+  (e: 'saveSingleToLibrary'): void;
 }>();
 
 const isExpanded = ref(false);

--- a/wasmegg/ascension-planner/src/components/auto/AscensionOverview.vue
+++ b/wasmegg/ascension-planner/src/components/auto/AscensionOverview.vue
@@ -1,0 +1,391 @@
+<template>
+  <div class="bg-white rounded-xl sm:rounded-2xl p-3.5 sm:p-4 text-slate-900 relative overflow-hidden shadow-md border border-slate-200">
+    <!-- Background accents -->
+    <div class="absolute -right-20 -top-20 w-64 h-64 bg-indigo-500/5 rounded-full blur-3xl"></div>
+    <div class="absolute -left-20 -bottom-20 w-64 h-64 bg-emerald-500/5 rounded-full blur-3xl"></div>
+
+    <div class="relative z-10">
+      <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 sm:gap-3 mb-3">
+        <div class="flex items-center gap-2.5 sm:gap-3">
+          <div class="w-7 h-7 sm:w-8 sm:h-8 bg-gradient-to-br from-indigo-500 to-indigo-600 rounded-lg sm:rounded-xl flex items-center justify-center shadow-md shadow-indigo-100/50 flex-shrink-0">
+            <svg class="w-4 h-4 sm:w-5 sm:h-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+            </svg>
+          </div>
+          <div>
+            <div class="flex flex-col sm:flex-row sm:items-baseline gap-0.5 sm:gap-2">
+              <h3 class="text-base sm:text-lg font-black uppercase tracking-tight text-slate-800 leading-none">
+                A{{ index + 1 }} of {{ total }}
+                <span v-if="index === 0" class="ml-1 sm:ml-2 text-[8px] sm:text-[10px] font-bold text-slate-400 capitalize opacity-70">
+                  — {{ summary.strategyLabel === 'Continue current' ? 'Continue current ascension' : 'Prestige Now' }}
+                </span>
+              </h3>
+              <span class="text-[8px] sm:text-[9px] font-bold text-slate-400 uppercase tracking-wider leading-none">{{ formatTimeRange(summary.startTime, summary.endTime) }}</span>
+            </div>
+
+            <div v-if="displayComparisons.length > 0" class="flex flex-wrap gap-2 mt-1">
+              <div v-for="(comp, ci) in displayComparisons" :key="ci"
+                class="px-1.5 py-0.5 rounded text-[8px] sm:text-[9px] font-black uppercase tracking-wider flex items-center gap-1 shadow-sm w-fit"
+                :class="comp.message ? 'bg-indigo-50 text-indigo-600 border border-indigo-100' : 'bg-emerald-50 text-emerald-600 border border-emerald-100'">
+                <svg v-if="!comp.message" class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6" />
+                </svg>
+                <svg v-else class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+                <template v-if="comp.message">{{ comp.message }}</template>
+                <template v-else>{{ comp.daysFaster.toFixed(1) }} days faster than {{ comp.otherPlanLabel }}</template>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="flex items-center gap-2">
+          <button
+            @click="isExpanded = !isExpanded"
+            class="flex items-center gap-1 px-2.5 py-1 bg-slate-50 hover:bg-indigo-50 border border-slate-200/80 hover:border-indigo-200/50 rounded-lg text-[9px] font-black text-slate-500 hover:text-indigo-600 transition-colors uppercase tracking-wider group shadow-sm flex-shrink-0"
+          >
+            <span>{{ isExpanded ? 'Hide details' : 'View details' }}</span>
+            <svg
+              class="w-3 h-3 transition-transform duration-500"
+              :class="isExpanded ? 'rotate-180' : ''"
+              fill="none" stroke="currentColor" viewBox="0 0 24 24"
+            >
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="M19 9l-7 7-7-7" />
+            </svg>
+          </button>
+
+          <button
+            v-if="index === 0"
+            @click="$emit('forceModeChange', summary.strategyLabel === 'Continue current' ? 'prestige' : 'continue')"
+            :disabled="summary.strategyLabel !== 'Continue current' && !result3Available"
+            class="flex items-center gap-1 px-2.5 py-1 rounded-lg text-[9px] font-black transition-colors uppercase tracking-wider group shadow-sm flex-shrink-0 border"
+            :class="[
+              summary.strategyLabel === 'Continue current'
+                ? 'bg-rose-50 border-rose-200 text-rose-600 hover:bg-rose-100'
+                : 'bg-emerald-50 border-emerald-200 text-emerald-600 hover:bg-emerald-100 disabled:opacity-50 disabled:grayscale disabled:cursor-not-allowed',
+            ]"
+          >
+            <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                v-if="summary.strategyLabel === 'Continue current'"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="3"
+                d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6"
+              />
+              <path v-else stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="M5 13l4 4L19 7" />
+            </svg>
+            <span>{{ summary.strategyLabel === 'Continue current' ? 'Prestige Now' : 'Continue Ascension' }}</span>
+          </button>
+        </div>
+      </div>
+
+      <div class="grid grid-cols-3 gap-x-1.5 sm:gap-x-6 gap-y-2 mb-3.5">
+        <!-- TE Progress -->
+        <div class="space-y-0.5">
+          <div class="text-[7px] sm:text-[9px] font-black text-slate-400 uppercase tracking-wide sm:tracking-widest flex items-center gap-1 sm:gap-1.5">
+            <div class="w-1 h-1 rounded-full bg-emerald-500"></div>
+            TE Progress
+          </div>
+          <div class="flex items-baseline gap-1 sm:gap-1.5">
+            <span class="text-sm sm:text-xl font-mono-premium font-black text-slate-400">{{ summary.startTE }}</span>
+            <svg class="w-2 h-2 sm:w-3.5 sm:h-3.5 text-slate-200" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3" />
+            </svg>
+            <span class="text-base sm:text-2xl font-mono-premium font-black text-emerald-600">{{ summary.endTE }}</span>
+            <img :src="iconURL('egginc/egg_truth.png', 64)" class="w-3 h-3 sm:w-4 sm:h-4 ml-0.5" alt="TE" />
+          </div>
+          <div class="text-[8px] sm:text-[9px] font-black text-emerald-500/80 uppercase tracking-tight mt-0.5">+{{ summary.teGained }}</div>
+        </div>
+
+        <!-- Peak ELR -->
+        <div class="space-y-0.5">
+          <div class="text-[7px] sm:text-[9px] font-black text-slate-400 uppercase tracking-wide sm:tracking-widest flex items-center gap-1 sm:gap-1.5">
+            <div class="w-1 h-1 rounded-full bg-indigo-500"></div>
+            Peak ELR
+          </div>
+          <div class="flex items-center gap-1 sm:gap-1.5">
+            <span class="text-sm sm:text-xl font-mono-premium font-black text-indigo-600">{{ formatNumber(summary.maxELR * 3600, 3) }}</span>
+            <span class="text-[7px] sm:text-[9px] font-black text-slate-400 uppercase">/HR</span>
+          </div>
+          <div v-if="summary.alternativeELRs && summary.alternativeELRs.length > 0" class="flex flex-col gap-0.5 mt-0.5">
+            <div
+              v-for="alt in summary.alternativeELRs"
+              :key="alt.label"
+              class="flex items-baseline gap-1"
+            >
+              <span class="text-[9px] sm:text-[10px] font-mono-premium font-bold text-slate-400">{{ formatNumber(alt.elr * 3600, 3) }}</span>
+              <span class="text-[7px] sm:text-[8px] font-black text-slate-300 uppercase tracking-wide">/hr</span>
+              <span class="text-[7px] sm:text-[8px] font-black text-slate-400 uppercase tracking-wide">{{ alt.label }}</span>
+            </div>
+          </div>
+        </div>
+
+        <!-- Total Duration -->
+        <div class="space-y-0.5">
+          <div class="text-[7px] sm:text-[9px] font-black text-slate-400 uppercase tracking-wide sm:tracking-widest flex items-center gap-1 sm:gap-1.5">
+            <div class="w-1 h-1 rounded-full bg-indigo-600"></div>
+            Duration
+          </div>
+          <div class="flex items-center gap-1 sm:gap-1.5">
+            <span class="text-sm sm:text-xl font-mono-premium font-black text-indigo-600">{{ formatDuration(summary.totalDurationSeconds) }}</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Warnings -->
+      <div v-if="warnings.length > 0" class="mb-3 space-y-1">
+        <div v-for="warning in warnings" :key="warning" 
+             class="bg-amber-50 border border-amber-100 rounded-xl px-2.5 py-1.5 flex items-center gap-2 text-amber-600">
+          <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+          </svg>
+          <span class="text-[9px] font-black uppercase tracking-wider leading-tight">{{ warning }}</span>
+        </div>
+      </div>
+
+      <!-- Collapsible Detailed Breakdown Content -->
+      <div v-if="isExpanded" class="mt-2.5 border-t border-slate-100 pt-2.5 space-y-2 animate-in fade-in slide-in-from-top-4 duration-500">
+        <!-- SE Cost & Balance Grid -->
+        <div class="grid grid-cols-3 gap-x-1.5 sm:gap-x-4 gap-y-2 bg-slate-50/50 border border-slate-100 rounded-xl p-2 sm:p-3">
+          <!-- SE Cost -->
+          <div class="space-y-0.5">
+            <div class="text-[7px] sm:text-[9px] font-black text-slate-400 uppercase tracking-wide sm:tracking-widest flex items-center gap-1 sm:gap-1.5">
+              <div class="w-1 h-1 rounded-full bg-rose-500"></div>
+              SE Consumed
+            </div>
+            <div class="flex items-center gap-1 sm:gap-1.5">
+              <span class="text-sm sm:text-xl font-mono-premium font-black text-rose-600">{{ formatNumber(summary.totalShiftCost, 3) }}</span>
+              <img :src="iconURL('egginc/egg_soul.png', 32)" class="w-3 h-3 sm:w-4 sm:h-4 opacity-80" alt="SE" />
+            </div>
+          </div>
+
+          <!-- Ending SE Balance -->
+          <div class="space-y-0.5">
+            <div class="text-[7px] sm:text-[9px] font-black text-slate-400 uppercase tracking-wide sm:tracking-widest flex items-center gap-1 sm:gap-1.5">
+              <div class="w-1 h-1 rounded-full bg-slate-400"></div>
+              Ending SE Balance
+            </div>
+            <div class="flex items-center gap-1 sm:gap-1.5">
+              <span class="text-sm sm:text-xl font-mono-premium font-black" :class="summary.endSoulEggs < 0 ? 'text-rose-600' : 'text-slate-600'">
+                {{ formatNumber(summary.endSoulEggs, 3) }}
+              </span>
+              <img :src="iconURL('egginc/egg_soul.png', 32)" class="w-3 h-3 sm:w-4 sm:h-4 opacity-40" alt="SE" />
+            </div>
+            <div class="text-[7px] sm:text-[9px] font-black text-slate-400 uppercase tracking-tight">shift count: {{ summary.endShiftCount }}</div>
+          </div>
+
+          <!-- Total Eggs Delivered -->
+          <div class="space-y-0.5">
+            <div class="text-[7px] sm:text-[9px] font-black text-slate-400 uppercase tracking-wide sm:tracking-widest flex items-center gap-1 sm:gap-1.5">
+              <div class="w-1 h-1 rounded-full bg-slate-400"></div>
+              Eggs Delivered
+            </div>
+            <div class="flex items-center gap-1 sm:gap-1.5">
+              <span class="text-sm sm:text-xl font-mono-premium font-black text-slate-600">
+                {{ formatNumber(Object.values(summary.eggsDelivered).reduce((s, n) => s + n, 0), 3) }}
+              </span>
+            </div>
+          </div>
+        </div>
+
+        <!-- TE Breakdown -->
+        <div class="bg-slate-50/50 border border-slate-100 rounded-xl p-2 sm:p-3">
+          <div class="grid grid-cols-5 gap-1 sm:gap-2">
+            <div v-for="egg in eggs" :key="egg" class="flex flex-col items-center sm:flex-row sm:items-center gap-1 sm:gap-2 bg-white p-1 sm:p-1.5 rounded-lg border border-slate-200/50 shadow-sm">
+              <!-- Egg Icon -->
+              <div class="w-5 h-5 sm:w-12 sm:h-12 flex-shrink-0 bg-slate-50 rounded-md p-0.5 sm:p-1.5 border border-slate-100 shadow-inner">
+                <img :src="iconURL(`egginc/egg_${egg}.png`, 64)" class="w-full h-full object-contain" :alt="egg" />
+              </div>
+
+              <div class="space-y-0 sm:space-y-0.5 text-center sm:text-left">
+                <!-- TE Count -->
+                <div class="flex items-center justify-center sm:justify-start gap-0.5 sm:gap-1">
+                  <span class="text-[10px] sm:text-base font-mono-premium font-black text-slate-800 leading-none">
+                    {{ summary.finalTE[egg] || 0 }}
+                  </span>
+                  <span v-if="summary.teEarned[egg]" class="text-[7px] sm:text-[8px] font-black text-emerald-500 leading-none">
+                    (+{{ summary.teEarned[egg] }})
+                  </span>
+                </div>
+
+                <!-- Eggs Delivered -->
+                <div class="text-[7px] sm:text-[8px] font-bold text-slate-400 font-mono-premium leading-none">
+                  {{ formatNumber(summary.eggsDelivered[egg], 3) }}
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Shift List -->
+        <ShiftSummary
+          v-for="(shift, index) in shifts"
+          :key="index"
+          :title="shift.title"
+          :egg="shift.egg"
+          :actions="shift.actions"
+          :duration="shift.duration"
+          :cost="shift.cost"
+          :cost-type="shift.costType"
+          :start-time="shift.startTime"
+          :end-time="shift.endTime"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed } from 'vue';
+import { formatNumber, formatDuration } from '@/lib/format';
+import { iconURL } from 'lib';
+import type { AscensionSummary } from '@/auto/types';
+import type { VirtueEgg } from '@/types';
+import ShiftSummary from './ShiftSummary.vue';
+
+const props = defineProps<{
+  summary: AscensionSummary & {
+    comparison?: {
+      daysFaster: number;
+      otherPlanLabel: string;
+      message?: string;
+    };
+    comparisons?: {
+      daysFaster: number;
+      otherPlanLabel: string;
+      message?: string;
+    }[];
+    alternativeELRs?: {
+      elr: number;
+      label: string;
+    }[];
+  };
+  actions: any[];
+  index: number;
+  total: number;
+  targetTE: number | null;
+  result3Available?: boolean;
+}>();
+
+defineEmits<{
+  (e: 'forceModeChange', mode: 'continue' | 'prestige'): void;
+}>();
+
+const isExpanded = ref(false);
+const eggs: VirtueEgg[] = ['curiosity', 'integrity', 'humility', 'resilience', 'kindness'];
+
+const displayComparisons = computed(() => {  
+  if (props.summary.comparisons && props.summary.comparisons.length > 0) {
+    return props.summary.comparisons;
+  }
+  if (props.summary.comparison && props.summary.comparison.daysFaster > 0.01) {
+    return [props.summary.comparison];
+  }
+  return [];
+});
+
+const warnings = computed(() => {
+  const list: string[] = [];
+  if (props.summary.endSoulEggs < 0) {
+    list.push('Soul Egg balance will go negative. You may not be able to afford all shifts.');
+  }
+  if (props.summary.endTE < props.summary.startTE + 1) {
+    list.push('No TE gained during this ascension. Goal may be unreachable or already met.');
+  }
+  return list;
+});
+
+const shifts = computed(() => {
+  const actions = props.actions;
+  const ascStartTime = props.summary.startTime;
+  const shifts: any[] = [];
+  let absoluteTime = ascStartTime;
+
+  const isContinueCurrent = props.summary.strategyLabel === 'Continue current';
+  const startEgg = (actions[0]?.type === 'start_ascension' && actions[0]?.payload?.initialEgg) || 'curiosity';
+
+  let currentShift = {
+    title: isContinueCurrent
+      ? `${startEgg.charAt(0).toUpperCase() + startEgg.slice(1)} Shift`
+      : 'C1 Shift',
+    egg: startEgg,
+    actions: [] as any[],
+    duration: 0,
+    cost: 0,
+    costType: 'SE' as 'SE' | 'Virtue',
+    startTime: absoluteTime,
+    endTime: absoluteTime,
+  };
+
+  const titles = [
+    'C1 Shift', 'K1 Shift', 'I1 Shift', 
+    'C2 Shift', 'K2 Shift', 'R1 Shift', 
+    'C3 Shift', 'H1 Shift', 'K3 Shift', 
+    'C4 Shift', 'I2 Shift', 'R2 Shift', 
+    'H2 Shift',
+  ];
+  let shiftIndex = 0;
+
+  for (const action of actions) {
+    if (action.type === 'shift') {
+      if (currentShift.actions.length > 0) {
+        currentShift.endTime = absoluteTime;
+        shifts.push(currentShift);
+      }
+      shiftIndex++;
+      const nextEgg = action.payload.toEgg;
+      const title = isContinueCurrent
+        ? `${nextEgg.charAt(0).toUpperCase() + nextEgg.slice(1)} Shift`
+        : (titles[shiftIndex] || `${nextEgg.charAt(0).toUpperCase() + nextEgg.slice(1)} Shift`);
+
+      currentShift = {
+        title: title,
+        egg: nextEgg,
+        actions: [action],
+        duration: 0,
+        cost: action.cost || 0,
+        costType: 'SE',
+        startTime: absoluteTime,
+        endTime: absoluteTime,
+      };
+    } else {
+      currentShift.actions.push(action);
+      if (action.type.startsWith('wait_')) {
+        const dt = action.totalTimeSeconds || action.payload.totalTimeSeconds || action.payload.timeSeconds || 0;
+        currentShift.duration += dt;
+        absoluteTime += dt;
+      }
+    }
+  }
+
+  if (currentShift.actions.length > 0) {
+    currentShift.endTime = absoluteTime;
+    shifts.push(currentShift);
+  }
+
+  return shifts;
+});
+
+const formatTimeRange = (start: number, end: number) => {
+  const s = new Date(start * 1000);
+  const e = new Date(end * 1000);
+  
+  const options: Intl.DateTimeFormatOptions = { 
+    year: 'numeric',
+    month: 'short', 
+    day: 'numeric', 
+    hour: 'numeric', 
+    minute: '2-digit' 
+  };
+  
+  return `${s.toLocaleString('en-US', options)} — ${e.toLocaleString('en-US', options)}`;
+};
+</script>
+
+<style scoped>
+.font-mono-premium {
+  font-family: 'JetBrains Mono', 'Roboto Mono', monospace;
+}
+</style>

--- a/wasmegg/ascension-planner/src/components/auto/AutomaticPlanner.vue
+++ b/wasmegg/ascension-planner/src/components/auto/AutomaticPlanner.vue
@@ -70,6 +70,34 @@
           <span v-if="isGenerating">{{ generateProgress || 'Generating Plan...' }}</span>
           <span v-else>{{ ascensionChain.length > 0 ? 'Update Plan' : 'Generate Plan' }}</span>
         </button>
+
+        <div v-if="ascensionChain.length === 0" class="mt-4 p-4 bg-amber-50 border border-amber-200 rounded-xl text-xs text-amber-800 space-y-2">
+          <p class="font-bold uppercase tracking-wide text-amber-700">Before you generate — a few assumptions to know about</p>
+          <ul class="space-y-1.5 list-disc list-inside leading-relaxed">
+            <li><span class="font-semibold">Habs are always full.</span> To keep processing fast, Auto-AP assumes full habs throughout. Results are most reliable once you're around 100 TE and time to fill habs is negligible.</li>
+            <li><span class="font-semibold">Your artifacts don't improve.</span> The plan is built around whatever artifacts you have right now — it won't account for better gear you might find later.</li>
+            <li><span class="font-semibold">No downtime between ascensions.</span> Each ascension is assumed to start the moment the previous one ends.</li>
+            <li><span class="font-semibold">Only 1-sale and 2-sale builds are considered</span> — except for A1, where continuing your current ascension is also evaluated as an option.</li>
+            <li><span class="font-semibold">You never sleep.</span> Auto-AP doesn't do any accounting for sleep hours.</li>
+          </ul>
+          <p class="text-amber-600 leading-relaxed">Use this as a starting point, not a final word. Your actual results may vary.</p>
+
+          <div class="border-t border-amber-200 pt-3 mt-1">
+            <p class="font-bold uppercase tracking-wide text-amber-700 mb-2">Each ascension will have exactly this shift order:</p>
+            <ul class="space-y-1.5 list-disc list-inside leading-relaxed">
+              <li><span class="font-semibold">C1</span> — Spends up to 30 minutes with the primary target being fleet size and Graviton Coupling.</li>
+              <li><span class="font-semibold">K1</span> — Spends up to 30 minutes buying the best vehicles it can afford.</li>
+              <li><span class="font-semibold">I1</span> — Max Chicken Universes.</li>
+              <li><span class="font-semibold">C2</span> — Maxes fleet size research. If it can afford Graviton Coupling within 4 hours, it does.</li>
+              <li><span class="font-semibold">K2</span> — Max Vehicles and Hyperloop Train Cars.</li>
+              <li><span class="font-semibold">R1</span> — Buys as many silos as possible within one hour.</li>
+              <li><span class="font-semibold">C3</span> — Purchases remaining ELR-boosting research: lay rate, shipping capacity, and hab capacity.</li>
+              <li><span class="font-semibold">H1</span> — Swaps to the optimal artifact loadout for ELR.</li>
+              <li><span class="font-semibold">K3</span> — Buys new hyperloop cars unlocked by C3, then waits out the ascension until the TE goal is reached.</li>
+              <li><span class="font-semibold">C4 / I2 / R2 / H2</span> — Each shifts to its respective virtue egg and waits until that egg's share of the TE goal is met.</li>
+            </ul>
+          </div>
+        </div>
       </div>
     </div>
 

--- a/wasmegg/ascension-planner/src/components/auto/AutomaticPlanner.vue
+++ b/wasmegg/ascension-planner/src/components/auto/AutomaticPlanner.vue
@@ -167,7 +167,8 @@
             :total="visibleTotal"
             :target-t-e="result.targetTE"
             :result3-available="result.result3Available"
-            @force-mode-change="handleToggleForceMode"
+            :result3-skipped-reason="result.result3SkippedReason"
+            @set-plan-variant="(variant: 'continue' | '1-sale' | '2-sale') => handleSetPlanVariant(idx, variant)"
           />
         </template>
       </div>
@@ -276,7 +277,7 @@ const {
   copySummary,
   exportCurrentPlan,
   saveToLibrary,
-  handleToggleForceMode,
+  handleSetPlanVariant,
 } = useAscensionGenerator();
 
 const runGenerate = () => {

--- a/wasmegg/ascension-planner/src/components/auto/AutomaticPlanner.vue
+++ b/wasmegg/ascension-planner/src/components/auto/AutomaticPlanner.vue
@@ -1,0 +1,279 @@
+<template>
+  <div class="space-y-6">
+    <!-- Form Card -->
+    <div class="section-premium p-4 sm:p-8 max-w-4xl mx-auto mt-4 relative overflow-hidden">
+      <div class="absolute -right-20 -top-20 w-64 h-64 bg-indigo-500/5 rounded-full blur-3xl"></div>
+
+      <div class="relative z-10">
+        <div class="flex items-center gap-4 mb-8">
+          <div class="w-12 h-12 bg-indigo-600 rounded-2xl flex items-center justify-center text-white shadow-lg shadow-indigo-200">
+            <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z" />
+            </svg>
+          </div>
+          <h2 class="text-xl font-black text-slate-900 uppercase tracking-tight">Auto-AP</h2>
+        </div>
+
+        <div class="space-y-8 relative">
+          <!-- Generating overlay -->
+          <div
+            v-if="isGenerating"
+            class="absolute -inset-4 bg-white/60 backdrop-blur-[1px] z-50 flex items-center justify-center rounded-3xl transition-all duration-300"
+          >
+            <div class="flex items-center gap-3 bg-white px-6 py-3 rounded-2xl border border-indigo-100 shadow-xl shadow-indigo-500/10">
+              <div class="w-4 h-4 border-2 border-indigo-200 border-t-indigo-600 rounded-full animate-spin"></div>
+              <span class="text-[10px] font-black text-indigo-600 uppercase tracking-widest">Form locked while calculating...</span>
+            </div>
+          </div>
+
+          <div class="space-y-8">
+            <SchedulingInputs />
+            <VirtueProgressSection />
+
+            <!-- Ascension Targets -->
+            <div>
+              <div class="flex items-center gap-3 mb-4 px-1">
+                <div class="w-8 h-8 bg-indigo-100 rounded-lg flex items-center justify-center text-indigo-600">
+                  <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
+                  </svg>
+                </div>
+                <h3 class="text-xs font-black text-slate-700 uppercase tracking-wider">Ascension Targets</h3>
+              </div>
+              <div class="space-y-1.5">
+                <label class="text-[9px] font-black text-slate-500 uppercase tracking-widest px-1">Target TE(s)</label>
+                <div class="relative">
+                  <input
+                    ref="targetInput"
+                    v-model="targetTE"
+                    @input="handleTargetTEInput"
+                    @keydown.enter="runGenerate()"
+                    type="text"
+                    class="w-full bg-white border border-slate-200 rounded-xl px-4 py-2 text-sm font-black text-slate-900 outline-none focus:border-indigo-500/50 transition-all pr-10"
+                    placeholder="e.g. 300 400 490"
+                  />
+                  <div class="absolute right-3 top-1/2 -translate-y-1/2 text-slate-300 font-black text-[10px]">TE</div>
+                </div>
+                <p class="text-[10px] font-bold text-slate-400 leading-relaxed px-1 mt-2">
+                  Enter a sequence of target TEs separated by spaces to generate an entire multi-ascension chain at once.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <button
+          class="btn-premium btn-primary w-full py-4 mt-8 text-sm shadow-xl shadow-indigo-500/20 active:scale-[0.98]"
+          :disabled="isGenerating || !isA1Dirty"
+          @click="runGenerate()"
+        >
+          <span v-if="isGenerating">{{ generateProgress || 'Generating Plan...' }}</span>
+          <span v-else>{{ ascensionChain.length > 0 ? 'Update Plan' : 'Generate Plan' }}</span>
+        </button>
+      </div>
+    </div>
+
+    <!-- Results Section -->
+    <div v-if="ascensionChain.length > 0" class="max-w-4xl mx-auto space-y-6 pb-24 relative px-4 sm:px-0">
+      <div class="flex flex-col sm:flex-row justify-between items-center gap-4 px-4">
+        <h2 class="text-lg font-black text-slate-800 uppercase tracking-tight">Generated Roadmap</h2>
+        <div class="flex flex-wrap justify-center items-center gap-3">
+          <button
+            @click="copySummary"
+            :disabled="isGenerating"
+            class="flex items-center gap-2 px-6 py-2.5 bg-white border border-slate-200 hover:border-indigo-300 hover:text-indigo-600 text-slate-600 text-[10px] font-black uppercase tracking-widest rounded-xl transition-all shadow-sm active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:border-slate-200 disabled:hover:text-slate-600"
+          >
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 5H6a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2v-1M8 5a2 2 0 002 2h2a2 2 0 002-2M8 5a2 2 0 012-2h2a2 2 0 012 2m0 0h2a2 2 0 012 2v3m2 4H10m0 0l3-3m-3 3l3 3" />
+            </svg>
+            {{ copySuccess ? 'Copied!' : 'Copy Summary' }}
+          </button>
+          <button
+            @click="saveToLibrary"
+            :disabled="isGenerating || isSavingToLibrary"
+            class="flex items-center gap-2 px-6 py-2.5 bg-white border border-slate-200 hover:border-indigo-300 hover:text-indigo-600 text-slate-600 text-[10px] font-black uppercase tracking-widest rounded-xl transition-all shadow-sm active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:border-slate-200 disabled:hover:text-slate-600"
+          >
+            <svg v-if="isSavingToLibrary" class="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
+              <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
+              <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+            </svg>
+            <svg v-else-if="saveToLibrarySuccess" class="w-4 h-4 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+            </svg>
+            <svg v-else class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7H5a2 2 0 00-2 2v9a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-3m-1 4l-3 3m0 0l-3-3m3 3V4" />
+            </svg>
+            {{ isSavingToLibrary ? 'Saving...' : saveToLibrarySuccess ? 'Saved!' : 'Save to Library' }}
+          </button>
+          <button
+            @click="exportCurrentPlan"
+            :disabled="isGenerating || isExporting"
+            class="flex items-center gap-2 px-6 py-2.5 bg-indigo-600 hover:bg-indigo-700 text-white text-[10px] font-black uppercase tracking-widest rounded-xl transition-all shadow-lg shadow-indigo-100 active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-indigo-600"
+          >
+            <svg v-if="isExporting" class="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
+              <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
+              <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+            </svg>
+            <svg v-else class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a2 2 0 002 2h12a2 2 0 002-2v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+            </svg>
+            {{ isExporting ? 'Exporting...' : 'Export Plan' }}
+          </button>
+        </div>
+      </div>
+
+      <div class="space-y-4">
+        <template v-for="(result, idx) in bestResults" :key="idx">
+          <ForcedAscensionPreview
+            v-if="ascensionChain[idx]?.forcedTarget490"
+            :result1="ascensionChain[idx].result1"
+            :result2="ascensionChain[idx].result2"
+            :index="idx"
+            :total="visibleTotal"
+          />
+          <AscensionOverview
+            v-else
+            :summary="result.summary"
+            :actions="result.actions"
+            :index="idx"
+            :total="visibleTotal"
+            :target-t-e="result.targetTE"
+            :result3-available="result.result3Available"
+            @force-mode-change="handleToggleForceMode"
+          />
+        </template>
+      </div>
+
+      <SimulationErrorAlert v-if="simulationError" :message="simulationError" />
+    </div>
+
+    <ChainSummaryBar :is-collapsed="isCollapsed" @toggle="isCollapsed = !isCollapsed" />
+
+    <!-- Floating Progress Indicator -->
+    <div
+      v-if="isGenerating"
+      class="fixed right-8 z-[200] bg-slate-900/90 text-white backdrop-blur-md border border-slate-700/50 px-6 py-4 rounded-2xl shadow-2xl shadow-indigo-500/20 flex items-center gap-4 animate-in fade-in slide-in-from-bottom-6 duration-300 transition-[bottom] duration-500"
+      :class="[ascensionChain.length >= 1 && !isCollapsed ? 'bottom-32' : 'bottom-8']"
+    >
+      <div class="w-6 h-6 border-3 border-indigo-400/30 border-t-indigo-400 rounded-full animate-spin"></div>
+      <div class="space-y-0.5 pr-2">
+        <div class="text-[10px] font-black uppercase tracking-widest text-indigo-400">Updating Roadmap</div>
+        <div class="text-xs font-bold text-slate-200 font-mono-premium">{{ generateProgress || 'Calculating...' }}</div>
+      </div>
+    </div>
+
+    <ValidationDialog
+      :is-open="isValidationErrorOpen"
+      :message="validationErrorMessage"
+      @close="isValidationErrorOpen = false"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch, nextTick } from 'vue';
+import { storeToRefs } from 'pinia';
+import { useAutoPlannerStore } from '@/stores/autoPlanner';
+import { useVirtueStore } from '@/stores/virtue';
+import { useTruthEggsStore } from '@/stores/truthEggs';
+import { useAscensionGenerator } from '@/auto/useAscensionGenerator';
+import SchedulingInputs from './SchedulingInputs.vue';
+import VirtueProgressSection from './VirtueProgressSection.vue';
+import ChainSummaryBar from './ChainSummaryBar.vue';
+import SimulationErrorAlert from './SimulationErrorAlert.vue';
+import AscensionOverview from './AscensionOverview.vue';
+import ForcedAscensionPreview from './ForcedAscensionPreview.vue';
+import ValidationDialog from './ValidationDialog.vue';
+
+const autoPlannerStore = useAutoPlannerStore();
+const virtueStore = useVirtueStore();
+const truthEggsStore = useTruthEggsStore();
+
+const { ascensionChain, timezone, startDate, startTime, targetTE } = storeToRefs(autoPlannerStore);
+
+// The forced-490 ascension is a silent bonus card — don't count it in the "A1 of N" denominator.
+const visibleTotal = computed(() => {
+  const chain = ascensionChain.value;
+  const lastIsForced = chain.length > 0 && !!chain[chain.length - 1].forcedTarget490;
+  return chain.length - (lastIsForced ? 1 : 0);
+});
+const targetInput = ref<HTMLInputElement | null>(null);
+const isCollapsed = ref(typeof window !== 'undefined' ? window.innerWidth < 768 : false);
+
+// Initialize timezone default
+if (!timezone.value) {
+  timezone.value = virtueStore.ascensionTimezone || Intl.DateTimeFormat().resolvedOptions().timeZone;
+}
+
+// Initialize start date/time defaults
+const now = new Date();
+if (!startDate.value) {
+  startDate.value = new Intl.DateTimeFormat('en-CA', { timeZone: timezone.value }).format(now);
+}
+if (!startTime.value) {
+  startTime.value = new Intl.DateTimeFormat('en-GB', {
+    timeZone: timezone.value,
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  }).format(now);
+}
+
+// Initialize Target TE to current + 30 once store data loads
+let targetTEInitialized = false;
+watch(
+  () => truthEggsStore.totalTE,
+  newVal => {
+    if (newVal > 0 && !targetTEInitialized) {
+      if (!targetTE.value) targetTE.value = String(Math.min(490, newVal + 30));
+      targetTEInitialized = true;
+    }
+  },
+  { immediate: true }
+);
+
+const {
+  isGenerating,
+  isExporting,
+  isSavingToLibrary,
+  saveToLibrarySuccess,
+  generateProgress,
+  simulationError,
+  isValidationErrorOpen,
+  validationErrorMessage,
+  copySuccess,
+  isA1Dirty,
+  bestResults,
+  generate,
+  copySummary,
+  exportCurrentPlan,
+  saveToLibrary,
+  handleToggleForceMode,
+} = useAscensionGenerator();
+
+const runGenerate = () => {
+  console.clear();
+  generate(() => nextTick(() => targetInput.value?.focus()));
+};
+
+const handleTargetTEInput = (e: Event) => {
+  const input = e.target as HTMLInputElement;
+  const formatted = input.value.replace(/\D+/g, ' ');
+  targetTE.value = formatted.replace(/^\s+/, '').replace(/\s{2,}/g, ' ');
+};
+</script>
+
+<style scoped>
+.btn-premium {
+  @apply rounded-2xl font-black uppercase tracking-[0.2em] transition-all duration-300 flex items-center justify-center gap-3;
+}
+.btn-primary {
+  @apply bg-indigo-600 text-white hover:bg-indigo-700 shadow-lg shadow-indigo-200 active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed;
+}
+.section-premium {
+  @apply bg-white rounded-[3rem] border border-slate-100 shadow-sm hover:shadow-2xl hover:shadow-slate-200/50 transition-all duration-700;
+}
+.font-mono-premium {
+  font-family: 'JetBrains Mono', 'Roboto Mono', monospace;
+}
+</style>

--- a/wasmegg/ascension-planner/src/components/auto/AutomaticPlanner.vue
+++ b/wasmegg/ascension-planner/src/components/auto/AutomaticPlanner.vue
@@ -168,7 +168,10 @@
             :target-t-e="result.targetTE"
             :result3-available="result.result3Available"
             :result3-skipped-reason="result.result3SkippedReason"
+            :is-saving-single="savingIndex === idx"
+            :save-single-success="savedIndex === idx"
             @set-plan-variant="(variant: 'continue' | '1-sale' | '2-sale') => handleSetPlanVariant(idx, variant)"
+            @save-single-to-library="saveSingleAscensionToLibrary(idx)"
           />
         </template>
       </div>
@@ -277,6 +280,9 @@ const {
   copySummary,
   exportCurrentPlan,
   saveToLibrary,
+  savingIndex,
+  savedIndex,
+  saveSingleAscensionToLibrary,
   handleSetPlanVariant,
 } = useAscensionGenerator();
 

--- a/wasmegg/ascension-planner/src/components/auto/ChainSummaryBar.vue
+++ b/wasmegg/ascension-planner/src/components/auto/ChainSummaryBar.vue
@@ -1,0 +1,195 @@
+<template>
+  <div
+    v-if="ascensionChain.length >= 1"
+    class="fixed bottom-0 left-0 right-0 z-[1000] bg-white/95 backdrop-blur-xl border-t border-slate-100 shadow-[0_-8px_32px_rgba(0,0,0,0.06)] transition-transform duration-500"
+    :class="[isCollapsed ? 'translate-y-full' : 'translate-y-0']"
+  >
+    <button
+      @click="$emit('toggle')"
+      class="absolute -top-8 right-6 bg-white/95 backdrop-blur-xl border border-b-0 border-slate-100 px-3 py-1 rounded-t-lg shadow-sm text-slate-500 hover:text-slate-800 transition-colors flex items-center gap-1 text-[10px] font-black uppercase tracking-wider h-8"
+    >
+      <svg
+        class="w-4 h-4 transition-transform duration-300"
+        :class="{ 'rotate-180': !isCollapsed }"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+      >
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 15l7-7 7 7" />
+      </svg>
+    </button>
+
+    <div class="max-w-7xl mx-auto px-3 py-2 sm:px-6 sm:py-4 flex flex-wrap justify-between items-center gap-x-3 gap-y-2 sm:gap-6">
+      <div class="summary-item">
+        <span class="summary-label">Start Date</span>
+        <span class="summary-value text-slate-900">{{ totals.startDateStr }}</span>
+      </div>
+      <div class="summary-item">
+        <span class="summary-label">Ascensions</span>
+        <span class="summary-value font-mono-premium font-black text-slate-600">{{ totals.count }}</span>
+      </div>
+      <div
+        class="summary-item cursor-pointer hover:bg-slate-50 p-2 -mx-2 -my-2 rounded-xl transition-colors duration-200 group"
+        @click="showTeModal = true"
+      >
+        <span class="summary-label group-hover:text-indigo-400 transition-colors">TE Progress</span>
+        <div class="flex items-center gap-2">
+          <span class="summary-value font-mono-premium font-black text-indigo-600 group-hover:text-indigo-700 transition-colors">+{{ totals.teGained }}</span>
+          <span class="hidden sm:inline text-[10px] font-black text-slate-400 uppercase tracking-widest bg-slate-50 group-hover:bg-indigo-50 px-2 py-0.5 rounded-full border border-slate-100 group-hover:border-indigo-100 transition-colors">
+            ({{ totals.startTE }} → {{ totals.endTE }})
+          </span>
+        </div>
+      </div>
+      <div class="summary-item">
+        <span class="summary-label">Duration</span>
+        <span class="summary-value font-mono-premium font-black text-slate-600">{{ totals.durationStr }}</span>
+      </div>
+      <div class="summary-item">
+        <span class="summary-label">End Date</span>
+        <span class="summary-value text-slate-900">{{ totals.endDateStr }}</span>
+      </div>
+      <div class="summary-item">
+        <span class="summary-label">Shifts</span>
+        <div class="flex items-center gap-2">
+          <span class="summary-value font-mono-premium font-black text-slate-600">+{{ totals.shiftsTotal }}</span>
+          <span class="hidden sm:inline text-[10px] font-black text-slate-400 uppercase tracking-widest bg-slate-50 px-2 py-0.5 rounded-full border border-slate-100 font-mono-premium">
+            (#{{ totals.startShifts }} → #{{ totals.endShifts }})
+          </span>
+        </div>
+      </div>
+      <div class="summary-item">
+        <span class="summary-label">Soul Eggs</span>
+        <div class="flex items-center gap-2">
+          <span class="summary-value font-mono-premium font-black text-rose-500" v-tippy="'SE Consumed'">
+            -{{ formatNumber(totals.totalSEConsumed, 1) }}
+          </span>
+          <div class="hidden sm:flex flex-col justify-center border-l border-slate-100 pl-2 h-7 opacity-80" v-tippy="'Remaining SE'">
+            <div class="text-[8px] font-black leading-none text-slate-400 mb-1 uppercase tracking-widest">Remaining</div>
+            <div class="text-[11px] font-black leading-none text-slate-700 font-mono-premium flex items-center gap-1">
+              {{ formatNumber(totals.remainingSE, 1) }}
+              <img :src="iconURL('egginc/egg_soul.png', 32)" class="w-3 h-3" alt="SE" />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <TeBreakdownModal :show="showTeModal" :stats="teStatsList" @close="showTeModal = false" />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import { storeToRefs } from 'pinia';
+import { useAutoPlannerStore } from '@/stores/autoPlanner';
+import { useInitialStateStore } from '@/stores/initialState';
+import { formatNumber } from '@/lib/format';
+import { iconURL } from 'lib';
+import { VIRTUE_EGGS } from '@/types/actions/virtue';
+import TeBreakdownModal from '@/components/TeBreakdownModal.vue';
+
+defineProps<{ isCollapsed: boolean }>();
+defineEmits<{ toggle: [] }>();
+
+const { ascensionChain, timezone } = storeToRefs(useAutoPlannerStore());
+const initialStateStore = useInitialStateStore();
+
+const showTeModal = ref(false);
+
+function formatDateOnly(timestampSeconds: number, tz: string): string {
+  if (!timestampSeconds) return 'N/A';
+  const date = new Date(timestampSeconds * 1000);
+  if (isNaN(date.getTime())) return 'N/A';
+  return date.toLocaleDateString('en-US', {
+    weekday: 'short', month: 'short', day: 'numeric', year: 'numeric', timeZone: tz,
+  });
+}
+
+const totals = computed(() => {
+  // Exclude any silently-injected forced-490 ascension from all footer totals.
+  const visibleChain = ascensionChain.value.filter(item => !item.forcedTarget490);
+  const plans = visibleChain.map(item => {
+    const candidates = [item.result1, item.result2, ...(item.result3 ? [item.result3] : [])];
+    return candidates.reduce((a, b) => (a.summary.totalDurationSeconds <= b.summary.totalDurationSeconds ? a : b)).summary;
+  });
+
+  if (plans.length === 0) {
+    return {
+      count: 0, startTE: 0, endTE: 0, teGained: 0,
+      startDateStr: 'N/A', endDateStr: 'N/A', durationStr: '—',
+      totalSEConsumed: 0, remainingSE: 0, shiftsTotal: 0, startShifts: 0, endShifts: 0,
+    };
+  }
+
+  const startTE = plans[0].startTE;
+  const endTE = plans[plans.length - 1].endTE;
+  const totalSeconds = plans.reduce((sum, p) => sum + p.totalDurationSeconds, 0);
+  const days = Math.floor(totalSeconds / 86400);
+  const hours = Math.floor((totalSeconds % 86400) / 3600);
+
+  return {
+    count: plans.length,
+    startTE,
+    endTE,
+    teGained: endTE - startTE,
+    startDateStr: formatDateOnly(plans[0].startTime, timezone.value),
+    endDateStr: formatDateOnly(plans[plans.length - 1].endTime, timezone.value),
+    durationStr: days > 0 ? `${days}d ${hours}h` : `${hours}h`,
+    totalSEConsumed: plans.reduce((sum, p) => sum + (p.startSoulEggs - p.endSoulEggs), 0),
+    remainingSE: plans[plans.length - 1].endSoulEggs,
+    shiftsTotal: plans.reduce((sum, p) => sum + (p.endShiftCount - p.startShiftCount), 0),
+    startShifts: plans[0].startShiftCount,
+    endShifts: plans[plans.length - 1].endShiftCount,
+  };
+});
+
+const teStatsList = computed(() => {
+  const visibleChain = ascensionChain.value.filter(item => !item.forcedTarget490);
+  if (visibleChain.length === 0) return [];
+
+  const plans = visibleChain.map(item => {
+    const candidates = [item.result1, item.result2, ...(item.result3 ? [item.result3] : [])];
+    return candidates.reduce((a, b) => (a.summary.totalDurationSeconds <= b.summary.totalDurationSeconds ? a : b)).summary;
+  });
+
+  const lastPlan = plans[plans.length - 1];
+
+  const totalDelivered = VIRTUE_EGGS.reduce((sum, egg) => sum + (lastPlan.eggsDelivered[egg] || 0), 0);
+  const initialTotal = Object.values(initialStateStore.initialTeEarned).reduce((sum, val) => sum + val, 0);
+
+  const stats = [
+    {
+      id: 'truth',
+      name: 'Total TE',
+      start: initialTotal,
+      end: lastPlan.endTE,
+      delta: lastPlan.endTE - initialTotal,
+      icon: iconURL('egginc/egg_truth.png', 64),
+      delivered: totalDelivered,
+    },
+  ];
+
+  for (const egg of VIRTUE_EGGS) {
+    const start = initialStateStore.initialTeEarned[egg] || 0;
+    const end = lastPlan.finalTE[egg] || 0;
+    stats.push({
+      id: egg,
+      name: egg.charAt(0).toUpperCase() + egg.slice(1),
+      start,
+      end,
+      delta: end - start,
+      icon: iconURL(`egginc/egg_${egg}.png`, 64),
+      delivered: lastPlan.eggsDelivered[egg] || 0,
+    });
+  }
+
+  return stats;
+});
+</script>
+
+<style scoped>
+.font-mono-premium { font-family: 'JetBrains Mono', 'Roboto Mono', monospace; }
+.summary-item { @apply flex flex-col gap-0.5 sm:gap-1; }
+.summary-label { @apply text-[7px] sm:text-[9px] font-black text-slate-400 uppercase tracking-wider sm:tracking-[0.2em] leading-none; }
+.summary-value { @apply text-[10px] sm:text-[13px] font-bold tracking-tight whitespace-nowrap; }
+</style>

--- a/wasmegg/ascension-planner/src/components/auto/ForcedAscensionPreview.vue
+++ b/wasmegg/ascension-planner/src/components/auto/ForcedAscensionPreview.vue
@@ -1,0 +1,63 @@
+<template>
+  <div class="bg-white rounded-xl sm:rounded-2xl p-3.5 sm:p-4 text-slate-900 relative overflow-hidden shadow-md border border-violet-100">
+    <!-- Background accents -->
+    <div class="absolute -right-20 -top-20 w-64 h-64 bg-violet-500/5 rounded-full blur-3xl"></div>
+    <div class="absolute -left-20 -bottom-20 w-64 h-64 bg-indigo-500/5 rounded-full blur-3xl"></div>
+
+    <div class="relative z-10">
+      <!-- Header -->
+      <div class="flex items-center gap-2.5 sm:gap-3 mb-4">
+        <div class="w-7 h-7 sm:w-8 sm:h-8 bg-gradient-to-br from-violet-500 to-violet-600 rounded-lg sm:rounded-xl flex items-center justify-center shadow-md shadow-violet-100/50 flex-shrink-0">
+          <svg class="w-4 h-4 sm:w-5 sm:h-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+          </svg>
+        </div>
+        <div>
+          <div class="flex items-baseline gap-2">
+            <h3 class="text-base sm:text-lg font-black uppercase tracking-tight text-slate-800 leading-none">
+              Next Ascension preview
+            </h3>
+          </div>
+        </div>
+      </div>
+
+      <!-- Peak ELR row -->
+      <div class="flex items-center gap-3 mb-4 px-1">
+        <span class="text-[9px] font-black text-slate-400 uppercase tracking-widest">Peak ELR</span>
+        <div class="flex items-center gap-1.5">
+          <span class="text-[9px] font-black text-slate-500 uppercase tracking-wider">1-sale</span>
+          <span class="text-[13px] font-mono-premium font-black text-indigo-600">
+            {{ formatNumber(result1.summary.maxELR * 3600, 3) }}
+          </span>
+          <span class="text-[9px] font-black text-slate-400">/hr</span>
+        </div>
+        <div class="w-px h-4 bg-slate-200"></div>
+        <div class="flex items-center gap-1.5">
+          <span class="text-[9px] font-black text-slate-500 uppercase tracking-wider">2-sale</span>
+          <span class="text-[13px] font-mono-premium font-black text-indigo-600">
+            {{ formatNumber(result2.summary.maxELR * 3600, 3) }}
+          </span>
+          <span class="text-[9px] font-black text-slate-400">/hr</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { formatNumber } from '@/lib/format';
+import type { AscensionSummary } from '@/auto/types';
+import type { Action } from '@/types/actions/meta';
+
+defineProps<{
+  result1: { summary: AscensionSummary; actions: Action[] };
+  result2: { summary: AscensionSummary; actions: Action[] };
+  index: number;
+  total: number;
+}>();
+</script>
+
+<style scoped>
+.font-mono-premium { font-family: 'JetBrains Mono', 'Roboto Mono', monospace; }
+</style>

--- a/wasmegg/ascension-planner/src/components/auto/SchedulingInputs.vue
+++ b/wasmegg/ascension-planner/src/components/auto/SchedulingInputs.vue
@@ -1,0 +1,79 @@
+<template>
+  <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
+    <div class="space-y-2">
+      <label class="text-[10px] font-black text-slate-500 uppercase tracking-widest ml-1">Start Time</label>
+      <div class="flex gap-3">
+        <input
+          v-model="startDate"
+          type="date"
+          :min="formatUnixToDateInput(Date.now() / 1000 - 86400 * 7, timezone)"
+          class="flex-grow bg-slate-50 border border-slate-200 rounded-xl px-4 py-2.5 text-xs font-bold text-slate-700 outline-none focus:border-indigo-500/50 focus:bg-white transition-all"
+        />
+        <input
+          v-model="startTime"
+          type="time"
+          class="w-32 bg-slate-50 border border-slate-200 rounded-xl px-4 py-2.5 text-xs font-bold text-slate-700 outline-none focus:border-indigo-500/50 focus:bg-white transition-all"
+        />
+      </div>
+    </div>
+
+    <div class="space-y-2">
+      <label class="text-[10px] font-black text-slate-500 uppercase tracking-widest ml-1">Timezone</label>
+      <div class="flex gap-2">
+        <div class="relative flex-grow">
+          <select
+            v-model="timezone"
+            class="w-full bg-slate-50 border border-slate-200 rounded-xl pl-5 pr-10 py-2.5 text-xs font-bold text-slate-700 outline-none focus:border-indigo-500/50 focus:bg-white transition-all"
+          >
+            <option v-for="tz in allTimezones" :key="tz.value" :value="tz.value">
+              {{ tz.label }}
+            </option>
+          </select>
+        </div>
+        <button
+          @click="setStartTimeToNow"
+          class="px-4 py-2 bg-indigo-600 hover:bg-indigo-700 text-white text-[10px] font-black uppercase tracking-widest rounded-xl transition-all shadow-md shadow-indigo-100 flex items-center justify-center active:scale-95 whitespace-nowrap"
+        >
+          Now
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import { storeToRefs } from 'pinia';
+import { useAutoPlannerStore } from '@/stores/autoPlanner';
+import { formatUnixToDateInput, formatUnixToTimeInput } from '@/lib/format';
+
+const { startDate, startTime, timezone } = storeToRefs(useAutoPlannerStore());
+
+const setStartTimeToNow = () => {
+  const nowUnix = Date.now() / 1000;
+  startDate.value = formatUnixToDateInput(nowUnix, timezone.value);
+  startTime.value = formatUnixToTimeInput(nowUnix, timezone.value);
+};
+
+const allTimezones = computed(() => {
+  try {
+    const zones = Intl.supportedValuesOf('timeZone');
+    return zones
+      .map(tz => {
+        const parts = tz.split('/');
+        const city = parts[parts.length - 1].replace(/_/g, ' ');
+        const region = parts.length > 1 ? parts[0] : '';
+        return { value: tz, label: region ? `${city} (${region})` : city, region, city };
+      })
+      .sort((a, b) => {
+        if (a.region !== b.region) return a.region.localeCompare(b.region);
+        return a.city.localeCompare(b.city);
+      });
+  } catch {
+    return [
+      { value: 'America/Los_Angeles', label: 'Los Angeles (America)', region: 'America', city: 'Los Angeles' },
+      { value: 'UTC', label: 'UTC', region: '', city: 'UTC' },
+    ];
+  }
+});
+</script>

--- a/wasmegg/ascension-planner/src/components/auto/SchedulingInputs.vue
+++ b/wasmegg/ascension-planner/src/components/auto/SchedulingInputs.vue
@@ -7,12 +7,12 @@
           v-model="startDate"
           type="date"
           :min="formatUnixToDateInput(Date.now() / 1000 - 86400 * 7, timezone)"
-          class="flex-grow bg-slate-50 border border-slate-200 rounded-xl px-4 py-2.5 text-xs font-bold text-slate-700 outline-none focus:border-indigo-500/50 focus:bg-white transition-all"
+          class="flex-grow bg-slate-50 border border-slate-200 rounded-xl px-4 py-2.5 text-xs font-bold text-slate-700 outline-none focus:border-indigo-500/50 bg-white transition-all"
         />
         <input
           v-model="startTime"
           type="time"
-          class="w-32 bg-slate-50 border border-slate-200 rounded-xl px-4 py-2.5 text-xs font-bold text-slate-700 outline-none focus:border-indigo-500/50 focus:bg-white transition-all"
+          class="w-32 bg-slate-50 border border-slate-200 rounded-xl px-4 py-2.5 text-xs font-bold text-slate-700 outline-none focus:border-indigo-500/50 bg-white transition-all"
         />
       </div>
     </div>
@@ -23,7 +23,7 @@
         <div class="relative flex-grow">
           <select
             v-model="timezone"
-            class="w-full bg-slate-50 border border-slate-200 rounded-xl pl-5 pr-10 py-2.5 text-xs font-bold text-slate-700 outline-none focus:border-indigo-500/50 focus:bg-white transition-all"
+            class="w-full bg-slate-50 border border-slate-200 rounded-xl pl-5 pr-10 py-2.5 text-xs font-bold text-slate-700 outline-none focus:border-indigo-500/50 bg-white transition-all"
           >
             <option v-for="tz in allTimezones" :key="tz.value" :value="tz.value">
               {{ tz.label }}

--- a/wasmegg/ascension-planner/src/components/auto/ShiftSummary.vue
+++ b/wasmegg/ascension-planner/src/components/auto/ShiftSummary.vue
@@ -1,0 +1,405 @@
+<template>
+  <div class="bg-white rounded-xl border border-slate-100 p-2.5 sm:p-3 shadow-sm">
+    <div class="grid grid-cols-2 items-center gap-y-0.5 sm:flex sm:items-center sm:justify-between mb-1.5">
+      <!-- Col 1 Row 1 / Desktop left: icon + shift name -->
+      <div class="flex items-center gap-2">
+        <div class="w-5 h-5 rounded-md flex items-center justify-center" :class="eggTheme.bg">
+          <svg class="w-3.5 h-3.5" :class="eggTheme.text" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M19.428 15.428a2 2 0 00-1.022-.547l-2.387-.477a6 6 0 00-3.86.517l-.675.337a4 4 0 01-2.574.338L6.5 15.1l-1.5-1.5 1.5-1.5 2.414.483a2 2 0 001.287-.169l.675-.337a8 8 0 015.147-.69l2.387.477a2 2 0 001.022.547l1.718.344a2 2 0 011.414 1.414l.344 1.718a2 2 0 01-.547 1.022l-1.5 1.5-1.5-1.5.483-2.414a2 2 0 00-.169-1.287l-.337-.675a8 8 0 00-.69-5.147l.477-2.387a2 2 0 00-.547-1.022l-1.718-.344a2 2 0 00-1.414-1.414l-1.718-.344a2 2 0 00-1.022.547l-1.5 1.5 1.5 1.5.483-2.414a2 2 0 011.287-.169l.675.337a8 8 0 01.69 5.147l-.477 2.387a2 2 0 01.547 1.022l1.718.344a2 2 0 011.414 1.414l.344 1.718a2 2 0 01-.547 1.022l-1.5 1.5z"
+            />
+          </svg>
+        </div>
+        <span class="text-[9px] font-black text-slate-400 uppercase tracking-[0.1em]">{{ title }}</span>
+      </div>
+
+      <!-- Col 2 Row 1 (mobile only): Duration, right-aligned -->
+      <div class="flex justify-end items-center text-[9px] font-black text-slate-400 sm:hidden">
+        <span
+          v-tippy="{ content: timeTooltipContent, allowHTML: true }"
+          class="cursor-help border-b border-dashed border-slate-300/50 transition-colors"
+        >
+          {{ formatDuration(duration) }}
+        </span>
+      </div>
+
+      <!-- Col 1 Row 2 (mobile only): SE cost, left-aligned -->
+      <div class="flex items-center gap-1 text-[9px] font-black text-slate-400 sm:hidden">
+        <span>{{ formatNumber(cost, 3) }}</span>
+        <img v-if="costType === 'SE'" :src="iconURL('egginc/egg_soul.png', 32)" class="w-3 h-3 opacity-40" alt="SE" />
+      </div>
+
+      <!-- Col 2 Row 2 (mobile only): Eggs delivered, right-aligned -->
+      <div class="flex justify-end items-center gap-1 text-[9px] font-black text-slate-500 sm:hidden">
+        <template v-if="totalEggsLaid > 0">
+          <span>{{ formatNumber(totalEggsLaid, 3) }}</span>
+          <span class="text-[7.5px] opacity-60">EGGS</span>
+        </template>
+      </div>
+
+      <!-- Desktop only: full right-side row with dot separators (unchanged) -->
+      <div class="hidden sm:flex items-center gap-2 text-[9px] font-black text-slate-400">
+        <span
+          v-tippy="{ content: timeTooltipContent, allowHTML: true }"
+          class="cursor-help border-b border-dashed border-slate-300/50 hover:text-slate-500 hover:border-slate-400 transition-colors"
+        >
+          {{ formatDuration(duration) }}
+        </span>
+        <span class="w-1 h-1 bg-slate-200 rounded-full"></span>
+        <div class="flex items-center gap-1">
+          <span>{{ formatNumber(cost, 3) }}</span>
+          <img v-if="costType === 'SE'" :src="iconURL('egginc/egg_soul.png', 32)" class="w-3 h-3 opacity-40" alt="SE" />
+        </div>
+        <template v-if="totalEggsLaid > 0">
+          <span class="w-1 h-1 bg-slate-200 rounded-full"></span>
+          <div class="flex items-center gap-1 text-slate-500">
+            <span>{{ formatNumber(totalEggsLaid, 3) }}</span>
+            <span class="text-[7.5px] opacity-60">EGGS</span>
+          </div>
+        </template>
+      </div>
+    </div>
+
+    <div v-if="summaryItems.length > 0" class="flex flex-wrap gap-1">
+      <div v-for="(item, index) in summaryItems" :key="index" class="flex items-center">
+        <template v-if="item.isPremium">
+          <span
+            class="badge-premium px-1.5 py-0.5 text-[8.5px] font-black tracking-tight"
+            :class="eggTheme.badge"
+          >
+            {{ item.text }}
+          </span>
+        </template>
+        <template v-else-if="item.isPeakELR">
+          <div
+            class="flex items-center gap-1 px-1.5 py-0.5 rounded border transition-all duration-500"
+            :class="item.isOvertake ? 'bg-amber-50 border-amber-100' : 'bg-indigo-50 border-indigo-100'"
+          >
+            <div
+              class="w-1.5 h-1.5 rounded-full animate-pulse"
+              :class="item.isOvertake ? 'bg-amber-500' : 'bg-indigo-500'"
+            ></div>
+            <span
+              class="text-[8.5px] font-black tracking-tighter"
+              :class="item.isOvertake ? 'text-amber-700' : 'text-indigo-700'"
+            >
+              {{ item.text }}
+            </span>
+          </div>
+        </template>
+        <template v-else>
+          <div class="flex items-center gap-1 bg-slate-50 border border-slate-100 px-1.5 py-0.5 rounded">
+            <span class="text-[8.5px] font-bold text-slate-600">{{ item.name }}</span>
+            <span class="text-[8.5px] font-black text-indigo-500 tracking-tighter">{{ item.delta }}</span>
+          </div>
+        </template>
+      </div>
+    </div>
+    <div v-else class="text-center py-1">
+      <p class="text-[8.5px] font-black text-slate-300 uppercase tracking-widest">No purchases during this shift</p>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import { formatNumber, formatDuration } from '@/lib/format';
+import { iconURL } from 'lib';
+import { getResearchById, getResearchByTier } from '@/calculations/commonResearch';
+import { getVehicleType } from '@/lib/vehicles';
+import { getHabById, type HabId } from '../../lib/habs';
+import { getArtifact, getStone } from '@/lib/artifacts/data';
+import type { VirtueEgg } from '@/types';
+
+const props = defineProps<{
+  title: string;
+  egg: VirtueEgg;
+  actions: any[];
+  duration: number;
+  cost: number;
+  costType: 'SE' | 'Virtue';
+  startTime: number;
+  endTime: number;
+}>();
+
+const formatTime = (ts: number) => {
+  return new Date(ts * 1000).toLocaleString('en-US', {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+  });
+};
+
+const timeTooltipContent = computed(() => {
+  return `
+    <div class="text-left font-sans">
+      <div class="text-[10px] text-slate-300 font-bold uppercase tracking-widest mb-1 border-b border-slate-600/50 pb-1">Shift Schedule</div>
+      <div class="text-xs mb-0.5"><span class="text-slate-400 mr-2">Start:</span><span class="text-white">${formatTime(props.startTime)}</span></div>
+      <div class="text-xs"><span class="text-slate-400 mr-2">End:</span><span class="text-white">${formatTime(props.endTime)}</span></div>
+    </div>
+  `;
+});
+
+const eggThemes: Record<VirtueEgg, { bg: string; text: string; badge: string }> = {
+  curiosity: { bg: 'bg-amber-50', text: 'text-amber-500', badge: 'bg-amber-50 text-amber-700 border-amber-100' },
+  integrity: { bg: 'bg-blue-50', text: 'text-blue-500', badge: 'bg-blue-50 text-blue-700 border-blue-100' },
+  humility: { bg: 'bg-purple-50', text: 'text-purple-500', badge: 'bg-purple-50 text-purple-700 border-purple-100' },
+  resilience: { bg: 'bg-rose-50', text: 'text-rose-500', badge: 'bg-rose-50 text-rose-700 border-rose-100' },
+  kindness: {
+    bg: 'bg-emerald-50',
+    text: 'text-emerald-500',
+    badge: 'bg-emerald-50 text-emerald-700 border-emerald-100',
+  },
+};
+
+const eggTheme = computed(() => eggThemes[props.egg] || eggThemes.curiosity);
+
+const totalEggsLaid = computed(() => {
+  const eggAction = props.actions.find(a => a.payload?.eggsLaid !== undefined);
+  return eggAction ? eggAction.payload.eggsLaid : 0;
+});
+
+const summaryItems = computed(() => {
+  const finalResearch: Record<string, number> = {};
+  const modifiedResearchIds = new Set<string>();
+  const modifiedTiers = new Set<number>();
+
+  const finalVehicles: Record<number, { id: number; trainLength?: number }> = {};
+  const finalHabs: Record<number, number> = {};
+  let finalSiloCount = 0;
+  const equippedArtifacts: any[] = [];
+  const equippedSets: string[] = [];
+
+  for (const action of props.actions) {
+    if (action.type === 'buy_research') {
+      const { researchId, toLevel } = action.payload;
+      finalResearch[researchId] = toLevel;
+      modifiedResearchIds.add(researchId);
+      const research = getResearchById(researchId);
+      if (research) modifiedTiers.add(research.tier);
+    } else if (action.type === 'buy_vehicle') {
+      const { slotIndex, vehicleId, trainLength } = action.payload;
+      finalVehicles[slotIndex] = { id: vehicleId, trainLength };
+    } else if (action.type === 'buy_train_car') {
+      const { slotIndex, toLength } = action.payload;
+      if (finalVehicles[slotIndex]) {
+        finalVehicles[slotIndex].trainLength = toLength;
+      } else {
+        finalVehicles[slotIndex] = { id: 11, trainLength: toLength }; // 11 is Hyperloop
+      }
+    } else if (action.type === 'buy_hab') {
+      const { slotIndex, habId } = action.payload;
+      finalHabs[slotIndex] = habId;
+    } else if (action.type === 'buy_silo') {
+      const { toCount } = action.payload;
+      finalSiloCount = Math.max(finalSiloCount, toCount);
+    } else if (action.type === 'change_artifacts') {
+      const { toLoadout } = action.payload;
+      // Clear previous if multiple change actions exist in one shift (unlikely but safe)
+      equippedArtifacts.length = 0;
+      for (const slot of toLoadout) {
+        if (slot.artifactId) {
+          const artifact = getArtifact(slot.artifactId);
+          if (artifact) {
+            const stones = (slot.stones || [])
+              .map((s: string | null) => (s ? getStone(s) : null))
+              .filter((s: any) => s !== null);
+            equippedArtifacts.push({
+              name: artifact.familyName,
+              tier: artifact.tier,
+              rarity: artifact.rarityCode,
+              stones: stones.map((s: any) => ({ name: s.familyName, tier: s.tier })),
+            });
+          }
+        }
+      }
+    } else if (action.type === 'update_artifact_set') {
+      const { newLoadout } = action.payload;
+      equippedArtifacts.length = 0;
+      for (const slot of newLoadout) {
+        if (slot.artifactId) {
+          const artifact = getArtifact(slot.artifactId);
+          if (artifact) {
+            const stones = (slot.stones || [])
+              .map((s: string | null) => (s ? getStone(s) : null))
+              .filter((s: any) => s !== null);
+            equippedArtifacts.push({
+              name: artifact.familyName,
+              tier: artifact.tier,
+              rarity: artifact.rarityCode,
+              stones: stones.map((s: any) => ({ name: s.familyName, tier: s.tier })),
+            });
+          }
+        }
+      }
+    } else if (action.type === 'equip_artifact_set') {
+      const setName = action.payload.setName === 'earnings' ? 'Earnings' : 'ELR';
+      equippedSets.push(setName);
+    }
+  }
+
+    const items: any[] = [];
+
+    for (const setName of equippedSets) {
+      items.push({
+        isPremium: true,
+        text: `Equipped ${setName} Set`,
+      });
+    }
+
+    // --- Peak ELR / K3 Wait ---
+    const peakELRAction = props.actions.find(a => a.payload?.peakELR !== undefined);
+    if (peakELRAction) {
+      items.push({
+        isPeakELR: true,
+        text: `Peak ELR: ${formatNumber(peakELRAction.payload.peakELR * 3600, 3)}/hr`,
+      });
+    }
+    // --- TE Earned ---
+    const teWaitActions = props.actions.filter(a => a.type === 'wait_for_te' || a.payload?.isTEWait);
+    if (teWaitActions.length > 0) {
+      const totalTE = teWaitActions.reduce((sum, a) => sum + (a.payload.teGained || a.payload.teEarned || 0), 0);
+      if (totalTE > 0) {
+        items.push({
+          isPremium: true,
+          text: `+${totalTE} Truth Eggs`,
+        });
+      }
+    }
+
+    // --- Overtake Info ---
+    const overtakeAction = props.actions.find(a => a.type === 'virtual_overtake_info');
+    if (overtakeAction) {
+      items.push({
+        isPeakELR: true, // Use same styling but different icon/color if possible
+        isOvertake: true,
+        text: `Overtakes 1-sale in ${overtakeAction.payload.daysToOvertake.toFixed(1)}d`,
+      });
+    }
+
+  // --- Artifacts & Stones ---
+  const totalStoneCounts: Record<string, number> = {};
+  for (const art of equippedArtifacts) {
+    items.push({
+      isPremium: true,
+      text: `T${art.tier}${art.rarity} ${art.name}`,
+    });
+    for (const s of art.stones) {
+      const label = `T${s.tier} ${s.name.split(' ')[0]}`;
+      totalStoneCounts[label] = (totalStoneCounts[label] || 0) + 1;
+    }
+  }
+
+  for (const [label, count] of Object.entries(totalStoneCounts)) {
+    items.push({
+      isPremium: true,
+      text: `${count}x ${label}`,
+    });
+  }
+
+  // --- Silos ---
+  if (finalSiloCount > 0) {
+    items.push({ isPremium: true, text: `${finalSiloCount} Silos` });
+  }
+
+  // --- Habs ---
+  let hasCU = false;
+  let highestHabId = -1;
+  const habCounts: Record<number, number> = {};
+
+  for (const habId of Object.values(finalHabs)) {
+    if (habId === 18) hasCU = true;
+    if (habId > highestHabId) highestHabId = habId;
+    habCounts[habId] = (habCounts[habId] || 0) + 1;
+  }
+
+  if (hasCU) {
+    items.push({ isPremium: true, text: `${habCounts[18]}x Chicken Universe` });
+  } else if (highestHabId >= 0) {
+    const habName = getHabById(highestHabId as HabId)?.name || 'Hab';
+    items.push({ isPremium: false, name: `Hab Upgrade`, delta: `to ${habName}` });
+  }
+
+  // --- Vehicles ---
+  const vehicleCounts: Record<string, number> = {};
+  for (const v of Object.values(finalVehicles)) {
+    const name = getVehicleType(v.id)?.name || 'Vehicle';
+    let label = name;
+    if (v.id === 11 && v.trainLength) {
+      label = `${name} (${v.trainLength} cars)`;
+    }
+    vehicleCounts[label] = (vehicleCounts[label] || 0) + 1;
+  }
+
+  for (const [label, count] of Object.entries(vehicleCounts)) {
+    if (count > 1) {
+      items.push({ isPremium: false, name: label, delta: `${count}x` });
+    } else {
+      items.push({ isPremium: false, name: 'Vehicle', delta: label });
+    }
+  }
+
+  // --- Research ---
+  if (modifiedResearchIds.size > 0) {
+    const maxedTiers: number[] = [];
+    const handledResearchIds = new Set<string>();
+    const researchByTierMap = getResearchByTier();
+
+    const sortedModifiedTiers = Array.from(modifiedTiers).sort((a, b) => a - b);
+    for (const tier of sortedModifiedTiers) {
+      const tierResearches = researchByTierMap.get(tier) || [];
+      const isTierMaxed = tierResearches.every(r => (finalResearch[r.id] || 0) >= r.levels);
+      if (isTierMaxed) {
+        maxedTiers.push(tier);
+        tierResearches.forEach(r => handledResearchIds.add(r.id));
+      }
+    }
+
+    if (maxedTiers.length > 0) {
+      let start = maxedTiers[0];
+      let prev = maxedTiers[0];
+      for (let i = 1; i <= maxedTiers.length; i++) {
+        const curr = maxedTiers[i];
+        if (curr === prev + 1) {
+          prev = curr;
+        } else {
+          items.push({
+            isPremium: true,
+            text: start === prev ? `Max Tier ${start}` : `Max Tiers ${start}-${prev}`,
+          });
+          start = curr;
+          prev = curr;
+        }
+      }
+    }
+
+    const remaining = Array.from(modifiedResearchIds)
+      .filter(id => !handledResearchIds.has(id))
+      .map(id => getResearchById(id)!)
+      .sort((a, b) => a.serial_id - b.serial_id);
+
+    for (const r of remaining) {
+      const final = finalResearch[r.id] || 0;
+      if (final >= r.levels) {
+        items.push({ isPremium: false, name: `Max ${r.name}`, delta: '' });
+      } else {
+        items.push({ isPremium: false, name: r.name, delta: `0 -> ${final}` });
+      }
+    }
+  }
+
+  return items;
+});
+</script>
+
+<style scoped>
+.badge-premium {
+  @apply border rounded-lg;
+}
+</style>

--- a/wasmegg/ascension-planner/src/components/auto/ShiftSummary.vue
+++ b/wasmegg/ascension-planner/src/components/auto/ShiftSummary.vue
@@ -167,6 +167,7 @@ const totalEggsLaid = computed(() => {
 
 const summaryItems = computed(() => {
   const finalResearch: Record<string, number> = {};
+  const startResearch: Record<string, number> = {};
   const modifiedResearchIds = new Set<string>();
   const modifiedTiers = new Set<number>();
 
@@ -178,7 +179,8 @@ const summaryItems = computed(() => {
 
   for (const action of props.actions) {
     if (action.type === 'buy_research') {
-      const { researchId, toLevel } = action.payload;
+      const { researchId, fromLevel, toLevel } = action.payload;
+if (!(researchId in startResearch)) startResearch[researchId] = fromLevel;
       finalResearch[researchId] = toLevel;
       modifiedResearchIds.add(researchId);
       const research = getResearchById(researchId);
@@ -389,7 +391,7 @@ const summaryItems = computed(() => {
       if (final >= r.levels) {
         items.push({ isPremium: false, name: `Max ${r.name}`, delta: '' });
       } else {
-        items.push({ isPremium: false, name: r.name, delta: `0 -> ${final}` });
+        items.push({ isPremium: false, name: r.name, delta: `${startResearch[r.id] ?? 0} -> ${final}` });
       }
     }
   }

--- a/wasmegg/ascension-planner/src/components/auto/SimulationErrorAlert.vue
+++ b/wasmegg/ascension-planner/src/components/auto/SimulationErrorAlert.vue
@@ -1,0 +1,19 @@
+<template>
+  <div class="px-4">
+    <div class="bg-rose-50 border border-rose-100 rounded-3xl p-6 flex items-start gap-4 shadow-xl shadow-rose-500/5 animate-in fade-in slide-in-from-top-4">
+      <div class="w-10 h-10 bg-rose-100 rounded-xl flex items-center justify-center text-rose-600 flex-shrink-0">
+        <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+        </svg>
+      </div>
+      <div class="space-y-1">
+        <h4 class="text-sm font-black text-rose-800 uppercase tracking-tight">Simulation Failed</h4>
+        <p class="text-xs font-bold text-rose-600/80 leading-relaxed">{{ message }}</p>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+defineProps<{ message: string }>();
+</script>

--- a/wasmegg/ascension-planner/src/components/auto/ValidationDialog.vue
+++ b/wasmegg/ascension-planner/src/components/auto/ValidationDialog.vue
@@ -1,0 +1,120 @@
+<template>
+  <Teleport to="body">
+    <Transition
+      enter-active-class="transition duration-300 ease-out"
+      enter-from-class="opacity-0"
+      enter-to-class="opacity-100"
+      leave-active-class="transition duration-200 ease-in"
+      leave-from-class="opacity-100"
+      leave-to-class="opacity-0"
+    >
+      <div v-if="isOpen" class="fixed inset-0 z-[2000] flex items-center justify-center p-4">
+        <!-- Backdrop -->
+        <div 
+          class="absolute inset-0 bg-slate-900/60 backdrop-blur-sm"
+          @click="close"
+        />
+        
+        <!-- Dialog -->
+        <Transition
+          enter-active-class="transition duration-300 ease-out"
+          enter-from-class="opacity-0 scale-95 translate-y-4"
+          enter-to-class="opacity-100 scale-100 translate-y-0"
+          leave-active-class="transition duration-200 ease-in"
+          leave-from-class="opacity-100 scale-100 translate-y-0"
+          leave-to-class="opacity-0 scale-95 translate-y-4"
+        >
+          <div 
+            class="relative w-full max-w-lg bg-white rounded-[2rem] shadow-[0_20px_50px_rgba(0,0,0,0.3)] overflow-hidden border border-white/20"
+          >
+            <!-- Header -->
+            <div class="bg-gradient-to-br from-rose-500 to-rose-600 px-8 py-10 text-white relative overflow-hidden">
+              <!-- Decorative background elements -->
+              <div class="absolute top-0 right-0 -translate-y-1/2 translate-x-1/2 w-64 h-64 bg-white/10 rounded-full blur-3xl pointer-events-none" />
+              <div class="absolute bottom-0 left-0 translate-y-1/2 -translate-x-1/2 w-48 h-48 bg-rose-400/20 rounded-full blur-2xl pointer-events-none" />
+              
+              <div class="relative flex items-center gap-6">
+                <div class="w-16 h-16 bg-white/20 backdrop-blur-md rounded-2xl flex items-center justify-center text-white border border-white/30 shadow-xl">
+                  <svg class="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+                  </svg>
+                </div>
+                <div>
+                  <h3 class="text-[10px] font-black text-rose-100 uppercase tracking-[0.2em] mb-1">Validation Error</h3>
+                  <div class="text-2xl font-black tracking-tight leading-tight">Invalid Target TE</div>
+                </div>
+              </div>
+            </div>
+
+            <!-- Content -->
+            <div class="p-8 pb-10 space-y-8">
+              <div class="bg-slate-50 border border-slate-200/60 rounded-3xl p-8 relative group">
+                <div class="absolute -top-3 left-6 px-3 py-1 bg-white border border-slate-200 rounded-full text-[9px] font-black text-slate-400 uppercase tracking-widest shadow-sm">
+                  System Message
+                </div>
+                <p class="text-[15px] font-bold text-slate-700 leading-relaxed italic">
+                  "{{ message }}"
+                </p>
+              </div>
+
+              <div class="space-y-4">
+                <div class="flex items-start gap-4 p-5 bg-amber-50/50 rounded-2xl border border-amber-100/50 transition-colors hover:bg-amber-50/80">
+                  <div class="w-8 h-8 rounded-xl bg-amber-100 flex items-center justify-center text-amber-600 shrink-0">
+                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                    </svg>
+                  </div>
+                  <p class="text-xs font-bold text-amber-900/80 leading-relaxed">
+                    Ascension plans must always result in a <span class="text-amber-700">positive gain</span> of Truth Eggs. You cannot target a value lower than or equal to what you have already earned.
+                  </p>
+                </div>
+              </div>
+
+              <!-- Footer/Actions -->
+              <div class="flex justify-end pt-2">
+                <button 
+                  @click="close"
+                  class="group relative px-10 py-4 bg-slate-900 text-white overflow-hidden rounded-2xl transition-all duration-300 hover:scale-[1.02] active:scale-[0.98] shadow-2xl shadow-slate-200"
+                >
+                  <div class="absolute inset-0 bg-gradient-to-r from-blue-600 to-indigo-600 opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
+                  <span class="relative text-[11px] font-black uppercase tracking-[0.2em]">Okay</span>
+                </button>
+              </div>
+            </div>
+
+            <!-- Close button in corner -->
+            <button 
+              @click="close"
+              class="absolute top-4 right-4 w-10 h-10 flex items-center justify-center text-white/50 hover:text-white transition-colors"
+            >
+              <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+        </Transition>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+interface Props {
+  isOpen: boolean;
+  message: string;
+}
+
+defineProps<Props>();
+
+const emit = defineEmits<{
+  (e: 'close'): void;
+}>();
+
+const close = () => emit('close');
+</script>
+
+<style scoped>
+.font-mono-premium {
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+}
+</style>

--- a/wasmegg/ascension-planner/src/components/auto/VirtueProgressSection.vue
+++ b/wasmegg/ascension-planner/src/components/auto/VirtueProgressSection.vue
@@ -49,7 +49,7 @@
                 :value="truthEggsStore.teEarned[egg]"
                 min="0"
                 max="98"
-                class="w-full bg-white/50 border border-slate-100 rounded-lg px-3 py-1.5 text-[11px] font-mono-premium font-black text-slate-900 outline-none focus:border-indigo-500/50 focus:bg-white transition-all"
+                class="w-full bg-white border border-slate-100 rounded-lg px-3 py-1.5 text-[11px] font-mono-premium font-black text-slate-900 outline-none focus:border-indigo-500/50 focus:bg-white transition-all"
                 @change="handleTEEarnedChange(egg, ($event.target as HTMLInputElement).value)"
                 @keydown.enter="($event.target as HTMLInputElement).blur()"
               />

--- a/wasmegg/ascension-planner/src/components/auto/VirtueProgressSection.vue
+++ b/wasmegg/ascension-planner/src/components/auto/VirtueProgressSection.vue
@@ -1,0 +1,181 @@
+<template>
+  <div class="space-y-6">
+    <div class="flex items-center justify-between px-1">
+      <div class="flex items-center gap-3">
+        <div class="w-10 h-10 bg-indigo-100 rounded-xl flex items-center justify-center text-indigo-600 shadow-sm shadow-indigo-100">
+          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+        </div>
+        <div>
+          <h2 class="text-xs font-black text-slate-800 uppercase tracking-wider leading-none">Virtue Progress</h2>
+          <div class="flex items-center gap-2 mt-1">
+            <span class="text-[10px] font-black text-indigo-500 uppercase">{{ currentTE }} TE Total</span>
+            <span v-if="truthEggsStore.totalPendingTE > 0" class="text-[10px] font-black text-emerald-500 uppercase">
+              +{{ truthEggsStore.totalPendingTE }} Pending
+            </span>
+            <span class="w-1 h-1 bg-slate-200 rounded-full"></span>
+            <span class="text-[10px] font-black text-slate-500">ELR {{ formatNumber(currentELR * 3600, 3) }}/hr</span>
+          </div>
+        </div>
+      </div>
+      <button
+        v-if="truthEggsStore.hasPendingTE"
+        @click="rollUpPendingTE()"
+        class="px-4 py-2 bg-emerald-500 hover:bg-emerald-600 text-white text-[10px] font-black uppercase tracking-widest rounded-lg transition-all shadow-md shadow-emerald-100 flex items-center gap-2 active:scale-95"
+      >
+        <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+        </svg>
+        Roll Up Pending
+      </button>
+    </div>
+
+    <div class="grid grid-cols-2 md:grid-cols-5 gap-3">
+      <div v-for="egg in VIRTUE_TE_ORDER" :key="egg" class="relative group">
+        <div class="bg-slate-50 border border-slate-100 rounded-xl p-3 group-hover:border-indigo-100 group-hover:bg-slate-50/80 transition-all duration-300">
+          <div class="flex items-center justify-between mb-2">
+            <div class="flex items-center gap-2">
+              <img :src="iconURL(`egginc/egg_${egg}.png`, 64)" class="w-4 h-4 object-contain grayscale group-hover:grayscale-0 transition-all" />
+              <span class="text-[8px] font-black text-slate-500 uppercase tracking-widest group-hover:text-indigo-400 transition-colors">
+                {{ VIRTUE_EGG_NAMES[egg] }}
+              </span>
+            </div>
+          </div>
+          <div class="flex items-center gap-2">
+            <div class="relative flex-grow">
+              <input
+                type="number"
+                :value="truthEggsStore.teEarned[egg]"
+                min="0"
+                max="98"
+                class="w-full bg-white/50 border border-slate-100 rounded-lg px-3 py-1.5 text-[11px] font-mono-premium font-black text-slate-900 outline-none focus:border-indigo-500/50 focus:bg-white transition-all"
+                @change="handleTEEarnedChange(egg, ($event.target as HTMLInputElement).value)"
+                @keydown.enter="($event.target as HTMLInputElement).blur()"
+              />
+            </div>
+            <div
+              v-if="truthEggsStore.pendingTEForEgg(egg) > 0"
+              class="flex flex-col items-center justify-center bg-emerald-50 px-2 py-0.5 rounded-lg border border-emerald-100 min-w-[44px]"
+            >
+              <span class="text-[9px] font-black text-emerald-600">+{{ truthEggsStore.pendingTEForEgg(egg) }}</span>
+              <span class="text-[5px] font-black text-emerald-400 uppercase leading-none">Pending</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import { iconURL } from 'lib';
+import { formatNumber } from '@/lib/format';
+import { useTruthEggsStore, VIRTUE_TE_ORDER } from '@/stores/truthEggs';
+import { VIRTUE_EGG_NAMES } from '@/types';
+import { useActionsStore } from '@/stores/actions';
+import { useInitialStateStore } from '@/stores/initialState';
+import { useVirtueStore } from '@/stores/virtue';
+import { useFuelTankStore } from '@/stores/fuelTank';
+import { useSilosStore } from '@/stores/silos';
+import { countTEThresholdsPassed } from '@/lib/truthEggs';
+import { getSimulationContext, createBaseEngineState } from '@/engine/adapter';
+import { getArtifactLoadoutFromBackup, getOptimalEarningsSet } from '@/lib/artifacts';
+import { computeSnapshot } from '@/engine/compute';
+import { rollUpPendingTE } from '@/lib/modes';
+import type { VirtueEgg } from '@/types';
+
+const VIRTUE_EGGS_MAP: Record<number, VirtueEgg> = {
+  50: 'curiosity',
+  51: 'integrity',
+  52: 'humility',
+  53: 'resilience',
+  54: 'kindness',
+};
+
+const truthEggsStore = useTruthEggsStore();
+const actionsStore = useActionsStore();
+const initialStateStore = useInitialStateStore();
+const virtueStore = useVirtueStore();
+const fuelTankStore = useFuelTankStore();
+const silosStore = useSilosStore();
+
+const currentTE = computed(() => {
+  const snapshot = actionsStore.effectiveSnapshot;
+  if (!snapshot?.teEarned) return 0;
+  return Object.values(snapshot.teEarned).reduce((a, b) => a + b, 0);
+});
+
+const currentELR = computed(() => {
+  const farmState = initialStateStore.currentFarmState;
+  if (!farmState) {
+    return actionsStore.effectiveSnapshot?.elr ?? 0;
+  }
+
+  const rawLoadout = initialStateStore.rawBackup
+    ? getArtifactLoadoutFromBackup(initialStateStore.rawBackup)
+    : initialStateStore.artifactLoadout;
+
+  const optimalEarnings = initialStateStore.rawBackup
+    ? getOptimalEarningsSet(initialStateStore.rawBackup)
+    : initialStateStore.artifactSets.earnings || null;
+
+  const continueState: import('@/engine/types').EngineState = {
+    currentEgg: (VIRTUE_EGGS_MAP[farmState.eggType] || 'curiosity') as VirtueEgg,
+    shiftCount: virtueStore.initialShiftCount,
+    te: virtueStore.initialTE,
+    soulEggs: initialStateStore.soulEggs,
+    vehicles: farmState.vehicles || [{ vehicleId: 0, trainLength: 1 }],
+    habIds: farmState.habs || [0, null, null, null],
+    researchLevels: { ...farmState.commonResearches },
+    siloCount: silosStore.siloCount || 1,
+    tankLevel: fuelTankStore.tankLevel || 0,
+    artifactLoadout: rawLoadout.map(slot => ({ artifactId: slot.artifactId, stones: [...slot.stones] })),
+    activeArtifactSet: 'elr',
+    artifactSets: {
+      earnings: optimalEarnings ? JSON.parse(JSON.stringify(optimalEarnings)) : null,
+      elr: JSON.parse(JSON.stringify(rawLoadout)),
+    },
+    fuelTankAmounts: { ...initialStateStore.initialFuelAmounts },
+    eggsDelivered: { ...initialStateStore.initialEggsDelivered },
+    teEarned: { ...initialStateStore.initialTeEarned },
+    population: farmState.population || 0,
+    lastStepTime: farmState.lastStepTime || 0,
+    bankValue: farmState.cash || 0,
+    activeSales: { research: false, hab: false, vehicle: false },
+    earningsBoost: { active: false, multiplier: 1 },
+  };
+
+  return computeSnapshot(continueState, getSimulationContext(), { skipGrowth: true }).elr;
+});
+
+const handleTEEarnedChange = (egg: VirtueEgg, value: string) => {
+  const count = parseInt(value);
+  if (isNaN(count)) return;
+
+  truthEggsStore.setTEEarnedWithSync(egg, count);
+  syncTEAcrossStores(egg);
+};
+
+const syncTEAcrossStores = async (egg: VirtueEgg) => {
+  initialStateStore.setInitialEggsDelivered(egg, truthEggsStore.eggsDelivered[egg]);
+  initialStateStore.setInitialTeEarned(egg, truthEggsStore.teEarned[egg]);
+
+  const theoreticalTE = countTEThresholdsPassed(truthEggsStore.eggsDelivered[egg]);
+  initialStateStore.setInitialTePending(egg, Math.max(0, theoreticalTE - truthEggsStore.teEarned[egg]));
+
+  virtueStore.setInitialTE(truthEggsStore.totalTE);
+  virtueStore.setTE(truthEggsStore.totalTE);
+
+  const baseState = createBaseEngineState(null);
+  const initialSnapshot = computeSnapshot(baseState, getSimulationContext());
+  await actionsStore.setInitialSnapshot(initialSnapshot);
+};
+</script>
+
+<style scoped>
+.font-mono-premium {
+  font-family: 'JetBrains Mono', 'Roboto Mono', monospace;
+}
+</style>

--- a/wasmegg/ascension-planner/src/components/containers/InitialStateContainer.vue
+++ b/wasmegg/ascension-planner/src/components/containers/InitialStateContainer.vue
@@ -29,6 +29,7 @@
     @set-ascension-date="handleSetAscensionDate"
     @set-ascension-time="handleSetAscensionTime"
     @set-ascension-timezone="handleSetAscensionTimezone"
+    @apply-ascension-settings="handleApplyAscensionSettings"
     @set-tank-level="handleSetTankLevel"
     @set-fuel-amount="handleSetFuelAmount"
     @set-eggs-delivered="handleSetEggsDelivered"
@@ -230,6 +231,13 @@ function handleSetAscensionTime(time: string) {
 }
 
 function handleSetAscensionTimezone(timezone: string) {
+  virtueStore.setAscensionTimezone(timezone);
+  actionsStore.recalculateFrom(0);
+}
+
+function handleApplyAscensionSettings(date: string, time: string, timezone: string) {
+  virtueStore.setAscensionDate(date);
+  virtueStore.setAscensionTime(time);
   virtueStore.setAscensionTimezone(timezone);
   actionsStore.recalculateFrom(0);
 }

--- a/wasmegg/ascension-planner/src/components/presenters/InitialStateDisplay.vue
+++ b/wasmegg/ascension-planner/src/components/presenters/InitialStateDisplay.vue
@@ -669,6 +669,7 @@ const emit = defineEmits<{
   'set-ascension-date': [value: string];
   'set-ascension-time': [value: string];
   'set-ascension-timezone': [value: string];
+  'apply-ascension-settings': [date: string, time: string, timezone: string];
   'set-tank-level': [level: number];
   'set-fuel-amount': [egg: VirtueEgg, amount: number];
   'set-eggs-delivered': [egg: VirtueEgg, amount: number];
@@ -705,9 +706,7 @@ const hasAscensionChanges = computed(() => {
 });
 
 function applyAscensionChanges() {
-  emit('set-ascension-date', localAscensionDate.value);
-  emit('set-ascension-time', localAscensionTime.value);
-  emit('set-ascension-timezone', localAscensionTimezone.value);
+  emit('apply-ascension-settings', localAscensionDate.value, localAscensionTime.value, localAscensionTimezone.value);
 }
 
 // Collapsible state

--- a/wasmegg/ascension-planner/src/composables/useResearchViews.ts
+++ b/wasmegg/ascension-planner/src/composables/useResearchViews.ts
@@ -25,6 +25,8 @@ import { calculateArtifactModifiers } from '@/lib/artifacts';
 import { calculateLayRate } from '@/calculations/layRate';
 import { calculateEffectiveLayRate } from '@/calculations/effectiveLayRate';
 import { calculateHabCapacity_Full } from '@/calculations/habCapacity';
+import { computeRealisticELR } from '@/calculations/realisticELR';
+import { calculateResearchROI } from '@/calculations/researchROI';
 import { createSimAction } from '@/types/actions/meta';
 
 export type ViewType = 'game' | 'cheapest' | 'roi' | 'elr';
@@ -104,55 +106,7 @@ const ELR_EXCLUDED_CATEGORIES = [
   'egg_value',
 ];
 
-/**
- * Compute ELR using the full pipeline with given research levels, artifact mods, max habs/vehicles.
- */
-function computeRealisticELR(
-  researchLevels: Record<string, number>,
-  artifactMods: ReturnType<typeof calculateArtifactModifiers>,
-  epicResearchLevels: Record<string, number>,
-  colleggtibleModifiers: any,
-): { layRate: number; shippingRate: number; effectiveRate: number } {
-  const habCapOutput = calculateHabCapacity_Full({
-    habIds: [18, 18, 18, 18] as (number | null)[],
-    researchLevels,
-    peggMultiplier: colleggtibleModifiers.habCap,
-    artifactMultiplier: artifactMods.habCapacity.totalMultiplier,
-    artifactEffects: artifactMods.habCapacity.effects,
-  });
-  const population = habCapOutput.totalFinalCapacity;
 
-  const layRateOutput = calculateLayRate({
-    researchLevels,
-    epicComfyNestsLevel: epicResearchLevels['epic_egg_laying'] || 0,
-    siliconMultiplier: colleggtibleModifiers.elr,
-    population,
-    artifactMultiplier: artifactMods.eggLayingRate.totalMultiplier,
-    artifactEffects: artifactMods.eggLayingRate.effects,
-  });
-
-  const totalSlots = calculateMaxVehicleSlots(researchLevels);
-  const maxTrainLen = calculateMaxTrainLength(researchLevels);
-  const vehicles = Array(totalSlots).fill(null).map(() => ({ vehicleId: 11, trainLength: maxTrainLen }));
-
-  const shippingOutput = calculateShippingCapacity({
-    vehicles,
-    researchLevels,
-    transportationLobbyistLevel: epicResearchLevels['transportation_lobbyist'] || 0,
-    colleggtibleMultiplier: colleggtibleModifiers.shippingCap,
-    artifactMultiplier: artifactMods.shippingRate.totalMultiplier,
-    artifactEffects: artifactMods.shippingRate.effects,
-  });
-
-  const layRate = layRateOutput.totalRatePerSecond;
-  const shippingRate = shippingOutput.totalFinalCapacity;
-
-  return {
-    layRate,
-    shippingRate,
-    effectiveRate: Math.min(layRate, shippingRate),
-  };
-}
 
 export function useResearchViews() {
   const commonResearchStore = useCommonResearchStore();
@@ -561,52 +515,22 @@ export function useResearchViews() {
         const isLaying = categories.includes('egg_laying_rate');
         const isShipping = categories.includes('shipping_capacity');
 
-        const timeToBuySeconds = getTimeToSave(price, effectiveSnapshot);
+        const roiResult = calculateResearchROI({
+          research: r,
+          level,
+          price,
+          snapshot: effectiveSnapshot,
+          context,
+          eventTiming: {
+            absoluteSimTime,
+            nextSaleStart,
+            eventExpirationSeconds,
+            researchSaleDeadline: researchSaleDeadline.value,
+            isSaleActive: isSale,
+          },
+        });
 
-        const tempAction = createSimAction('buy_research', {
-          researchId: r.id,
-          fromLevel: level,
-          toLevel: level + 1,
-        }, price);
-
-        // Project the farm state forward to the actual time of purchase to get accurate ROI 
-        // predictions based on expected population growth while saving.
-        const stateAtBuy = timeToBuySeconds > 0 && isFinite(timeToBuySeconds)
-          ? applyAction(baseState, createSimAction('wait_for_time', { totalTimeSeconds: timeToBuySeconds }))
-          : baseState;
-        const snapshotAtBuy = timeToBuySeconds > 0 && isFinite(timeToBuySeconds)
-          ? computeSnapshot(stateAtBuy, context)
-          : effectiveSnapshot;
-
-        const nextStateAtBuy = applyAction(stateAtBuy, tempAction);
-        const nextSnapshot = computeSnapshot(nextStateAtBuy, context);
-        
-        const relativeExpirationAtBuy = eventExpirationSeconds - timeToBuySeconds;
-
-        let roiSeconds = Infinity;
-        const maxTime = 1e9; // ~31 years
-        const getExtra = (t: number) => 
-          calculateEarningsForTime(t, nextSnapshot, relativeExpirationAtBuy) - 
-          calculateEarningsForTime(t, snapshotAtBuy, relativeExpirationAtBuy);
-
-        if (getExtra(maxTime) >= price) {
-          let low = 0;
-          let high = maxTime;
-          for (let i = 0; i < 60; i++) {
-            const mid = (low + high) / 2;
-            if (getExtra(mid) >= price) {
-              high = mid;
-            } else {
-              low = mid;
-            }
-          }
-          roiSeconds = high;
-        }
-
-        const delta = roiSeconds !== Infinity && roiSeconds > 0 ? price / roiSeconds : 0;
-        const bankValue = effectiveSnapshot.bankValue || 0;
-        const effectivePrice = Math.max(0, price - bankValue);
-        const totalRoiSeconds = timeToBuySeconds + roiSeconds;
+        const { roiSeconds, totalRoiSeconds, showSaleWarning, showDeadlineWarning, timeToBuySeconds: resultTimeToBuySeconds, nextSnapshot } = roiResult;
 
         return {
           research: r,
@@ -614,12 +538,12 @@ export function useResearchViews() {
           currentLevel: level,
           targetLevel: level + 1,
           timeToBuy:
-            timeToBuySeconds > 0
-              ? timeToBuySeconds === Infinity
+            resultTimeToBuySeconds > 0
+              ? resultTimeToBuySeconds === Infinity
                 ? '∞'
-                : timeToBuySeconds < 1
+                : resultTimeToBuySeconds < 1
                   ? '0s'
-                  : formatDuration(timeToBuySeconds)
+                  : formatDuration(resultTimeToBuySeconds)
               : '',
           canBuy,
           isMaxed: false,
@@ -631,11 +555,8 @@ export function useResearchViews() {
           isLaying,
           isShipping,
           nextSnapshot,
-          showSaleWarning: !isSale && (
-            (absoluteSimTime + timeToBuySeconds >= nextSaleStart) ||
-            (delta * (nextSaleStart - (absoluteSimTime + timeToBuySeconds)) < 0.7 * price)
-          ),
-          showDeadlineWarning: isSale && (absoluteSimTime + timeToBuySeconds > researchSaleDeadline.value),
+          showSaleWarning,
+          showDeadlineWarning,
         };
       });
 
@@ -744,14 +665,16 @@ export function useResearchViews() {
 
         if (baseline.effectiveRate <= 0) return [];
 
+        const baselineFmt = (n: number) => n.toExponential(3);
+        console.log(`[ELR View] Baseline (max Hyperloops): lay=${baselineFmt(baseline.layRate * 3600)}/hr, ship=${baselineFmt(baseline.shippingRate * 3600)}/hr, ELR=${baselineFmt(baseline.effectiveRate * 3600)}/hr — bottleneck: ${baseline.layRate < baseline.shippingRate ? 'LAY RATE' : 'SHIPPING'}`);
+
         candidates = uniqueUnpurchased
           .map(r => {
             const level = researchLevels[r.id] || 0;
             const price = getDiscountedVirtuePrice(r, level, mods, isSale);
 
             const tempLevels = { ...researchLevels, [r.id]: level + 1 };
-            
-            // Re-calculate OPTIMAL artifacts for THIS research level
+
             const tempOptimal = getOptimalELRSet(rawBackup, {
               assumeMaxHabsVehicles: true,
               excludeGusset: false,
@@ -759,7 +682,7 @@ export function useResearchViews() {
               epicResearchLevels: context.epicResearchLevels,
               colleggtibleModifiers: context.colleggtibleModifiers,
             });
-            
+
             const tempArtifactMods = calculateArtifactModifiers(tempOptimal);
             const stats = computeRealisticELR(tempLevels, tempArtifactMods, context.epicResearchLevels, context.colleggtibleModifiers);
             const impact = (stats.effectiveRate - baseline.effectiveRate) / baseline.effectiveRate;
@@ -769,6 +692,43 @@ export function useResearchViews() {
             const secondsToBuyWithBank = getTimeToSave(price, actionsStore.effectiveSnapshot);
             const hoursToBuy = secondsToBuyNoBank / 3600;
             const hpp = impact > 0 ? hoursToBuy / (impact * 100) : Infinity;
+
+            // Lookahead: find minimum N levels that unlock positive ELR impact.
+            let lookahead: { minLevels: number; impact: number; hpp: number; realisticStats: { layRate: number; shippingRate: number; elr: number; elrDelta: number } } | undefined;
+            if (impact <= 0 && level + 1 < r.levels) {
+              for (let n = 2; n <= r.levels - level; n++) {
+                const laLevels = { ...researchLevels, [r.id]: level + n };
+                const laOptimal = getOptimalELRSet(rawBackup, {
+                  assumeMaxHabsVehicles: true,
+                  excludeGusset: false,
+                  commonResearch: laLevels,
+                  epicResearchLevels: context.epicResearchLevels,
+                  colleggtibleModifiers: context.colleggtibleModifiers,
+                });
+                const laArtifactMods = calculateArtifactModifiers(laOptimal);
+                const laStats = computeRealisticELR(laLevels, laArtifactMods, context.epicResearchLevels, context.colleggtibleModifiers);
+                const laImpact = (laStats.effectiveRate - baseline.effectiveRate) / baseline.effectiveRate;
+                if (laImpact > 0) {
+                  let totalPriceForN = 0;
+                  for (let l = level; l < level + n; l++) {
+                    totalPriceForN += getDiscountedVirtuePrice(r, l, mods, isSale);
+                  }
+                  const totalHoursForN = getTimeToSave(totalPriceForN, noBankSnapshot) / 3600;
+                  lookahead = {
+                    minLevels: n,
+                    impact: laImpact,
+                    hpp: totalHoursForN / (laImpact * 100),
+                    realisticStats: {
+                      layRate: laStats.layRate * 3600,
+                      shippingRate: laStats.shippingRate * 3600,
+                      elr: laStats.effectiveRate * 3600,
+                      elrDelta: (laStats.effectiveRate - baseline.effectiveRate) * 3600,
+                    },
+                  };
+                  break;
+                }
+              }
+            }
 
             return {
               research: r,
@@ -780,6 +740,7 @@ export function useResearchViews() {
               isMaxed: false,
               impact,
               hpp,
+              lookahead,
               realisticStats: {
                 layRate: stats.layRate * 3600,
                 shippingRate: stats.shippingRate * 3600,
@@ -789,7 +750,17 @@ export function useResearchViews() {
               showDeadlineWarning: isSale && (absoluteSimTime + secondsToBuyWithBank > researchSaleDeadline.value),
             };
           })
-          .filter(c => c.impact > 0);
+          .map(c => {
+            const fmt = (n: number) => n.toExponential(3);
+            const DEBUG_IDS = ['neural_net_refine', 'hyper_portalling'];
+            if (DEBUG_IDS.includes(c.research.id) || c.impact > 0 || c.lookahead) {
+              const stats = c.realisticStats!;
+              const laNote = c.lookahead ? ` [lookahead ${c.lookahead.minLevels} levels → +${(c.lookahead.impact * 100).toFixed(4)}%]` : '';
+              console.log(`[ELR View] ${c.research.name}: impact=${(c.impact * 100).toFixed(4)}%, lay=${fmt(stats.layRate)}/hr, ship=${fmt(stats.shippingRate)}/hr, elr=${fmt(stats.elr)}/hr${laNote}`);
+            }
+            return c;
+          })
+          .filter(c => c.impact > 0 || c.lookahead !== undefined);
       } else {
         // Potential mode: theoretical formula-based impact
         const currentSlots = calculateMaxVehicleSlots(researchLevels);
@@ -850,12 +821,17 @@ export function useResearchViews() {
         });
       }
 
-      return candidates.map(c => ({
-        ...c,
-        extraStats: `+${(c.impact * 100).toFixed(3)}%`,
-        extraLabel: 'Impact',
-        hpp: c.hpp,
-      }));
+      return candidates.map(c => {
+        const la = (c as { lookahead?: { minLevels: number; impact: number; hpp: number; realisticStats: typeof c.realisticStats } }).lookahead;
+        return {
+          ...c,
+          extraStats: la ? `+${(la.impact * 100).toFixed(3)}%` : `+${(c.impact * 100).toFixed(3)}%`,
+          extraLabel: la ? `${la.minLevels}-lvl impact` : 'Impact',
+          hpp: la ? la.hpp : c.hpp,
+          realisticStats: la ? la.realisticStats : c.realisticStats,
+          lookahead: la ? { minLevels: la.minLevels, impact: la.impact, hpp: la.hpp } : undefined,
+        };
+      });
     }
 
     return [];

--- a/wasmegg/ascension-planner/src/engine/adapter.ts
+++ b/wasmegg/ascension-planner/src/engine/adapter.ts
@@ -29,6 +29,7 @@ export function getSimulationContext(): SimulationContext {
     ascensionStartTime,
     planStartOffset: (useActionsStore() as any).planStartOffset || 0,
     assumeDoubleEarnings: initialStateStore.assumeDoubleEarnings,
+    rawBackup: initialStateStore.rawBackup || undefined,
   };
 }
 

--- a/wasmegg/ascension-planner/src/engine/compute.ts
+++ b/wasmegg/ascension-planner/src/engine/compute.ts
@@ -76,8 +76,7 @@ export function computeSnapshot(
   let lastStepTime = state.lastStepTime;
 
   if (options.skipGrowth) {
-    // Force maintenance of state values
-    population = state.population || 0;
+    population = habCapacityOutput.totalFinalCapacity;
     bankValue = state.bankValue || 0;
   } else {
     // 8. Population growth (catch-up if starting from a backup)

--- a/wasmegg/ascension-planner/src/engine/types.ts
+++ b/wasmegg/ascension-planner/src/engine/types.ts
@@ -42,6 +42,7 @@ export interface EngineState {
     active: boolean;
     multiplier: number;
   };
+  maxELR?: number;
 }
 
 /**
@@ -53,6 +54,10 @@ export interface SimulationContext {
   ascensionStartTime: number; // Unix timestamp in seconds
   planStartOffset: number; // Seconds since ascension start at which planning begins
   assumeDoubleEarnings: boolean;
+  rawBackup?: any; // ei.IBackup
+  // Shared ELR memo — populated by the first C3 run and reused by subsequent runs
+  // with the same inventory/epic research (e.g. 1-sale and 2-sale).
+  elrMemo?: Map<string, { layRate: number; shippingRate: number; effectiveRate: number }>;
   // TODO: Add any other global context needed (e.g. events?)
 }
 

--- a/wasmegg/ascension-planner/src/lib/artifacts/virtue.ts
+++ b/wasmegg/ascension-planner/src/lib/artifacts/virtue.ts
@@ -72,6 +72,339 @@ export function getOptimalEarningsSet(backup: ei.IBackup): EquippedArtifact[] {
   return artifactSet.artifacts.map(libArtifactToEquippedArtifact);
 }
 
+// Internal candidate representation used by the pool-based ELR optimizer.
+type Candidate = { item: InventoryItem; rarity: ei.ArtifactSpec.Rarity; slots: number; isTarget: boolean };
+
+/**
+ * Pre-built pool of ELR-relevant artifact candidates and available stones.
+ * Construct once per backup with {@link buildELRCandidatePool}, then pass to
+ * {@link evaluateELRWithPool} for every research-state evaluation to avoid
+ * repeating the expensive inventory scan and combo search.
+ */
+export interface ELRCandidatePool {
+  /** @internal Opaque candidate list — do not inspect outside virtue.ts */
+  topCandidates: unknown[];
+  tachyonStones: { id: string; delta: number; count: number; tier: number }[];
+  quantumStones: { id: string; delta: number; count: number; tier: number }[];
+}
+
+/**
+ * Build the static part of the ELR optimizer: scan the backup inventory,
+ * pick the candidate artifacts, and collect available stones.
+ *
+ * This is the expensive step (Inventory construction + artifact selection).
+ * Call it **once per backup / planning session** and reuse the result across
+ * many {@link evaluateELRWithPool} calls.
+ *
+ * @param backup       The raw EI backup.
+ * @param excludeGusset Whether to exclude the Ornate Gusset family (default false).
+ */
+export function buildELRCandidatePool(
+  backup: ei.IBackup,
+  excludeGusset: boolean = false,
+): ELRCandidatePool {
+  if (!backup.artifactsDb) {
+    return { topCandidates: [], tachyonStones: [], quantumStones: [] };
+  }
+
+  const inventory = new Inventory(backup.artifactsDb, { virtue: true });
+  const name = ei.ArtifactSpec.Name;
+  const targetAfxIds = new Set([name.QUANTUM_METRONOME, name.INTERSTELLAR_COMPASS, name.ORNATE_GUSSET]);
+
+  const afxGroups = new Map<number, Candidate[]>();
+
+  for (const item of inventory.items) {
+    if (item.have === 0 || !item.isArtifact) continue;
+    const afxId = item.afxId;
+    if (excludeGusset && afxId === name.ORNATE_GUSSET) continue;
+    const isTarget = targetAfxIds.has(afxId);
+
+    for (const rarity of [
+      ei.ArtifactSpec.Rarity.LEGENDARY,
+      ei.ArtifactSpec.Rarity.EPIC,
+      ei.ArtifactSpec.Rarity.RARE,
+      ei.ArtifactSpec.Rarity.COMMON,
+    ]) {
+      if (item.haveRarity[rarity] > 0) {
+        const slots = item.stoneSlotCount(rarity);
+        const cand: Candidate = { item, rarity, slots, isTarget };
+        if (!afxGroups.has(afxId)) afxGroups.set(afxId, []);
+        afxGroups.get(afxId)!.push(cand);
+        break; // Only take best rarity of each tier
+      }
+    }
+  }
+
+  const finalCandidates: Candidate[] = [];
+  for (const [afxId, group] of afxGroups.entries()) {
+    const isTarget = targetAfxIds.has(afxId);
+    if (isTarget) {
+      group.sort((a, b) => {
+        if (a.item.tierNumber !== b.item.tierNumber) return b.item.tierNumber - a.item.tierNumber;
+        if (a.rarity !== b.rarity) return b.rarity - a.rarity;
+        return b.slots - a.slots;
+      });
+      finalCandidates.push(...group.slice(0, 2));
+    } else {
+      group.sort((a, b) => {
+        if (a.slots !== b.slots) return b.slots - a.slots;
+        return b.item.tierNumber - a.item.tierNumber;
+      });
+      finalCandidates.push(group[0]);
+    }
+  }
+
+  const targetCands = finalCandidates.filter(c => c.isTarget);
+  const nonTargetCands = finalCandidates
+    .filter(c => !c.isTarget)
+    .sort((a, b) => b.slots - a.slots)
+    .slice(0, 4);
+  const topCandidates: Candidate[] = [...targetCands, ...nonTargetCands];
+
+  const tachyonStones = inventory.items
+    .filter(i => i.isStone && i.props.family.id === 'tachyon-stone' && i.tierNumber >= 2)
+    .map(i => ({
+      id: i.id,
+      delta: i.props.effects?.[0]?.effect_delta || 0,
+      count: i.haveCommon,
+      tier: i.tierNumber,
+    }))
+    .sort((a, b) => b.tier - a.tier);
+
+  const quantumStones = inventory.items
+    .filter(i => i.isStone && i.props.family.id === 'quantum-stone' && i.tierNumber >= 2)
+    .map(i => ({
+      id: i.id,
+      delta: i.props.effects?.[0]?.effect_delta || 0,
+      count: i.haveCommon,
+      tier: i.tierNumber,
+    }))
+    .sort((a, b) => b.tier - a.tier);
+
+  return { topCandidates, tachyonStones, quantumStones };
+}
+
+/**
+ * Internal: fill a loadout with a given stone arrangement and return ELR metrics.
+ * Assumes max habs (4× CU) and max vehicle slots/length.
+ */
+function _evalStones(
+  loadout: EquippedArtifact[],
+  stones: (string | null)[],
+  commonResearch: Record<string, number>,
+  epicResearchLevels: Record<string, number>,
+  colleggtibles: any,
+): { layRate: number; shipRate: number; elr: number } {
+  const tempLoadout: EquippedArtifact[] = JSON.parse(JSON.stringify(loadout));
+  let sIdx = 0;
+  for (const slot of tempLoadout) {
+    for (let i = 0; i < slot.stones.length; i++) slot.stones[i] = stones[sIdx++];
+  }
+  const artifactMods = calculateArtifactModifiers(tempLoadout);
+  const habCapOutput = calculateHabCapacity_Full({
+    habIds: [18, 18, 18, 18] as (number | null)[],
+    researchLevels: commonResearch,
+    peggMultiplier: colleggtibles.habCap,
+    artifactMultiplier: artifactMods.habCapacity.totalMultiplier,
+    artifactEffects: artifactMods.habCapacity.effects,
+  });
+  const layRateOutput = calculateLayRate({
+    researchLevels: commonResearch,
+    epicComfyNestsLevel: epicResearchLevels['epic_egg_laying'] || 0,
+    siliconMultiplier: colleggtibles.elr,
+    population: habCapOutput.totalFinalCapacity,
+    artifactMultiplier: artifactMods.eggLayingRate.totalMultiplier,
+    artifactEffects: artifactMods.eggLayingRate.effects,
+  });
+  const totalSlots = calculateMaxVehicleSlots(commonResearch);
+  const maxTrainLen = calculateMaxTrainLength(commonResearch);
+  const vehicles = new Array(totalSlots).fill(null).map(() => ({ vehicleId: 11, trainLength: maxTrainLen }));
+  const shippingOutput = calculateShippingCapacity({
+    vehicles,
+    researchLevels: commonResearch,
+    transportationLobbyistLevel: epicResearchLevels['transportation_lobbyist'] || 0,
+    colleggtibleMultiplier: colleggtibles.shippingCap,
+    artifactMultiplier: artifactMods.shippingRate.totalMultiplier,
+    artifactEffects: artifactMods.shippingRate.effects,
+  });
+  const elr = calculateEffectiveLayRate(layRateOutput.totalRatePerSecond, shippingOutput.totalFinalCapacity);
+  return { layRate: layRateOutput.totalRatePerSecond, shipRate: shippingOutput.totalFinalCapacity, elr: elr.effectiveLayRate };
+}
+
+/**
+ * Evaluate ELR optimization given a pre-built {@link ELRCandidatePool} and the
+ * current research state. Skips the inventory scan — only the combo evaluation
+ * loop runs, making this suitable for repeated calls with varying research levels.
+ *
+ * Assumes `assumeMaxHabsVehicles: true` (4× CU habs, max vehicle slots/length).
+ */
+export function evaluateELRWithPool(
+  pool: ELRCandidatePool,
+  options: {
+    commonResearch: Record<string, number>;
+    epicResearchLevels: Record<string, number>;
+    colleggtibleModifiers: any;
+    currentSet?: (EquippedArtifact | null)[];
+  },
+): EquippedArtifact[] {
+  const topCandidates = pool.topCandidates as Candidate[];
+  const { tachyonStones, quantumStones } = pool;
+  const { commonResearch, epicResearchLevels } = options;
+  const colleggtibles = options.colleggtibleModifiers;
+
+  if (topCandidates.length === 0) return createEmptyLoadout();
+
+  function combinations<T>(array: T[], r: number): T[][] {
+    const result: T[][] = [];
+    function helper(start: number, combo: T[]) {
+      if (combo.length === r) { result.push([...combo]); return; }
+      for (let i = start; i < array.length; i++) helper(i + 1, [...combo, array[i]]);
+    }
+    helper(0, []);
+    return result;
+  }
+
+  const combos = [
+    ...combinations(topCandidates, 1),
+    ...combinations(topCandidates, 2),
+    ...combinations(topCandidates, 3),
+    ...combinations(topCandidates, 4),
+  ];
+
+  // Thin wrapper — binds the current options into the module-level helper.
+  const evalStones = (loadout: EquippedArtifact[], stones: (string | null)[]) =>
+    _evalStones(loadout, stones, commonResearch, epicResearchLevels, colleggtibles);
+
+  let bestSet: EquippedArtifact[] = createEmptyLoadout();
+  let maxELR = -1;
+  let bestLayRate = -1;
+
+  for (const comboWrappers of combos) {
+    // Only allow combos where every artifact is from a distinct family.
+    const families = new Set(comboWrappers.map((w: Candidate) => w.item.props.family.afx_id));
+    if (families.size !== comboWrappers.length) continue;
+
+    const loadout: EquippedArtifact[] = comboWrappers.map((wrapper: Candidate) => ({
+      artifactId: `${wrapper.item.props.family.id}-${wrapper.item.tierNumber}-${wrapper.rarity}`,
+      stones: new Array(wrapper.slots).fill(null),
+    }));
+    while (loadout.length < 4) loadout.push({ artifactId: null, stones: [] });
+
+    const totalStoneSlots = loadout.reduce((sum, slot) => sum + slot.stones.length, 0);
+    const remTachyonStones = tachyonStones.map(s => ({ ...s }));
+    const remQuantumStones = quantumStones.map(s => ({ ...s }));
+    const currentStones: (string | null)[] = new Array(totalStoneSlots).fill(null);
+
+    for (let slotIdx = 0; slotIdx < totalStoneSlots; slotIdx++) {
+      const metrics = evalStones(loadout, currentStones);
+      if (metrics.layRate < metrics.shipRate) {
+        const bestTachyon = remTachyonStones.find(s => s.count > 0);
+        if (bestTachyon) { currentStones[slotIdx] = bestTachyon.id; bestTachyon.count--; }
+        else {
+          const bestQuantum = remQuantumStones.find(s => s.count > 0);
+          if (bestQuantum) { currentStones[slotIdx] = bestQuantum.id; bestQuantum.count--; }
+        }
+      } else {
+        const bestQuantum = remQuantumStones.find(s => s.count > 0);
+        if (bestQuantum) { currentStones[slotIdx] = bestQuantum.id; bestQuantum.count--; }
+        else {
+          const bestTachyon = remTachyonStones.find(s => s.count > 0);
+          if (bestTachyon) { currentStones[slotIdx] = bestTachyon.id; bestTachyon.count--; }
+        }
+      }
+    }
+
+    currentStones.sort((a, b) => {
+      if (a === null && b === null) return 0;
+      if (a === null) return 1;
+      if (b === null) return -1;
+      const isTa = a.indexOf('quantum') === 0;
+      const isTb = b.indexOf('quantum') === 0;
+      if (isTa && !isTb) return -1;
+      if (!isTa && isTb) return 1;
+      const tierA = parseInt(a.split('-').pop() || '0', 10);
+      const tierB = parseInt(b.split('-').pop() || '0', 10);
+      return tierB - tierA;
+    });
+
+    const finalMetrics = evalStones(loadout, currentStones);
+    const isGlobalBetter =
+      finalMetrics.elr > maxELR ||
+      (finalMetrics.elr === maxELR && finalMetrics.layRate > bestLayRate);
+
+    if (isGlobalBetter) {
+      maxELR = finalMetrics.elr;
+      bestLayRate = finalMetrics.layRate;
+      const optimizedLoadout: EquippedArtifact[] = JSON.parse(JSON.stringify(loadout));
+      let sIdx = 0;
+      for (const slot of optimizedLoadout) {
+        for (let i = 0; i < slot.stones.length; i++) slot.stones[i] = currentStones[sIdx++];
+      }
+      bestSet = optimizedLoadout;
+    }
+  }
+
+  if (options.currentSet && isFunctionallyIdentical(bestSet, options.currentSet)) {
+    return options.currentSet as EquippedArtifact[];
+  }
+
+  return bestSet;
+}
+
+/**
+ * Evaluate ELR for a **fixed** artifact structure by re-running only the stone
+ * allocation phase. Call this after {@link evaluateELRWithPool} has determined
+ * the best structure once — it is ~500× cheaper per call.
+ *
+ * Stone allocation is re-run from scratch each time, so the tachyon ↔ quantum
+ * balance correctly reflects the current research bottleneck.
+ *
+ * @param structureLoadout  The winning loadout from {@link evaluateELRWithPool},
+ *                          used only for artifact IDs and slot counts (stones are ignored).
+ * @param pool              The same pool used to find the structure.
+ * @param options           Current research / epic research / colleggtibles.
+ */
+export function evaluateELRForStructure(
+  structureLoadout: EquippedArtifact[],
+  pool: ELRCandidatePool,
+  options: {
+    commonResearch: Record<string, number>;
+    epicResearchLevels: Record<string, number>;
+    colleggtibleModifiers: any;
+  },
+): { layRate: number; shippingRate: number; effectiveRate: number } {
+  const { tachyonStones, quantumStones } = pool;
+  const { commonResearch, epicResearchLevels } = options;
+  const colleggtibles = options.colleggtibleModifiers;
+
+  // Rebuild with empty stone slots so the allocator starts fresh.
+  const loadout: EquippedArtifact[] = structureLoadout.map(slot => ({
+    artifactId: slot.artifactId,
+    stones: new Array(slot.stones.length).fill(null),
+  }));
+
+  const totalStoneSlots = loadout.reduce((sum, slot) => sum + slot.stones.length, 0);
+  const remTachyon = tachyonStones.map(s => ({ ...s }));
+  const remQuantum = quantumStones.map(s => ({ ...s }));
+  const currentStones: (string | null)[] = new Array(totalStoneSlots).fill(null);
+
+  for (let slotIdx = 0; slotIdx < totalStoneSlots; slotIdx++) {
+    const m = _evalStones(loadout, currentStones, commonResearch, epicResearchLevels, colleggtibles);
+    if (m.layRate < m.shipRate) {
+      const t = remTachyon.find(s => s.count > 0);
+      if (t) { currentStones[slotIdx] = t.id; t.count--; }
+      else { const q = remQuantum.find(s => s.count > 0); if (q) { currentStones[slotIdx] = q.id; q.count--; } }
+    } else {
+      const q = remQuantum.find(s => s.count > 0);
+      if (q) { currentStones[slotIdx] = q.id; q.count--; }
+      else { const t = remTachyon.find(s => s.count > 0); if (t) { currentStones[slotIdx] = t.id; t.count--; } }
+    }
+  }
+
+  const final = _evalStones(loadout, currentStones, commonResearch, epicResearchLevels, colleggtibles);
+  return { layRate: final.layRate, shippingRate: final.shipRate, effectiveRate: final.elr };
+}
+
 /**
  * Get the optimal artifact set for ELR (Effective Lay Rate).
  * Factors in Metronomes, Compasses, Gussets, and Tachyon/Quantum stones.

--- a/wasmegg/ascension-planner/src/lib/events.ts
+++ b/wasmegg/ascension-planner/src/lib/events.ts
@@ -14,6 +14,10 @@ export const PACIFIC_TIMEZONE = 'America/Los_Angeles';
  * @returns The next occurrence timestamp in seconds
  */
 export function getNextPacificTime(targetDayOfWeek: number, targetHour: number, fromTimestampSeconds: number): number {
+    // 8.64e12 is the approximate max safe Unix timestamp in seconds for JavaScript Date (8.64e15 ms)
+    if (!Number.isFinite(fromTimestampSeconds) || fromTimestampSeconds > 8.64e12 || fromTimestampSeconds < 0) {
+        return fromTimestampSeconds;
+    }
     const formatter = new Intl.DateTimeFormat('en-US', {
         timeZone: PACIFIC_TIMEZONE,
         weekday: 'short',

--- a/wasmegg/ascension-planner/src/lib/format.ts
+++ b/wasmegg/ascension-planner/src/lib/format.ts
@@ -395,3 +395,24 @@ export function parseDuration(str: string): number {
 
   return hasMatch ? totalSeconds : NaN;
 }
+
+/**
+ * Format a Unix timestamp to a date string (YYYY-MM-DD) in a specific timezone.
+ */
+export function formatUnixToDateInput(timestamp: number, tz: string): string {
+  const d = new Date(timestamp * 1000);
+  return new Intl.DateTimeFormat('en-CA', { timeZone: tz }).format(d);
+}
+
+/**
+ * Format a Unix timestamp to a 24-hour time string (HH:MM) in a specific timezone.
+ */
+export function formatUnixToTimeInput(timestamp: number, tz: string): string {
+  const d = new Date(timestamp * 1000);
+  return new Intl.DateTimeFormat('en-GB', { 
+    timeZone: tz, 
+    hour: '2-digit', 
+    minute: '2-digit', 
+    hour12: false 
+  }).format(d);
+}

--- a/wasmegg/ascension-planner/src/stores/actions/index.ts
+++ b/wasmegg/ascension-planner/src/stores/actions/index.ts
@@ -64,7 +64,7 @@ export const useActionsStore = defineStore('actions', {
   getters: {
     currentSnapshot(): CalculationsSnapshot {
       if (this.actions.length === 0) {
-        return this._initialSnapshot ?? createEmptySnapshot();
+        return this.initialSnapshot;
       }
       return this.actions[this.actions.length - 1].endState;
     },
@@ -91,7 +91,7 @@ export const useActionsStore = defineStore('actions', {
       if (headerIndex === -1) return this.currentSnapshot;
       const nextShiftIndex = this.actions.findIndex((a, idx) => idx > headerIndex && a.type === 'shift');
       if (nextShiftIndex === -1) return this.currentSnapshot;
-      return this.actions[nextShiftIndex - 1]?.endState ?? this.currentSnapshot;
+      return this.actions[nextShiftIndex - 1].endState;
     },
 
     editingInsertIndex(): number {
@@ -183,8 +183,10 @@ export const useActionsStore = defineStore('actions', {
   },
 
   actions: {
-    async setInitialSnapshot(snapshot: CalculationsSnapshot) {
+    async setInitialSnapshot(snapshot: CalculationsSnapshot, options?: { silent?: boolean }) {
       this._initialSnapshot = snapshot;
+      if (options?.silent) return;
+
       if (this.actions.length === 0) {
         const startAction = createDefaultStartAction();
         this.actions.push(startAction);

--- a/wasmegg/ascension-planner/src/stores/actions/index.ts
+++ b/wasmegg/ascension-planner/src/stores/actions/index.ts
@@ -45,6 +45,7 @@ export const useActionsStore = defineStore('actions', {
       editingGroupId: null,
       expandedGroupIds: new Set([startAction.id]),
       isRecalculating: false,
+      pendingRecalculate: false,
       recalculationProgress: { current: 0, total: 0 },
       batchMode: false,
       minBatchIndex: Infinity,
@@ -627,8 +628,12 @@ export const useActionsStore = defineStore('actions', {
         return;
       }
       startIndex = Math.max(0, startIndex);
-      if (this.isRecalculating) return;
+      if (this.isRecalculating) {
+        this.pendingRecalculate = true;
+        return;
+      }
       this.isRecalculating = true;
+      this.pendingRecalculate = false;
       try {
         const context = getSimulationContext();
         const baseState =
@@ -651,6 +656,11 @@ export const useActionsStore = defineStore('actions', {
         this.isRecalculating = false;
         this.batchMode = false;
         this.minBatchIndex = Infinity;
+        // If a recalculate was requested while we were running, do it now with fresh context
+        if (this.pendingRecalculate) {
+          this.pendingRecalculate = false;
+          await this.recalculateFrom(0);
+        }
       }
     },
 

--- a/wasmegg/ascension-planner/src/stores/actions/io.ts
+++ b/wasmegg/ascension-planner/src/stores/actions/io.ts
@@ -10,7 +10,8 @@ import { useFuelTankStore } from '@/stores/fuelTank';
 import { useTruthEggsStore } from '@/stores/truthEggs';
 import { useNotesStore } from '@/stores/notes';
 import { useSilosStore } from '@/stores/silos';
-import type { VirtueEgg, Action, CalculationsSnapshot } from '@/types';
+import { createEmptySnapshot, type VirtueEgg, type Action, type CalculationsSnapshot } from '@/types';
+import { countTEThresholdsPassed } from '@/lib/truthEggs';
 
 export function exportPlanData(actions: Action[], initialSnapshot?: CalculationsSnapshot, activePlanId: string | null = null) {
   const initialStateStore = useInitialStateStore();
@@ -128,6 +129,46 @@ export function importPlanLogic(jsonString: string) {
     notesStore.setNotes(data.notesState.notes || []);
   } else {
     notesStore.$reset();
+  }
+
+  // Merge simple wait_for_time actions into subsequent purchases to reduce clutter
+  if (data.actions && data.actions.length > 0) {
+    const mergedActions: any[] = [];
+    for (let i = 0; i < data.actions.length; i++) {
+      const action = data.actions[i];
+      if (action.type === 'wait_for_time') {
+        const nextAction = data.actions[i + 1];
+        if (nextAction && ['buy_research', 'buy_hab', 'buy_vehicle', 'buy_train_car', 'buy_silo'].includes(nextAction.type)) {
+          nextAction.totalTimeSeconds = (nextAction.totalTimeSeconds || 0) + (action.totalTimeSeconds || 0);
+          nextAction.bankDelta = (nextAction.bankDelta || 0) + (action.bankDelta || 0);
+          continue; // Skip adding the wait_for_time action
+        }
+      }
+      mergedActions.push(action);
+    }
+    data.actions = mergedActions;
+  }
+
+  // Safeguard: Ensure a start_ascension action is present for the UI Action History
+  if (data.actions && data.actions.length > 0 && data.actions[0].type !== 'start_ascension') {
+    console.log('[ActionIO] Repairing imported plan: prepending missing start_ascension');
+    const startAction = {
+      id: 'start_' + Math.random().toString(36).substring(2, 9),
+      index: 0,
+      timestamp: data.actions[0].timestamp || Date.now(),
+      type: 'start_ascension',
+      payload: { initialEgg: 'curiosity' },
+      cost: 0, elrDelta: 0, offlineEarningsDelta: 0, eggValueDelta: 0,
+      habCapacityDelta: 0, layRateDelta: 0, shippingCapacityDelta: 0,
+      ihrDelta: 0, bankDelta: 0, populationDelta: 0, totalTimeSeconds: 0,
+      endState: createEmptySnapshot(),
+      dependsOn: [], dependents: []
+    };
+    data.actions = [startAction, ...data.actions];
+  }
+
+  if (data.actions) {
+    data.actions.forEach((a: any, i: number) => a.index = i);
   }
 
   return data;

--- a/wasmegg/ascension-planner/src/stores/actions/types.ts
+++ b/wasmegg/ascension-planner/src/stores/actions/types.ts
@@ -8,6 +8,7 @@ export interface ActionsState {
   // IDs of groups that are currently expanded
   expandedGroupIds: Set<string>;
   isRecalculating: boolean;
+  pendingRecalculate: boolean;
   recalculationProgress: { current: number; total: number };
   batchMode: boolean;
   minBatchIndex: number;

--- a/wasmegg/ascension-planner/src/stores/autoPlanner.ts
+++ b/wasmegg/ascension-planner/src/stores/autoPlanner.ts
@@ -3,6 +3,8 @@ import { ref } from 'vue';
 import type { AscensionSummary } from '@/auto/types';
 import type { Action } from '@/types/actions/meta';
 
+export type PlanVariant = '1-sale' | '2-sale' | 'continue';
+
 export interface ChainedAscension {
   index: number;
   result1: { summary: AscensionSummary; actions: Action[] };
@@ -36,7 +38,7 @@ export const useAutoPlannerStore = defineStore('autoPlanner', () => {
     0: { te: 490, date: '', time: '' }
   });
 
-  const a1ForceMode = ref<'continue' | 'prestige' | null>(null);
+  const planVariantOverrides = ref<Record<number, PlanVariant>>({});
 
   function setPlan(data: {
     ascensionChain: ChainedAscension[];
@@ -47,6 +49,8 @@ export const useAutoPlannerStore = defineStore('autoPlanner', () => {
     targetEndDate?: string;
     targetEndTime?: string;
     nextGoals: Record<number, { te: number | null, date: string, time: string }>;
+    planVariantOverrides?: Record<number, PlanVariant>;
+    /** @deprecated use planVariantOverrides */
     a1ForceMode?: 'continue' | 'prestige' | null;
   }) {
     ascensionChain.value = data.ascensionChain;
@@ -57,7 +61,13 @@ export const useAutoPlannerStore = defineStore('autoPlanner', () => {
     targetEndDate.value = data.targetEndDate || '';
     targetEndTime.value = data.targetEndTime || '';
     nextGoals.value = data.nextGoals;
-    a1ForceMode.value = data.a1ForceMode || null;
+    if (data.planVariantOverrides) {
+      planVariantOverrides.value = data.planVariantOverrides;
+    } else if (data.a1ForceMode === 'continue') {
+      planVariantOverrides.value = { 0: 'continue' };
+    } else {
+      planVariantOverrides.value = {};
+    }
   }
 
   function clear() {
@@ -66,7 +76,7 @@ export const useAutoPlannerStore = defineStore('autoPlanner', () => {
     targetEndDate.value = '';
     targetEndTime.value = '';
     nextGoals.value = { 0: { te: 490, date: '', time: '' } };
-    a1ForceMode.value = null;
+    planVariantOverrides.value = {};
   }
 
   return {
@@ -78,7 +88,7 @@ export const useAutoPlannerStore = defineStore('autoPlanner', () => {
     targetEndDate,
     targetEndTime,
     nextGoals,
-    a1ForceMode,
+    planVariantOverrides,
     setPlan,
     clear,
   };

--- a/wasmegg/ascension-planner/src/stores/autoPlanner.ts
+++ b/wasmegg/ascension-planner/src/stores/autoPlanner.ts
@@ -1,0 +1,85 @@
+import { defineStore } from 'pinia';
+import { ref } from 'vue';
+import type { AscensionSummary } from '@/auto/types';
+import type { Action } from '@/types/actions/meta';
+
+export interface ChainedAscension {
+  index: number;
+  result1: { summary: AscensionSummary; actions: Action[] };
+  result2: { summary: AscensionSummary; actions: Action[] };
+  result3?: { summary: AscensionSummary; actions: Action[] }; // "Continue current" option (A1 only)
+  result3SkippedReason?: string;
+  goal: {
+    type: 'te' | 'date';
+    te: number | null;
+    date: string;
+    time: string;
+  };
+  initialParams?: {
+    startDate: string;
+    startTime: string;
+    teEarned: Record<string, number>;
+  };
+  /** True when this ascension was silently injected to reach 490 TE, not entered by the user. */
+  forcedTarget490?: boolean;
+}
+
+export const useAutoPlannerStore = defineStore('autoPlanner', () => {
+  const ascensionChain = ref<ChainedAscension[]>([]);
+  const timezone = ref(Intl.DateTimeFormat().resolvedOptions().timeZone);
+  const startDate = ref('');
+  const startTime = ref('');
+  const targetTE = ref<string>('');
+  const targetEndDate = ref('');
+  const targetEndTime = ref('');
+  const nextGoals = ref<Record<number, { te: number | null, date: string, time: string }>>({
+    0: { te: 490, date: '', time: '' }
+  });
+
+  const a1ForceMode = ref<'continue' | 'prestige' | null>(null);
+
+  function setPlan(data: {
+    ascensionChain: ChainedAscension[];
+    timezone: string;
+    startDate: string;
+    startTime: string;
+    targetTE: string;
+    targetEndDate?: string;
+    targetEndTime?: string;
+    nextGoals: Record<number, { te: number | null, date: string, time: string }>;
+    a1ForceMode?: 'continue' | 'prestige' | null;
+  }) {
+    ascensionChain.value = data.ascensionChain;
+    timezone.value = data.timezone;
+    startDate.value = data.startDate;
+    startTime.value = data.startTime;
+    targetTE.value = data.targetTE || '';
+    targetEndDate.value = data.targetEndDate || '';
+    targetEndTime.value = data.targetEndTime || '';
+    nextGoals.value = data.nextGoals;
+    a1ForceMode.value = data.a1ForceMode || null;
+  }
+
+  function clear() {
+    ascensionChain.value = [];
+    targetTE.value = '';
+    targetEndDate.value = '';
+    targetEndTime.value = '';
+    nextGoals.value = { 0: { te: 490, date: '', time: '' } };
+    a1ForceMode.value = null;
+  }
+
+  return {
+    ascensionChain,
+    timezone,
+    startDate,
+    startTime,
+    targetTE,
+    targetEndDate,
+    targetEndTime,
+    nextGoals,
+    a1ForceMode,
+    setPlan,
+    clear,
+  };
+});

--- a/wasmegg/ascension-planner/src/stores/initialState.ts
+++ b/wasmegg/ascension-planner/src/stores/initialState.ts
@@ -558,6 +558,7 @@ export const useInitialStateStore = defineStore('initialState', {
       this.initialTePending[egg] = Math.max(0, count);
     },
 
+
     /**
      * Clear all initial state data
      */

--- a/wasmegg/ascension-planner/src/stores/truthEggs.ts
+++ b/wasmegg/ascension-planner/src/stores/truthEggs.ts
@@ -66,6 +66,13 @@ export const useTruthEggsStore = defineStore('truthEggs', {
     },
 
     /**
+     * Whether there are any pending TE across all eggs
+     */
+    hasPendingTE(): boolean {
+      return this.totalPendingTE > 0;
+    },
+
+    /**
      * Pending TE for a specific egg (thresholds passed but not yet claimed)
      */
     pendingTEForEgg(): (egg: VirtueEgg) => number {
@@ -174,6 +181,11 @@ export const useTruthEggsStore = defineStore('truthEggs', {
       return eggsNeededForTE(this.eggsDelivered[egg], targetTE);
     },
 
+    hydrate(data: any) {
+      if (!data) return;
+      if (data.initialEggsDelivered) this.eggsDelivered = { ...data.initialEggsDelivered };
+      if (data.initialTeEarned) this.teEarned = { ...data.initialTeEarned };
+    },
     /**
      * Reset to empty state
      */

--- a/wasmegg/ascension-planner/src/stores/ui.ts
+++ b/wasmegg/ascension-planner/src/stores/ui.ts
@@ -1,0 +1,38 @@
+import { defineStore } from 'pinia';
+import { ref } from 'vue';
+
+export const useUIStore = defineStore('ui', () => {
+  const plannerTab = ref<'manual' | 'automatic'>('manual');
+  const isHeaderCollapsed = ref(false);
+  const isFooterCollapsed = ref(false);
+  const loading = ref(false);
+  const error = ref('');
+
+  function setActiveTab(tab: 'manual' | 'automatic') {
+    plannerTab.value = tab;
+  }
+
+  function setHeaderCollapsed(collapsed: boolean) {
+    isHeaderCollapsed.value = collapsed;
+  }
+
+  function setLoading(l: boolean) {
+    loading.value = l;
+  }
+
+  function setError(e: string) {
+    error.value = e;
+  }
+
+  return {
+    plannerTab,
+    isHeaderCollapsed,
+    isFooterCollapsed,
+    loading,
+    error,
+    setActiveTab,
+    setHeaderCollapsed,
+    setLoading,
+    setError,
+  };
+});

--- a/wasmegg/ascension-planner/src/types/actions/core.ts
+++ b/wasmegg/ascension-planner/src/types/actions/core.ts
@@ -17,6 +17,8 @@ export interface ShiftPayload {
   fromEgg: VirtueEgg;
   toEgg: VirtueEgg;
   newShiftCount: number;
+  eggsLaid?: number;
+  peakELR?: number;
 }
 
 /**

--- a/wasmegg/ascension-planner/src/types/actions/meta.ts
+++ b/wasmegg/ascension-planner/src/types/actions/meta.ts
@@ -51,20 +51,35 @@ export type SimulatedAction = {
 
 /**
  * Create a minimal action for simulation purposes.
+ * Returns an Action with default values for deltas, ready to be hydrated.
  */
 export function createSimAction<T extends ActionType>(
   type: T,
   payload: ActionPayloadMap[T],
   cost: number = 0
-): SimulatedAction {
+): Action<T> {
   return {
     id: `sim_${Math.random().toString(36).substring(2, 9)}`,
+    index: 0,
+    timestamp: Math.floor(Date.now() / 1000),
     type,
     payload,
     cost,
-    timestamp: Math.floor(Date.now() / 1000),
+    elrDelta: 0,
+    offlineEarningsDelta: 0,
+    eggValueDelta: 0,
+    habCapacityDelta: 0,
+    layRateDelta: 0,
+    shippingCapacityDelta: 0,
+    ihrDelta: 0,
+    bankDelta: 0,
+    populationDelta: 0,
+    totalTimeSeconds: 0,
     dependsOn: [],
-  } as unknown as SimulatedAction;
+    dependents: [],
+    // We cast this placeholder because it will be hydrated immediately in the simulation loop
+    endState: {} as CalculationsSnapshot,
+  } as Action<T>;
 }
 
 /**


### PR DESCRIPTION
This adds the Auto-AP functionality.

Between your EID and plan library, you can switch to Auto Planner mode. This has AP generate plans for you based on a pre-defined pattern of shifts. You can plan a chain of ascensions together and Auto-AP will use the end of one ascension to start the beginning of the next.