### PR TITLE
Show usernames instead of EIDs across tools

### DIFF
--- a/eicoop/src/components/UserDashboardEntryForm.vue
+++ b/eicoop/src/components/UserDashboardEntryForm.vue
@@ -52,19 +52,26 @@
         >
           <base-input
             id="user_id"
-            v-model="userId"
+            v-model="displayValue"
             name="user_id"
             type="text"
+            :readonly="!editing"
             class="appearance-none block w-full px-3 py-2 text-base border border-gray-300 rounded-l-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-green-500 focus:border-green-500 sm:text-sm text-gray-900 dark:text-gray-100 dark:bg-gray-700 dark:border-gray-500"
+            :class="{ 'cursor-pointer': !editing && activeEid }"
+            :title="!editing && activeEid ? 'Click to reveal/edit the EID' : undefined"
             placeholder="User ID"
             spellcheck="false"
             autocapitalize="off"
+            @focus="onFocus"
+            @blur="onBlur"
           />
           <button
             type="submit"
             class="-ml-px relative inline-flex items-center space-x-2 px-3 py-2 border border-gray-300 dark:border-gray-500 rounded-r-md bg-blue-600 hover:bg-blue-700 !duration-0 focus:outline-none disabled:opacity-50"
             :class="{ 'cursor-not-allowed': !submittable }"
             :disabled="!submittable"
+            :title="!editing && activeEid ? 'Reload' : undefined"
+            @mousedown.prevent
           >
             <svg class="h-4 w-4 text-white" viewBox="0 0 20 20" fill="currentColor">
               <path
@@ -90,15 +97,20 @@
         <div class="text-xs text-gray-900 dark:text-gray-100 mb-1">Recent IDs:</div>
         <div class="flex flex-wrap gap-2">
           <span
-            v-for="[eid, name] in eids"
+            v-for="[eid, entry] in eids"
             :key="eid"
-            class="inline-flex items-center px-2 py-1 rounded-full bg-gray-200 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 text-xs text-gray-800 dark:text-gray-200"
+            class="inline-flex items-center px-2 py-1 rounded-full border text-xs"
+            :class="
+              eid === activeEid
+                ? 'bg-blue-100 dark:bg-blue-900 border-blue-400 dark:border-blue-500 text-gray-900 dark:text-gray-100'
+                : 'bg-gray-200 dark:bg-gray-700 border-gray-300 dark:border-gray-600 text-gray-800 dark:text-gray-200'
+            "
           >
             <button
               type="button"
               class="mr-1 text-gray-400 hover:text-blue-500 focus:outline-none"
               aria-label="Edit name"
-              @click="eidsStore.editName(eid, name)"
+              @click="eidsStore.editName(eid, entry.nickname)"
             >
               ✎
             </button>
@@ -106,12 +118,9 @@
               type="button"
               class="hover:underline mr-1"
               style="text-decoration-thickness: 1.5px"
-              @click="
-                userId = eid;
-                submit();
-              "
+              @click="loadEid(eid)"
             >
-              {{ name || eid }}
+              {{ eidsStore.displayName(eid) }}
             </button>
             <button
               type="button"
@@ -136,12 +145,12 @@ import {
   checkIfShouldOnboardUserDashboardFeature,
   getSavedPlayerID,
   savePlayerID,
-  useEidsStore,
   getLocalStorage,
   setLocalStorage,
 } from '@/lib';
 import BaseInfo from 'ui/components/BaseInfo.vue';
 import BaseInput from 'ui/components/BaseInput.vue';
+import { useEidInput } from 'ui/composables/eid_input';
 import { PlayerIdSchema } from 'lib/schema';
 
 const COLLAPSE_RECENT_EIDS_LOCALSTORAGE_KEY = 'collapseRecentEids';
@@ -157,29 +166,39 @@ export default defineComponent({
   setup(_, { emit }) {
     const router = useRouter();
     const onboarding = checkIfShouldOnboardUserDashboardFeature();
-    const userId = ref(getSavedPlayerID() || '');
-    const eidsStore = ref(useEidsStore());
-    const eids = eidsStore.value.eids;
     const collapsed = ref(getLocalStorage(COLLAPSE_RECENT_EIDS_LOCALSTORAGE_KEY) === 'true');
+
+    const { eidsStore, eids, activeEid, editing, displayValue, submittable, onFocus, onBlur, resolveSubmit, commit } =
+      useEidInput(getSavedPlayerID() || '');
 
     const isDashboard = computed(() => {
       const name = router.currentRoute.value.name;
       return name === 'dashboard' || name === 'dashboard-legacy';
     });
 
-    const submittable = computed(() => {
-      return PlayerIdSchema.safeParse(userId.value.trim()).success;
-    });
-
-    const submit = () => {
-      const trimmedUserId = userId.value.trim();
-      savePlayerID(trimmedUserId);
-      eidsStore.value.addEid(trimmedUserId);
+    const load = (eid: string) => {
+      const trimmedUserId = eid.trim();
+      if (!PlayerIdSchema.safeParse(trimmedUserId).success) {
+        return;
+      }
+      savePlayerID(trimmedUserId); // also adds the EID to the recent-IDs store
+      commit(trimmedUserId);
       emit('submit', trimmedUserId);
       // Only navigate if not already on dashboard
       if (router.currentRoute.value.name !== 'dashboard' && router.currentRoute.value.name !== 'dashboard-legacy') {
         router.push({ name: 'dashboard' });
       }
+    };
+
+    // The arrow submits the typed EID (or reloads the active player in display
+    // mode).
+    const submit = () => {
+      load(resolveSubmit());
+    };
+
+    // Clicking a recent-ID pill loads that player.
+    const loadEid = (eid: string) => {
+      load(eid);
     };
 
     const toggleCollapse = () => {
@@ -190,9 +209,14 @@ export default defineComponent({
     return {
       onboarding,
       isDashboard,
-      userId,
+      activeEid,
+      editing,
+      displayValue,
+      onFocus,
+      onBlur,
       submittable,
       submit,
+      loadEid,
       eids,
       eidsStore,
       collapsed,

--- a/eicoop/src/views/Dashboard.vue
+++ b/eicoop/src/views/Dashboard.vue
@@ -67,12 +67,18 @@ export default defineComponent({
     const userId = ref(getSavedPlayerID() || userIdProp.value || '');
 
     const setUserId = (newUserId: string) => {
+      const unchanged = userId.value === newUserId;
       userId.value = newUserId;
       savePlayerID(newUserId);
       eidsStore.addEid(newUserId);
       // Navigate to /dashboard without userId in URL
       if (router.currentRoute.value.params.userId) {
         router.replace({ name: 'dashboard' });
+      }
+      // Re-submitting the same EID (the form's reload action) won't trip the
+      // userId watcher, so refresh explicitly.
+      if (unchanged) {
+        refreshBackup();
       }
     };
 

--- a/lib/api/index.ts
+++ b/lib/api/index.ts
@@ -3,8 +3,8 @@ import { sha256 } from 'js-sha256';
 import { ei } from '../proto';
 import { decodeMessage } from './decode';
 import { encodeMessage } from './encode';
+import useEidsStore from '../stores/eids';
 import { APP_BUILD, APP_VERSION, CLIENT_VERSION, PLATFORM, PLATFORM_STRING } from './version';
-
 
 export * from './decode';
 export * from './encode';
@@ -161,6 +161,9 @@ export async function requestPeriodicals(userId?: string): Promise<ei.IPeriodica
  * @throws
  */
 export async function requestFirstContact(userId: string): Promise<ei.IEggIncFirstContactResponse> {
+  // Keep the original (as the caller stores it in the eids store) before
+  // processUserId strips any `mk2!` prefix, so the captured username keys match.
+  const originalUserId = userId.trim();
   userId = processUserId(userId);
   const requestPayload: ei.IEggIncFirstContactRequest = {
     rinfo: basicRequestInfo(''),
@@ -171,7 +174,23 @@ export async function requestFirstContact(userId: string): Promise<ei.IEggIncFir
   };
   const encodedRequestPayload = encodeMessage(ei.EggIncFirstContactRequest, requestPayload);
   const encodedResponsePayload = await request('/ei/bot_first_contact', encodedRequestPayload);
-  return decodeMessage(ei.EggIncFirstContactResponse, encodedResponsePayload, false) as ei.IEggIncFirstContactResponse;
+  const response = decodeMessage(
+    ei.EggIncFirstContactResponse,
+    encodedResponsePayload,
+    false
+  ) as ei.IEggIncFirstContactResponse;
+  // Auto-capture the in-game username so tools can display it in place of the
+  // EID. This is the central choke point every tool's backup fetch flows
+  // through. Never let a store hiccup break data loading.
+  const userName = response.backup?.userName;
+  if (userName) {
+    try {
+      useEidsStore().updateUsername(originalUserId, userName);
+    } catch {
+      // ignore — username capture is best-effort
+    }
+  }
+  return response;
 }
 
 /**

--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -3,4 +3,25 @@ import { z } from 'zod/v4-mini';
 // Zod schemas
 export const PlayerIdSchema = z.string().check(z.regex(/^(mk2!)?EI\d{16}$/, 'Invalid player ID format'));
 export const PlayerNameSchema = z.string();
-export const EidStoreFromDiskSchema = z.record(PlayerIdSchema, PlayerNameSchema, 'invalid player names object');
+
+// A stored EID entry. `username` is the in-game name auto-captured from the
+// player's backup; `nickname` is an optional label the user assigns manually.
+export const EidEntrySchema = z.object({
+  username: z.optional(z.string()),
+  nickname: z.optional(z.string()),
+});
+export type EidEntry = z.infer<typeof EidEntrySchema>;
+
+// Current on-disk shape: a record of EID -> entry object. Written to a
+// versioned localStorage key so older deployed bundles (which expect a record
+// of EID -> string) never read it and wipe it on a parse failure.
+export const EidStoreFromDiskSchema = z.record(PlayerIdSchema, EidEntrySchema, 'invalid player names object');
+
+// Legacy on-disk shape, read once for migration: values may be a bare string (a
+// manual nickname) or an object written by an early build of this feature.
+export const EidStoreValueSchema = z.union([PlayerNameSchema, EidEntrySchema]);
+export const EidStoreLegacyFromDiskSchema = z.record(
+  PlayerIdSchema,
+  EidStoreValueSchema,
+  'invalid player names object'
+);

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -7,11 +7,34 @@ import {
   setLocalStorageNoPrefix,
 } from './utils';
 import useEidsStore from './stores/eids';
-import { EidStoreFromDiskSchema, PlayerIdSchema } from './schema';
+import { EidStoreFromDiskSchema, EidStoreLegacyFromDiskSchema, PlayerIdSchema } from './schema';
+import type { EidEntry } from './schema';
+
+// Re-exported for existing importers (e.g. lib/stores/eids); the canonical
+// definition is inferred from EidEntrySchema in schema.ts.
+export type { EidEntry };
 
 const SITE_WIDE_SAVED_PLAYER_ID_LOCALSTORAGE_KEY = 'siteWideSavedPlayerId';
 const TOOL_SPECIFIC_PLAYER_ID_LOCALSTORAGE_KEY = 'playerId';
-const SITE_WIDE_SAVED_PLAYER_NAMES_LOCALSTORAGE_KEY = 'siteWideSavedPlayerNames';
+// Legacy key holding EID -> string (manual nickname). Older deployed bundles
+// still read and write it, so we read it once for migration but never write or
+// delete it — that lets a stale cached bundle keep working without either side
+// wiping the other.
+const SITE_WIDE_SAVED_PLAYER_NAMES_LEGACY_LOCALSTORAGE_KEY = 'siteWideSavedPlayerNames';
+// Current key holding EID -> entry object. Versioned so old bundles (which
+// validate values as strings) never parse it and delete it on failure.
+const SITE_WIDE_SAVED_PLAYER_NAMES_LOCALSTORAGE_KEY = 'siteWideSavedPlayerNamesV2';
+
+function parseJSON(raw: string | null | undefined): unknown {
+  if (!raw) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return undefined;
+  }
+}
 
 export function getSavedPlayerID() {
   const playerId =
@@ -38,21 +61,37 @@ export function deletePlayerID() {
 }
 
 export function getSavedPlayerIDs() {
-  const storedNames = getLocalStorageNoPrefix(SITE_WIDE_SAVED_PLAYER_NAMES_LOCALSTORAGE_KEY);
-  const parsedNames = JSON.parse(storedNames || '{}');
-
-  const result = EidStoreFromDiskSchema.safeParse(parsedNames);
-  if (!result.success) {
-    console.warn('Invalid player names data in localStorage: ', storedNames, result.error.message);
+  // Prefer the current (versioned) object store.
+  const current = getLocalStorageNoPrefix(SITE_WIDE_SAVED_PLAYER_NAMES_LOCALSTORAGE_KEY);
+  if (current) {
+    const result = EidStoreFromDiskSchema.safeParse(parseJSON(current));
+    if (result.success) {
+      // Values are already validated EidEntry objects.
+      return new Map<string, EidEntry>(Object.entries(result.data));
+    }
+    console.warn('Invalid player names data in localStorage: ', current, result.error.message);
     deleteLocalStorageNoPrefix(SITE_WIDE_SAVED_PLAYER_NAMES_LOCALSTORAGE_KEY);
-    return new Map<string, string | undefined>();
+    return new Map<string, EidEntry>();
   }
 
-  // Convert the validated object to a Map
-  return new Map(Object.entries(result.data));
+  // No current data yet: migrate from the legacy key (EID -> string nickname,
+  // or an object from an early build). Leave the legacy key in place so a stale
+  // cached old bundle keeps working; the first save writes the versioned key.
+  const legacy = getLocalStorageNoPrefix(SITE_WIDE_SAVED_PLAYER_NAMES_LEGACY_LOCALSTORAGE_KEY);
+  const result = EidStoreLegacyFromDiskSchema.safeParse(parseJSON(legacy) ?? {});
+  if (!result.success) {
+    return new Map<string, EidEntry>();
+  }
+  const entries = new Map<string, EidEntry>();
+  for (const [eid, value] of Object.entries(result.data)) {
+    // Legacy values were a bare string (a manual nickname); migrate into the
+    // nickname slot. Object values are already EidEntry.
+    entries.set(eid, typeof value === 'string' ? (value ? { nickname: value } : {}) : value);
+  }
+  return entries;
 }
 
-export function savePlayerIDs(playerIDs: Map<string, string | undefined>): void {
+export function savePlayerIDs(playerIDs: Map<string, EidEntry>): void {
   const obj = Object.fromEntries(playerIDs);
   const output = JSON.stringify(obj);
   setLocalStorageNoPrefix(SITE_WIDE_SAVED_PLAYER_NAMES_LOCALSTORAGE_KEY, output);

--- a/lib/stores/eids.ts
+++ b/lib/stores/eids.ts
@@ -1,7 +1,13 @@
 import { defineStore, acceptHMRUpdate } from 'pinia';
-import { getSavedPlayerIDs, savePlayerIDs } from '../storage';
+import { EidEntry, getSavedPlayerIDs, savePlayerIDs } from '../storage';
 import { ref } from 'vue';
 import { PlayerIdSchema } from '../schema';
+
+// Resolve the text to display for an EID: a manual nickname wins, then the
+// auto-captured in-game username, and finally the raw EID as a last resort.
+export function eidDisplayName(eid: string, entry: EidEntry | undefined): string {
+  return entry?.nickname || entry?.username || eid;
+}
 
 export const useEidsStore = defineStore('eids', () => {
   // Initialize from saved data
@@ -13,20 +19,20 @@ export const useEidsStore = defineStore('eids', () => {
       return;
     }
 
-    eids.value.set(eid, '');
+    eids.value.set(eid, {});
 
     // Remove oldest entry if over limit
     if (eids.value.size > 7) {
-      // First try to find an entry with empty string value
+      // First try to find an entry without any name (no nickname or username)
       let keyToDelete = null;
       for (const [key, value] of eids.value.entries()) {
-        if (value === '') {
+        if (!value.nickname && !value.username) {
           keyToDelete = key;
           break;
         }
       }
 
-      // If no empty string found, use the first key
+      // If none found, use the first key
       if (keyToDelete === null) {
         keyToDelete = eids.value.keys().next().value;
       }
@@ -42,22 +48,47 @@ export const useEidsStore = defineStore('eids', () => {
     savePlayerIDs(eids.value);
   }
 
-  function updateEid(eid: string, name: string) {
+  // Set the manual nickname for an EID. The EID must already be known.
+  function updateNickname(eid: string, nickname: string) {
     if (!PlayerIdSchema.safeParse(eid).success) {
       return;
     }
-    eids.value.set(eid, name);
+    const entry = eids.value.get(eid) ?? {};
+    eids.value.set(eid, { ...entry, nickname: nickname || undefined });
+    savePlayerIDs(eids.value);
+  }
+
+  // Auto-capture the in-game username for an EID (called after a backup loads).
+  // If the EID is not tracked yet, route through addEid so the 7-entry cap is
+  // enforced rather than growing the store unbounded.
+  function updateUsername(eid: string, username: string) {
+    eid = eid.trim();
+    if (!PlayerIdSchema.safeParse(eid).success || !username) {
+      return;
+    }
+    if (!eids.value.has(eid)) {
+      addEid(eid);
+    }
+    const entry = eids.value.get(eid);
+    if (!entry || entry.username === username) {
+      return;
+    }
+    eids.value.set(eid, { ...entry, username });
     savePlayerIDs(eids.value);
   }
 
   function editName(eid: string, oldname?: string) {
     const name = prompt('Enter a name for this EID:', oldname);
     if (name !== null) {
-      updateEid(eid, name);
+      updateNickname(eid, name);
     }
   }
 
-  return { eids, addEid, removeEid, updateEid, editName };
+  function displayName(eid: string): string {
+    return eidDisplayName(eid, eids.value.get(eid));
+  }
+
+  return { eids, addEid, removeEid, updateNickname, updateUsername, editName, displayName };
 });
 
 if (import.meta.hot) {

--- a/lib/stores/eids.ts
+++ b/lib/stores/eids.ts
@@ -22,7 +22,7 @@ export const useEidsStore = defineStore('eids', () => {
     eids.value.set(eid, {});
 
     // Remove oldest entry if over limit
-    if (eids.value.size > 7) {
+    if (eids.value.size > 15) {
       // First try to find an entry without any name (no nickname or username)
       let keyToDelete = null;
       for (const [key, value] of eids.value.entries()) {
@@ -80,7 +80,10 @@ export const useEidsStore = defineStore('eids', () => {
   function editName(eid: string, oldname?: string) {
     const name = prompt('Enter a name for this EID:', oldname);
     if (name !== null) {
-      updateNickname(eid, name);
+      // If the user clears the nickname and we have a captured username,
+      // fall back to displaying the username by copying it to nickname.
+      const entry = eids.value.get(eid);
+      updateNickname(eid, name || entry?.username || '');
     }
   }
 

--- a/ui/components/PlayerIdForm.vue
+++ b/ui/components/PlayerIdForm.vue
@@ -1,14 +1,19 @@
 <template>
-  <form class="mx-4 sm:mx-auto sm:max-w-xs sm:w-full mt-2 mb-4 space-y-1" @submit.prevent="$emit('submit', input)">
+  <form class="mx-4 sm:mx-auto sm:max-w-xs sm:w-full mt-2 mb-4 space-y-1" @submit.prevent="submit">
     <div>
       <label for="email" class="sr-only">Player ID</label>
       <base-input
         id="playerId"
-        v-model.trim="input"
+        v-model="displayValue"
         type="text"
         name="playerId"
+        :readonly="!editing"
         class="appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
+        :class="{ 'cursor-pointer': !editing && activeEid }"
+        :title="!editing && activeEid ? 'Click to reveal/edit the EID' : undefined"
         placeholder="Player ID"
+        @focus="onFocus"
+        @blur="onBlur"
       />
       <div v-if="eids.size <= 1" class="text-center">
         <span
@@ -25,26 +30,28 @@
       <div v-else class="mt-2 mb-2 w-fit mx-auto">
         <div class="flex flex-wrap gap-2 w-fit">
           <span
-            v-for="[eid, name] of eids"
+            v-for="[eid, entry] of eids"
             :key="eid"
-            class="inline-flex items-center px-1 py-1 rounded-full bg-gray-200 border border-gray-300 text-xs text-gray-900 w-fit"
+            class="inline-flex items-center px-1 py-1 rounded-full border text-xs w-fit"
+            :class="
+              eid === activeEid
+                ? 'bg-blue-100 border-blue-400 text-gray-900'
+                : 'bg-gray-200 border-gray-300 text-gray-900'
+            "
           >
             <button
               type="button"
               class="mr-1 text-gray-400 hover:text-blue-500 focus:outline-none"
               aria-label="Edit name"
-              @click="eidsStore.editName(eid, name)"
+              @click="eidsStore.editName(eid, entry.nickname)"
             >
               ✎
             </button>
             <span
               class="hover:underline cursor-pointer"
               style="text-decoration-thickness: 1.5px"
-              @click="
-                input = eid;
-                $emit('submit', eid);
-              "
-              >{{ name || eid }}</span
+              @click="loadEid(eid)"
+              >{{ eidsStore.displayName(eid) }}</span
             >
             <button
               type="button"
@@ -64,6 +71,7 @@
         class="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50"
         :class="{ 'cursor-not-allowed': !submittable }"
         :disabled="!submittable"
+        @mousedown.prevent
       >
         Load Player Data
       </button>
@@ -72,11 +80,11 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, ref, toRefs, watch } from 'vue';
+import { defineComponent, toRefs, watch } from 'vue';
 
 import BaseInfo from './BaseInfo.vue';
 import BaseInput from './BaseInput.vue';
-import { useEidsStore } from 'lib';
+import { useEidInput } from '../composables/eid_input';
 import { PlayerIdSchema } from 'lib/schema';
 
 export default defineComponent({
@@ -93,27 +101,52 @@ export default defineComponent({
   emits: {
     submit: (_playerId: string) => true,
   },
-  setup(props) {
+  setup(props, { emit }) {
     const { playerId } = toRefs(props);
-    const eidsStore = ref(useEidsStore());
-    const input = ref(playerId.value.trim());
-    const eids = eidsStore.value.eids;
+
+    const { eidsStore, eids, activeEid, editing, displayValue, submittable, onFocus, onBlur, resolveSubmit, commit } =
+      useEidInput(playerId.value);
 
     // Initialize with current playerId
     if (playerId.value) {
-      eidsStore.value.addEid(playerId.value);
+      eidsStore.addEid(playerId.value);
     }
 
+    // The parent drives the active player via the prop.
     watch(playerId, () => {
-      input.value = playerId.value.trim();
-      eidsStore.value.addEid(playerId.value);
+      commit(playerId.value);
+      eidsStore.addEid(playerId.value);
     });
 
-    const submittable = computed(() => PlayerIdSchema.safeParse(input.value.trim()).success);
+    const load = (eid: string) => {
+      const trimmed = eid.trim();
+      if (!PlayerIdSchema.safeParse(trimmed).success) {
+        return;
+      }
+      commit(trimmed);
+      emit('submit', trimmed);
+    };
+
+    // The button submits the typed EID (or reloads the active player in display
+    // mode).
+    const submit = () => {
+      load(resolveSubmit());
+    };
+
+    // Clicking a recent-ID pill loads that player.
+    const loadEid = (eid: string) => {
+      load(eid);
+    };
 
     return {
-      input,
+      activeEid,
+      editing,
+      displayValue,
+      onFocus,
+      onBlur,
       submittable,
+      submit,
+      loadEid,
       eids,
       eidsStore,
     };

--- a/ui/components/PlayerIdForm.vue
+++ b/ui/components/PlayerIdForm.vue
@@ -2,19 +2,30 @@
   <form class="mx-4 sm:mx-auto sm:max-w-xs sm:w-full mt-2 mb-4 space-y-1" @submit.prevent="submit">
     <div>
       <label for="email" class="sr-only">Player ID</label>
-      <base-input
-        id="playerId"
-        v-model="displayValue"
-        type="text"
-        name="playerId"
-        :readonly="!editing"
-        class="appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
-        :class="{ 'cursor-pointer': !editing && activeEid }"
-        :title="!editing && activeEid ? 'Click to reveal/edit the EID' : undefined"
-        placeholder="Player ID"
-        @focus="onFocus"
-        @blur="onBlur"
-      />
+      <div class="flex items-center gap-2">
+        <button
+          v-if="activeEid"
+          type="button"
+          class="text-gray-400 hover:text-blue-500 focus:outline-none"
+          aria-label="Edit name"
+          @click="eidsStore.editName(activeEid, eids.get(activeEid)?.nickname)"
+        >
+          ✎
+        </button>
+        <base-input
+          id="playerId"
+          v-model="displayValue"
+          type="text"
+          name="playerId"
+          :readonly="!editing"
+          class="appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
+          :class="{ 'cursor-pointer': !editing && activeEid }"
+          :title="!editing && activeEid ? 'Click to reveal/edit the EID' : undefined"
+          placeholder="Player ID"
+          @focus="onFocus"
+          @blur="onBlur"
+        />
+      </div>
       <div v-if="eids.size <= 1" class="text-center">
         <span
           v-tippy="{

--- a/ui/composables/eid_input.ts
+++ b/ui/composables/eid_input.ts
@@ -1,0 +1,95 @@
+import { computed, nextTick, ref } from 'vue';
+
+import { useEidsStore } from 'lib';
+import { PlayerIdSchema } from 'lib/schema';
+
+// Shared state machine for the player-ID input box used by both eicoop's
+// UserDashboardEntryForm and the suite-wide PlayerIdForm. The box has two modes:
+//
+//   - display mode: shows the active player's username (never the raw EID);
+//   - edit mode: reveals the raw EID for editing, entered by focusing the box.
+//
+// Focusing reveals the EID; blurring re-hides it and discards the edit, except a
+// valid typed EID is preserved across blur so a subsequent submit (e.g. Tab then
+// Enter, where focus has already left the input) loads it instead of silently
+// reloading the previously active player. The owning component supplies the
+// actual load side effect (save/navigate/emit) and calls `commit` once a load
+// has been initiated.
+export function useEidInput(initialEid: string) {
+  const eidsStore = useEidsStore();
+
+  // The EID whose data is currently loaded. Its display name (username), not the
+  // raw EID, is shown in the box by default.
+  const activeEid = ref(initialEid.trim());
+  const editing = ref(false);
+  // Raw text the user is typing while editing.
+  const inputValue = ref('');
+  // A valid EID typed then blurred without submitting, held so the next submit
+  // can use it rather than reloading the active player.
+  const pendingEid = ref('');
+
+  // What the box shows: the typed text while editing, otherwise the active
+  // player's display name — never the raw EID.
+  const displayValue = computed({
+    get: () => (editing.value ? inputValue.value : activeEid.value ? eidsStore.displayName(activeEid.value) : ''),
+    set: (value: string) => {
+      // Only accept writes while editing; guards against stray input events
+      // (e.g. browser autofill) on the read-only display value.
+      if (editing.value) {
+        inputValue.value = value;
+      }
+    },
+  });
+
+  // The submit control submits the typed EID while editing, a valid value
+  // preserved across blur, otherwise reloads the active player.
+  const submittable = computed(() =>
+    editing.value
+      ? PlayerIdSchema.safeParse(inputValue.value.trim()).success
+      : !!activeEid.value || PlayerIdSchema.safeParse(pendingEid.value).success
+  );
+
+  // Clicking into the box reveals the raw EID, ready to edit or replace.
+  const onFocus = (event: FocusEvent) => {
+    editing.value = true;
+    inputValue.value = activeEid.value;
+    pendingEid.value = '';
+    nextTick(() => (event.target as HTMLInputElement | null)?.select());
+  };
+
+  // Clicking away re-hides the EID. A valid typed EID is preserved for an
+  // imminent submit; anything else is discarded.
+  const onBlur = () => {
+    editing.value = false;
+    const typed = inputValue.value.trim();
+    pendingEid.value = PlayerIdSchema.safeParse(typed).success ? typed : '';
+    inputValue.value = '';
+  };
+
+  // The EID the submit control should act on right now.
+  function resolveSubmit(): string {
+    return (editing.value ? inputValue.value : pendingEid.value || activeEid.value).trim();
+  }
+
+  // Reset transient input state and record the now-active EID. Call once a load
+  // has been initiated (by submit, a pill click, or the parent prop changing).
+  function commit(eid: string) {
+    activeEid.value = eid.trim();
+    editing.value = false;
+    inputValue.value = '';
+    pendingEid.value = '';
+  }
+
+  return {
+    eidsStore,
+    eids: eidsStore.eids,
+    activeEid,
+    editing,
+    displayValue,
+    submittable,
+    onFocus,
+    onBlur,
+    resolveSubmit,
+    commit,
+  };
+}

--- a/wasmegg/ascension-planner/src/App.vue
+++ b/wasmegg/ascension-planner/src/App.vue
@@ -1,8 +1,12 @@
 <template>
-  
   <the-nav-bar active-entry-id="ascension-planner" />
 
-  <div :class="['min-h-screen bg-gray-100 transition-all duration-300', (plannerTab === 'automatic' || isFooterCollapsed) ? 'pb-8' : 'pb-24']">
+  <div
+    :class="[
+      'min-h-screen bg-gray-100 transition-all duration-300',
+      plannerTab === 'automatic' || isFooterCollapsed ? 'pb-8' : 'pb-24',
+    ]"
+  >
     <div class="max-w-6xl mx-auto p-4">
       <!-- Collapsible Header Region -->
       <div class="bg-white/95 backdrop-blur-xl rounded-2xl border border-slate-100 shadow-sm">
@@ -21,31 +25,54 @@
               Player Backup From: {{ lastBackupFormatted }}
             </div>
 
-            <the-player-id-form :player-id="playerId" @submit="submitPlayerId" @input="onFormInput" />
+            <the-player-id-form :player-id="playerId" @submit="submitPlayerId" />
 
             <!-- Mode Tabs -->
-            <div v-if="playerId && !loading" class="mt-6 flex justify-center animate-in fade-in slide-in-from-top-4 duration-500">
+            <div
+              v-if="playerId && !loading"
+              class="mt-6 flex justify-center animate-in fade-in slide-in-from-top-4 duration-500"
+            >
               <div class="bg-slate-50 p-1.5 rounded-2xl border border-slate-200/50 shadow-sm flex gap-1">
                 <button
                   class="px-6 py-2.5 rounded-xl text-[11px] font-black uppercase tracking-[0.15em] transition-all duration-300 flex items-center gap-2"
-                  :class="plannerTab === 'manual' ? 'bg-slate-900 text-white shadow-lg shadow-slate-200' : 'text-slate-400 hover:text-slate-600 hover:bg-slate-50'"
+                  :class="
+                    plannerTab === 'manual'
+                      ? 'bg-slate-900 text-white shadow-lg shadow-slate-200'
+                      : 'text-slate-400 hover:text-slate-600 hover:bg-slate-50'
+                  "
                   @click="plannerTab = 'manual'"
                 >
                   <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                      d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
+                    />
                   </svg>
                   Manual Planner
                 </button>
                 <button
                   class="px-6 py-2.5 rounded-xl text-[11px] font-black uppercase tracking-[0.15em] transition-all duration-300 flex items-center gap-2"
-                  :class="plannerTab === 'automatic' ? 'bg-indigo-600 text-white shadow-lg shadow-indigo-100' : 'text-slate-400 hover:text-slate-600 hover:bg-slate-50'"
+                  :class="
+                    plannerTab === 'automatic'
+                      ? 'bg-indigo-600 text-white shadow-lg shadow-indigo-100'
+                      : 'text-slate-400 hover:text-slate-600 hover:bg-slate-50'
+                  "
                   @click="handleAutoPlannerTabClick"
                 >
                   <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z" />
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                      d="M13 10V3L4 14h7v7l9-11h-7z"
+                    />
                   </svg>
                   Auto Planner
-                  <span class="bg-indigo-500 text-[8px] px-1.5 py-0.5 rounded-md ml-1 border border-indigo-400/30">BETA</span>
+                  <span class="bg-indigo-500 text-[8px] px-1.5 py-0.5 rounded-md ml-1 border border-indigo-400/30"
+                    >BETA</span
+                  >
                 </button>
               </div>
             </div>
@@ -187,7 +214,6 @@
                 </div>
               </div>
             </div>
-
           </div>
         </div>
       </div>
@@ -222,16 +248,26 @@
         >
           <div class="flex items-center gap-3 relative z-10">
             <!-- Icon/Status -->
-            <div class="w-8 h-8 rounded-full bg-emerald-100 flex items-center justify-center text-emerald-600 shadow-sm">
+            <div
+              class="w-8 h-8 rounded-full bg-emerald-100 flex items-center justify-center text-emerald-600 shadow-sm"
+            >
               <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+                />
               </svg>
             </div>
-            
+
             <div class="flex flex-col gap-0 text-left">
-              <span class="text-[8px] font-black text-slate-400 uppercase tracking-widest leading-none mb-0.5">Reconciliation Mode</span>
+              <span class="text-[8px] font-black text-slate-400 uppercase tracking-widest leading-none mb-0.5"
+                >Reconciliation Mode</span
+              >
               <span class="text-[10px] font-bold text-emerald-600 tracking-tight">
-                Backup from {{ lastBackupFormatted }} <span class="text-emerald-400/80 font-medium">({{ lastBackupAge }})</span>
+                Backup from {{ lastBackupFormatted }}
+                <span class="text-emerald-400/80 font-medium">({{ lastBackupAge }})</span>
               </span>
             </div>
           </div>
@@ -250,7 +286,7 @@
                   :class="actionsStore.showIncompleteOnly ? 'translate-x-[13px]' : 'translate-x-1'"
                 />
               </button>
-            </div> 
+            </div>
 
             <!-- Refresh Button -->
             <button
@@ -259,12 +295,19 @@
               :disabled="loading"
               @click="handleRefreshReconcile"
             >
-              <svg 
-                class="w-4 h-4" 
+              <svg
+                class="w-4 h-4"
                 :class="{ 'animate-spin': loading }"
-                fill="none" stroke="currentColor" viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
               >
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+                />
               </svg>
             </button>
           </div>
@@ -324,7 +367,11 @@
               </button>
             </div>
             <div v-if="expandedSections.actionHistory" class="border-t border-gray-200 p-4 bg-gray-50 rounded-b-lg">
-              <ActionHistory @show-details="showActionDetails" @undo="showUndoConfirmation" @clear-all="handleClearAll" />
+              <ActionHistory
+                @show-details="showActionDetails"
+                @undo="showUndoConfirmation"
+                @clear-all="handleClearAll"
+              />
             </div>
           </div>
 
@@ -340,10 +387,7 @@
               </button>
             </div>
             <div v-if="expandedSections.availableActions" class="border-t border-gray-200 p-4 bg-gray-50 rounded-b-lg">
-              <AvailableActions 
-                @show-current-details="showCurrentDetails" 
-                @refresh-backup="handleRefreshReconcile"
-              />
+              <AvailableActions @show-current-details="showCurrentDetails" @refresh-backup="handleRefreshReconcile" />
             </div>
           </div>
         </div>
@@ -353,87 +397,95 @@
         <AutomaticPlanner />
       </div>
 
-    <!-- Action Details Modal -->
-    <ActionDetailsModal v-if="showDetailsModal" :action="detailsModalAction" @close="closeActionDetails" />
+      <!-- Action Details Modal -->
+      <ActionDetailsModal v-if="showDetailsModal" :action="detailsModalAction" @close="closeActionDetails" />
 
-    <!-- Undo Confirmation Dialog -->
-    <UndoConfirmationDialog
-      v-if="undoAction"
-      :action="undoAction"
-      :dependents-a="undoDependentsA"
-      :dependents-b="undoDependentsB"
-      @confirm="executeUndo"
-      @cancel="cancelUndo"
-    />
+      <!-- Undo Confirmation Dialog -->
+      <UndoConfirmationDialog
+        v-if="undoAction"
+        :action="undoAction"
+        :dependents-a="undoDependentsA"
+        :dependents-b="undoDependentsB"
+        @confirm="executeUndo"
+        @cancel="cancelUndo"
+      />
 
-    <!-- Clear All Confirmation Dialog -->
-    <ConfirmationDialog
-      v-if="showClearAllConfirmation"
-      title="Clear All Actions"
-      message="Are you sure you want to clear all actions? This cannot be undone."
-      confirm-label="Clear All"
-      @confirm="executeClearAll"
-      @cancel="showClearAllConfirmation = false"
-    />
+      <!-- Clear All Confirmation Dialog -->
+      <ConfirmationDialog
+        v-if="showClearAllConfirmation"
+        title="Clear All Actions"
+        message="Are you sure you want to clear all actions? This cannot be undone."
+        confirm-label="Clear All"
+        @confirm="executeClearAll"
+        @cancel="showClearAllConfirmation = false"
+      />
 
-    <!-- Unsaved Changes Protection Dialog -->
-    <ConfirmationDialog
-      v-if="showUnsavedConfirm"
-      title="Unsaved Changes"
-      message="You have unsaved changes in your current plan. If you continue, these changes will be lost. Would you like to save before proceeding?"
-      confirm-label="Continue Without Saving"
-      variant="danger"
-      @confirm="
-        showUnsavedConfirm = false;
-        pendingAction?.();
-      "
-      @cancel="
-        showUnsavedConfirm = false;
-        pendingAction = null;
-      "
-    />
+      <!-- Unsaved Changes Protection Dialog -->
+      <ConfirmationDialog
+        v-if="showUnsavedConfirm"
+        title="Unsaved Changes"
+        message="You have unsaved changes in your current plan. If you continue, these changes will be lost. Would you like to save before proceeding?"
+        confirm-label="Continue Without Saving"
+        variant="danger"
+        @confirm="
+          showUnsavedConfirm = false;
+          pendingAction?.();
+        "
+        @cancel="
+          showUnsavedConfirm = false;
+          pendingAction = null;
+        "
+      />
 
-    <!-- Plan Selection Dialog (for Reconcile) -->
-    <PlanSelectionDialog
-      v-if="showReconcileLibraryModal"
-      @select="handleLibraryReconcile"
-      @cancel="showReconcileLibraryModal = false"
-    />
+      <!-- Plan Selection Dialog (for Reconcile) -->
+      <PlanSelectionDialog
+        v-if="showReconcileLibraryModal"
+        @select="handleLibraryReconcile"
+        @cancel="showReconcileLibraryModal = false"
+      />
 
-    <!-- Artifact Set Selection Dialog -->
-    <div v-if="showArtifactSetConfirm" class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
-      <div class="bg-white rounded-2xl shadow-2xl max-w-sm w-full overflow-hidden animate-in fade-in zoom-in-95 duration-200">
-        <div class="px-6 py-5 border-b border-slate-100">
-          <h3 class="text-lg font-bold text-slate-800">Current Artifact Set</h3>
-          <p class="mt-2 text-sm text-slate-500">Which artifact set do you currently have equipped in game?</p>
-        </div>
-        <div class="px-6 py-4 bg-slate-50 flex justify-end gap-3 rounded-b-2xl">
-          <button class="px-4 py-2 text-sm font-semibold text-white bg-indigo-600 rounded-lg hover:bg-indigo-700 transition-colors shadow-sm" @click="handleArtifactSetSelection('elr')">
-            Delivery Rate Set
-          </button>
-          <button class="px-4 py-2 text-sm font-semibold text-white bg-indigo-600 rounded-lg hover:bg-indigo-700 transition-colors shadow-sm" @click="handleArtifactSetSelection('earnings')">
-            Earnings Set
-          </button>
+      <!-- Artifact Set Selection Dialog -->
+      <div v-if="showArtifactSetConfirm" class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+        <div
+          class="bg-white rounded-2xl shadow-2xl max-w-sm w-full overflow-hidden animate-in fade-in zoom-in-95 duration-200"
+        >
+          <div class="px-6 py-5 border-b border-slate-100">
+            <h3 class="text-lg font-bold text-slate-800">Current Artifact Set</h3>
+            <p class="mt-2 text-sm text-slate-500">Which artifact set do you currently have equipped in game?</p>
+          </div>
+          <div class="px-6 py-4 bg-slate-50 flex justify-end gap-3 rounded-b-2xl">
+            <button
+              class="px-4 py-2 text-sm font-semibold text-white bg-indigo-600 rounded-lg hover:bg-indigo-700 transition-colors shadow-sm"
+              @click="handleArtifactSetSelection('elr')"
+            >
+              Delivery Rate Set
+            </button>
+            <button
+              class="px-4 py-2 text-sm font-semibold text-white bg-indigo-600 rounded-lg hover:bg-indigo-700 transition-colors shadow-sm"
+              @click="handleArtifactSetSelection('earnings')"
+            >
+              Earnings Set
+            </button>
+          </div>
         </div>
       </div>
-    </div>
 
-    <!-- Continuity Check Dialog -->
-    <ContinuityDialog />
+      <!-- Continuity Check Dialog -->
+      <ContinuityDialog />
 
-    <WarningDialog />
+      <WarningDialog />
 
-    <RecalculationOverlay />
+      <RecalculationOverlay />
 
-    <PlanFinalSummary
-      v-if="plannerTab === 'manual'"
-      @show-details="showCurrentDetails"
-      @update:collapsed="isFooterCollapsed = $event"
-      @save-plan="saveCurrentPlan"
-      @save-plan-as="savePlanAs"
-    />
-    <FloatingStats v-if="plannerTab === 'manual'" @show-details="showCurrentDetails" />
-    <FloatingNotes v-if="plannerTab === 'manual'" />
+      <PlanFinalSummary
+        v-if="plannerTab === 'manual'"
+        @show-details="showCurrentDetails"
+        @update:collapsed="isFooterCollapsed = $event"
+        @save-plan="saveCurrentPlan"
+        @save-plan-as="savePlanAs"
+      />
+      <FloatingStats v-if="plannerTab === 'manual'" @show-details="showCurrentDetails" />
+      <FloatingNotes v-if="plannerTab === 'manual'" />
     </div>
   </div>
 </template>
@@ -511,7 +563,7 @@ const lastBackupFormatted = computed(() => {
   const approxTime = initialStateStore.rawBackup?.approxTime;
   if (approxTime == null) return 'Unknown';
   const date = new Date(approxTime * 1000);
-  
+
   return date.toLocaleTimeString(undefined, {
     weekday: 'short',
     month: 'short',
@@ -526,12 +578,12 @@ const lastBackupAge = computed(() => {
   if (approxTime == null) return '';
   const now = Date.now() / 1000;
   const diff = Math.max(0, now - approxTime);
-  
+
   if (diff < 60) return 'Just now';
-  
+
   const minutes = Math.floor(diff / 60);
   if (minutes < 60) return `${minutes}m ago`;
-  
+
   const hours = Math.floor(minutes / 60);
   const remainingMinutes = minutes % 60;
   return `${hours}h${remainingMinutes}m ago`;
@@ -831,18 +883,10 @@ async function handleRefreshReconcile() {
   }
 }
 
-function onFormInput(e: Event) {
-  const target = e.target as HTMLInputElement;
-  if (target?.id === 'playerId') {
-    playerId.value = target.value.trim();
-  }
-  error.value = '';
-}
-
 async function handleAutoPlannerTabClick() {
   plannerTab.value = 'automatic';
   isHeaderCollapsed.value = true;
-  
+
   if (playerId.value && !loading.value) {
     loading.value = true;
     try {
@@ -888,12 +932,12 @@ async function submitPlayerId(id: string) {
     // Load into state store and sync global stores
     const { teEarnedPerEgg } = loadAndSyncBackup(id, backup, 'default');
 
-    // Catch-up calculations (eggs, earnings, population) are now handled 
+    // Catch-up calculations (eggs, earnings, population) are now handled
     // automatically by computeSnapshot in the engine.
     const context = getSimulationContext();
     const baseState = createBaseEngineState(null);
     const initialSnapshot = computeSnapshot(baseState, context);
-    
+
     // Sync farm state and Truth Eggs with caught-up values
     catchUpFarmState(initialSnapshot, baseState.bankValue, context.ascensionStartTime, teEarnedPerEgg);
 
@@ -1104,9 +1148,5 @@ const ChevronIcon = {
 }
 .btn-ghost {
   @apply bg-transparent hover:bg-slate-50 border border-slate-100;
-}
-:deep(#playerId:not(:focus)) {
-  filter: blur(4px);
-  transition: filter 0.2s;
 }
 </style>


### PR DESCRIPTION
The recent-ID pills and player-ID input boxes now display a player's in-game username rather than their raw EID, so EIDs stay hidden once data has loaded (friendlier and safer for screenshots).

- Store each EID as { username, nickname } instead of a single string. `username` is auto-captured from the backup. Display precedence: nickname || username || eid.
- Capture the username centrally in requestFirstContact so every tool's backup fetch populates it. Unknown EIDs route through addEid so the recent-IDs cap is enforced.
- Input box: shows the username by default; clicking it reveals the raw EID for editing, clicking away or reloading re-hides it, and the submit control reloads the active player. A valid typed EID is preserved across blur so Tab-then-submit loads it. Logic extracted to a shared ui/composables/eid_input composable used by eicoop's UserDashboardEntryForm and the shared ui/PlayerIdForm.