### PR TITLE
Misc. Fixes & Enhancements

### DIFF
--- a/wasmegg/ascension-planner/src/auto/ascension.ts
+++ b/wasmegg/ascension-planner/src/auto/ascension.ts
@@ -299,6 +299,19 @@ export function runAscension(
     nextSale = getNextSaleStart(nextSale + 1);
   }
 
+  // finalTE is the source of truth for TE totals: it's derived directly from
+  // eggsDelivered, whereas currentState.te is an incrementally-maintained counter
+  // that build-phase shifts (passive egg accumulation) don't update, so it can
+  // under-count relative to finalTE.
+  const finalTE = {
+    curiosity: countTEThresholdsPassed(currentState.eggsDelivered['curiosity'] || 0),
+    integrity: countTEThresholdsPassed(currentState.eggsDelivered['integrity'] || 0),
+    resilience: countTEThresholdsPassed(currentState.eggsDelivered['resilience'] || 0),
+    humility: countTEThresholdsPassed(currentState.eggsDelivered['humility'] || 0),
+    kindness: countTEThresholdsPassed(currentState.eggsDelivered['kindness'] || 0),
+  };
+  const endTE = Object.values(finalTE).reduce((a, b) => a + b, 0);
+
   // Build the summary
   const summary: AscensionSummary = {
     id,
@@ -308,8 +321,8 @@ export function runAscension(
     buildPhaseEndTime: buildPhaseEnd,
     buildPhaseSaleCount: (saleCount === 2 ? 2 : 1) as 1 | 2,
     startTE: startState.te,
-    endTE: currentState.te,
-    teGained: currentState.te - startState.te,
+    endTE,
+    teGained: endTE - startState.te,
     maxELR: currentState.maxELR || 0,
     startSoulEggs: startState.soulEggs,
     endSoulEggs: seResult.endingSE,
@@ -324,22 +337,10 @@ export function runAscension(
       humility: (currentState.teEarned['humility'] || 0) - (startState.teEarned['humility'] || 0),
       kindness: (currentState.teEarned['kindness'] || 0) - (startState.teEarned['kindness'] || 0),
     },
-    finalTE: {
-      curiosity: countTEThresholdsPassed(currentState.eggsDelivered['curiosity'] || 0),
-      integrity: countTEThresholdsPassed(currentState.eggsDelivered['integrity'] || 0),
-      resilience: countTEThresholdsPassed(currentState.eggsDelivered['resilience'] || 0),
-      humility: countTEThresholdsPassed(currentState.eggsDelivered['humility'] || 0),
-      kindness: countTEThresholdsPassed(currentState.eggsDelivered['kindness'] || 0),
-    },
+    finalTE,
     strategyLabel: `${saleCount}-sale build`,
     isMaxELRAscension: false,
-    lastTEDurationSeconds: computeLastTEDuration({
-      curiosity: countTEThresholdsPassed(currentState.eggsDelivered['curiosity'] || 0),
-      integrity: countTEThresholdsPassed(currentState.eggsDelivered['integrity'] || 0),
-      resilience: countTEThresholdsPassed(currentState.eggsDelivered['resilience'] || 0),
-      humility: countTEThresholdsPassed(currentState.eggsDelivered['humility'] || 0),
-      kindness: countTEThresholdsPassed(currentState.eggsDelivered['kindness'] || 0),
-    }, currentState.maxELR || 0),
+    lastTEDurationSeconds: computeLastTEDuration(finalTE, currentState.maxELR || 0),
   };
 
   return {
@@ -463,6 +464,15 @@ export function runContinueCurrent(
   const shiftCount = currentActions.filter(a => a.type === 'shift').length;
   const seResult = computeShiftCosts(startState.soulEggs, startState.shiftCount, shiftCount);
 
+  const finalTE = {
+    curiosity: countTEThresholdsPassed(currentState.eggsDelivered['curiosity'] || 0),
+    integrity: countTEThresholdsPassed(currentState.eggsDelivered['integrity'] || 0),
+    resilience: countTEThresholdsPassed(currentState.eggsDelivered['resilience'] || 0),
+    humility: countTEThresholdsPassed(currentState.eggsDelivered['humility'] || 0),
+    kindness: countTEThresholdsPassed(currentState.eggsDelivered['kindness'] || 0),
+  };
+  const endTE = Object.values(finalTE).reduce((a, b) => a + b, 0);
+
   const summary: AscensionSummary = {
     id,
     startTime,
@@ -471,8 +481,8 @@ export function runContinueCurrent(
     buildPhaseEndTime: startTime, // No build phase
     buildPhaseSaleCount: 1,
     startTE: startState.te,
-    endTE: currentState.te,
-    teGained: currentState.te - startState.te,
+    endTE,
+    teGained: endTE - startState.te,
     maxELR: currentELR,
     startSoulEggs: startState.soulEggs,
     endSoulEggs: seResult.endingSE,
@@ -487,22 +497,10 @@ export function runContinueCurrent(
       humility: (currentState.teEarned['humility'] || 0) - (startState.teEarned['humility'] || 0),
       kindness: (currentState.teEarned['kindness'] || 0) - (startState.teEarned['kindness'] || 0),
     },
-    finalTE: {
-      curiosity: countTEThresholdsPassed(currentState.eggsDelivered['curiosity'] || 0),
-      integrity: countTEThresholdsPassed(currentState.eggsDelivered['integrity'] || 0),
-      resilience: countTEThresholdsPassed(currentState.eggsDelivered['resilience'] || 0),
-      humility: countTEThresholdsPassed(currentState.eggsDelivered['humility'] || 0),
-      kindness: countTEThresholdsPassed(currentState.eggsDelivered['kindness'] || 0),
-    },
+    finalTE,
     strategyLabel: 'Continue current',
     isMaxELRAscension: false,
-    lastTEDurationSeconds: computeLastTEDuration({
-      curiosity: countTEThresholdsPassed(currentState.eggsDelivered['curiosity'] || 0),
-      integrity: countTEThresholdsPassed(currentState.eggsDelivered['integrity'] || 0),
-      resilience: countTEThresholdsPassed(currentState.eggsDelivered['resilience'] || 0),
-      humility: countTEThresholdsPassed(currentState.eggsDelivered['humility'] || 0),
-      kindness: countTEThresholdsPassed(currentState.eggsDelivered['kindness'] || 0),
-    }, currentELR),
+    lastTEDurationSeconds: computeLastTEDuration(finalTE, currentELR),
   };
 
   return {

--- a/wasmegg/ascension-planner/src/auto/buildLibraryPlans.ts
+++ b/wasmegg/ascension-planner/src/auto/buildLibraryPlans.ts
@@ -24,6 +24,16 @@ export function buildLibraryPlansFromExport(
   return imported.ascensions.map((a, idx) => {
     const best = pickBest(a, idx, overrides);
 
+    const state = JSON.parse(JSON.stringify(imported.initialState));
+
+    if (idx > 0) {
+      const prevBest = pickBest(imported.ascensions[idx - 1], idx - 1, overrides);
+      state.initialTeEarned = { ...prevBest.summary.finalTE };
+      state.initialEggsDelivered = { ...prevBest.summary.eggsDelivered };
+      state.soulEggs = prevBest.summary.endSoulEggs;
+      state.initialShiftCount = prevBest.summary.endShiftCount;
+    }
+
     let finalActions = best.actions;
     if (finalActions.length === 0 || finalActions[0].type !== 'start_ascension') {
       const startAction = {
@@ -35,7 +45,12 @@ export function buildLibraryPlansFromExport(
         cost: 0, elrDelta: 0, offlineEarningsDelta: 0, eggValueDelta: 0,
         habCapacityDelta: 0, layRateDelta: 0, shippingCapacityDelta: 0,
         ihrDelta: 0, bankDelta: 0, populationDelta: 0, totalTimeSeconds: 0,
-        endState: createEmptySnapshot(),
+        endState: {
+          ...createEmptySnapshot(),
+          currentEgg: 'curiosity',
+          eggsDelivered: { ...state.initialEggsDelivered },
+          teEarned: { ...state.initialTeEarned },
+        },
         dependsOn: [], dependents: [],
       };
       finalActions = [startAction, ...finalActions];
@@ -47,16 +62,6 @@ export function buildLibraryPlansFromExport(
     const peakELR = formatNumber(summary.maxELR * 3600, 2);
     const duration = formatDuration(summary.totalDurationSeconds);
     const name = `${namePrefix} A${idx + 1} - ${peakELR}/hr from ${summary.startTE} to ${summary.endTE} - ${duration} - starting ${startStr}`;
-
-    const state = JSON.parse(JSON.stringify(imported.initialState));
-
-    if (idx > 0) {
-      const prevBest = pickBest(imported.ascensions[idx - 1], idx - 1, overrides);
-      state.initialTeEarned = { ...prevBest.summary.finalTE };
-      state.initialEggsDelivered = { ...prevBest.summary.eggsDelivered };
-      state.soulEggs = prevBest.summary.endSoulEggs;
-      state.initialShiftCount = prevBest.summary.endShiftCount;
-    }
 
     return {
       name,

--- a/wasmegg/ascension-planner/src/auto/shifts/c1.ts
+++ b/wasmegg/ascension-planner/src/auto/shifts/c1.ts
@@ -14,7 +14,7 @@ import {
 } from '../engine/strategist';
 import { getArtifact, getStone, calculateArtifactModifiers } from '../../lib/artifacts';
 import { computeSnapshot } from '../../engine/compute';
-import { applyAction } from '../../engine/apply';
+import { applyAction, calculateEggsDeliveredForTime } from '../../engine/apply';
 import { createSimAction } from '@/types/actions/meta';
 import {
   isResearchSaleActive,
@@ -118,9 +118,15 @@ export function runC1(
 
         const snap = computeSnapshot(currentState, context, { skipGrowth: true });
         const waitAction = createSimAction(actionType, { totalTimeSeconds: stepSeconds });
-        
+        const passiveEggs = calculateEggsDeliveredForTime(stepSeconds, snap);
+
         currentState = applyAction(currentState, waitAction);
-        currentState = { ...currentState, lastStepTime: (currentState.lastStepTime || 0) + stepSeconds, bankValue: (currentState.bankValue || 0) + snap.offlineEarnings * stepSeconds };
+        currentState = {
+          ...currentState,
+          lastStepTime: (currentState.lastStepTime || 0) + stepSeconds,
+          bankValue: (currentState.bankValue || 0) + snap.offlineEarnings * stepSeconds,
+          eggsDelivered: { ...currentState.eggsDelivered, [currentState.currentEgg]: (currentState.eggsDelivered[currentState.currentEgg] || 0) + passiveEggs },
+        };
 
         const finalSnap = computeSnapshot(currentState, context, { skipGrowth: true });
         waitAction.endState = finalSnap;

--- a/wasmegg/ascension-planner/src/auto/shifts/c2.ts
+++ b/wasmegg/ascension-planner/src/auto/shifts/c2.ts
@@ -14,7 +14,7 @@ import {
   DEFAULT_EARNINGS_CATEGORIES,
 } from '../engine/strategist';
 import { computeSnapshot } from '../../engine/compute';
-import { applyAction } from '../../engine/apply';
+import { applyAction, calculateEggsDeliveredForTime } from '../../engine/apply';
 import { createSimAction } from '@/types/actions/meta';
 import { shiftCost } from 'lib';
 import {
@@ -106,9 +106,15 @@ export function runC2(
 
         const snap = computeSnapshot(currentState, context, { skipGrowth: true });
         const waitAction = createSimAction(actionType, { totalTimeSeconds: stepSeconds });
-        
+        const passiveEggs = calculateEggsDeliveredForTime(stepSeconds, snap);
+
         currentState = applyAction(currentState, waitAction);
-        currentState = { ...currentState, lastStepTime: (currentState.lastStepTime || 0) + stepSeconds, bankValue: (currentState.bankValue || 0) + snap.offlineEarnings * stepSeconds };
+        currentState = {
+          ...currentState,
+          lastStepTime: (currentState.lastStepTime || 0) + stepSeconds,
+          bankValue: (currentState.bankValue || 0) + snap.offlineEarnings * stepSeconds,
+          eggsDelivered: { ...currentState.eggsDelivered, [currentState.currentEgg]: (currentState.eggsDelivered[currentState.currentEgg] || 0) + passiveEggs },
+        };
 
         const finalSnap = computeSnapshot(currentState, context, { skipGrowth: true });
         waitAction.endState = finalSnap;

--- a/wasmegg/ascension-planner/src/auto/shifts/c3.ts
+++ b/wasmegg/ascension-planner/src/auto/shifts/c3.ts
@@ -11,7 +11,7 @@ import {
   getBestEarningsRecommendation,
 } from '../engine/strategist';
 import { computeSnapshot } from '../../engine/compute';
-import { applyAction } from '../../engine/apply';
+import { applyAction, calculateEggsDeliveredForTime } from '../../engine/apply';
 import { createSimAction } from '@/types/actions/meta';
 import { shiftCost } from 'lib';
 import {
@@ -107,9 +107,15 @@ export function runC3(
 
         const snap = computeSnapshot(currentState, context, { skipGrowth: true });
         const waitAction = createSimAction(actionType, { totalTimeSeconds: stepSeconds });
-        
+        const passiveEggs = calculateEggsDeliveredForTime(stepSeconds, snap);
+
         currentState = applyAction(currentState, waitAction);
-        currentState = { ...currentState, lastStepTime: (currentState.lastStepTime || 0) + stepSeconds, bankValue: (currentState.bankValue || 0) + snap.offlineEarnings * stepSeconds };
+        currentState = {
+          ...currentState,
+          lastStepTime: (currentState.lastStepTime || 0) + stepSeconds,
+          bankValue: (currentState.bankValue || 0) + snap.offlineEarnings * stepSeconds,
+          eggsDelivered: { ...currentState.eggsDelivered, [currentState.currentEgg]: (currentState.eggsDelivered[currentState.currentEgg] || 0) + passiveEggs },
+        };
 
         const finalSnap = computeSnapshot(currentState, context, { skipGrowth: true });
         waitAction.endState = finalSnap;

--- a/wasmegg/ascension-planner/src/auto/shifts/i1.ts
+++ b/wasmegg/ascension-planner/src/auto/shifts/i1.ts
@@ -1,7 +1,7 @@
 import type { Action } from '@/types/actions/meta';
 import type { EngineState, SimulationContext, ShiftResult } from '../types';
 import { computeSnapshot } from '../../engine/compute';
-import { applyAction } from '../../engine/apply';
+import { applyAction, calculateEggsDeliveredForTime } from '../../engine/apply';
 import { createSimAction } from '@/types/actions/meta';
 import { shiftCost } from 'lib';
 import {
@@ -31,10 +31,16 @@ export function runI1(
     if (seconds <= 0) return;
     const snap = computeSnapshot(currentState, context, { skipGrowth: true });
     const waitAction = createSimAction('wait_for_time', { totalTimeSeconds: seconds });
-    
+    const passiveEggs = calculateEggsDeliveredForTime(seconds, snap);
+
     currentState = applyAction(currentState, waitAction);
     // applyAction doesn't update bankValue or lastStepTime for wait actions, so we credit them manually
-    currentState = { ...currentState, lastStepTime: (currentState.lastStepTime || 0) + seconds, bankValue: (currentState.bankValue || 0) + snap.offlineEarnings * seconds };
+    currentState = {
+      ...currentState,
+      lastStepTime: (currentState.lastStepTime || 0) + seconds,
+      bankValue: (currentState.bankValue || 0) + snap.offlineEarnings * seconds,
+      eggsDelivered: { ...currentState.eggsDelivered, [currentState.currentEgg]: (currentState.eggsDelivered[currentState.currentEgg] || 0) + passiveEggs },
+    };
     
     // Decoration for the action store
     const finalSnap = computeSnapshot(currentState, context, { skipGrowth: true });

--- a/wasmegg/ascension-planner/src/auto/shifts/k1.ts
+++ b/wasmegg/ascension-planner/src/auto/shifts/k1.ts
@@ -1,7 +1,7 @@
 import type { Action } from '@/types/actions/meta';
 import type { EngineState, SimulationContext, ShiftResult } from '../types';
 import { computeSnapshot } from '../../engine/compute';
-import { applyAction } from '../../engine/apply';
+import { applyAction, calculateEggsDeliveredForTime } from '../../engine/apply';
 import { createSimAction } from '@/types/actions/meta';
 import { shiftCost } from 'lib';
 import {
@@ -34,10 +34,16 @@ export function runK1(
     if (seconds <= 0) return;
     const snap = computeSnapshot(currentState, context, { skipGrowth: true });
     const waitAction = createSimAction('wait_for_time', { totalTimeSeconds: seconds });
-    
+    const passiveEggs = calculateEggsDeliveredForTime(seconds, snap);
+
     currentState = applyAction(currentState, waitAction);
     // applyAction doesn't update bankValue or lastStepTime for wait actions, so we credit them manually
-    currentState = { ...currentState, lastStepTime: (currentState.lastStepTime || 0) + seconds, bankValue: (currentState.bankValue || 0) + snap.offlineEarnings * seconds };
+    currentState = {
+      ...currentState,
+      lastStepTime: (currentState.lastStepTime || 0) + seconds,
+      bankValue: (currentState.bankValue || 0) + snap.offlineEarnings * seconds,
+      eggsDelivered: { ...currentState.eggsDelivered, [currentState.currentEgg]: (currentState.eggsDelivered[currentState.currentEgg] || 0) + passiveEggs },
+    };
     
     // Decoration for the action store
     const finalSnap = computeSnapshot(currentState, context, { skipGrowth: true });

--- a/wasmegg/ascension-planner/src/auto/shifts/k2.ts
+++ b/wasmegg/ascension-planner/src/auto/shifts/k2.ts
@@ -1,7 +1,7 @@
 import type { Action } from '@/types/actions/meta';
 import type { EngineState, SimulationContext, ShiftResult } from '../types';
 import { computeSnapshot } from '../../engine/compute';
-import { applyAction } from '../../engine/apply';
+import { applyAction, calculateEggsDeliveredForTime } from '../../engine/apply';
 import { createSimAction } from '@/types/actions/meta';
 import { shiftCost } from 'lib';
 import {
@@ -33,10 +33,16 @@ export function runK2(
     if (seconds <= 0) return;
     const snap = computeSnapshot(currentState, context, { skipGrowth: true });
     const waitAction = createSimAction('wait_for_time', { totalTimeSeconds: seconds });
-    
+    const passiveEggs = calculateEggsDeliveredForTime(seconds, snap);
+
     currentState = applyAction(currentState, waitAction);
     // applyAction doesn't update bankValue or lastStepTime for wait actions, so we credit them manually
-    currentState = { ...currentState, lastStepTime: (currentState.lastStepTime || 0) + seconds, bankValue: (currentState.bankValue || 0) + snap.offlineEarnings * seconds };
+    currentState = {
+      ...currentState,
+      lastStepTime: (currentState.lastStepTime || 0) + seconds,
+      bankValue: (currentState.bankValue || 0) + snap.offlineEarnings * seconds,
+      eggsDelivered: { ...currentState.eggsDelivered, [currentState.currentEgg]: (currentState.eggsDelivered[currentState.currentEgg] || 0) + passiveEggs },
+    };
     
     // Decoration for the action store
     const finalSnap = computeSnapshot(currentState, context, { skipGrowth: true });

--- a/wasmegg/ascension-planner/src/auto/shifts/k3.ts
+++ b/wasmegg/ascension-planner/src/auto/shifts/k3.ts
@@ -1,7 +1,7 @@
 import type { Action } from '@/types/actions/meta';
 import type { EngineState, SimulationContext, ShiftResult } from '../types';
 import { computeSnapshot } from '../../engine/compute';
-import { applyAction } from '../../engine/apply';
+import { applyAction, calculateEggsDeliveredForTime } from '../../engine/apply';
 import { createSimAction } from '@/types/actions/meta';
 import { shiftCost } from 'lib';
 import {
@@ -39,10 +39,16 @@ export function runK3(
     if (seconds <= 0) return;
     const snap = computeSnapshot(currentState, context, { skipGrowth: true });
     const waitAction = createSimAction('wait_for_time', { totalTimeSeconds: seconds, ...metadata });
-    
+    const passiveEggs = calculateEggsDeliveredForTime(seconds, snap);
+
     currentState = applyAction(currentState, waitAction);
     // applyAction doesn't update bankValue or lastStepTime for wait actions, so we credit them manually
-    currentState = { ...currentState, lastStepTime: (currentState.lastStepTime || 0) + seconds, bankValue: (currentState.bankValue || 0) + snap.offlineEarnings * seconds };
+    currentState = {
+      ...currentState,
+      lastStepTime: (currentState.lastStepTime || 0) + seconds,
+      bankValue: (currentState.bankValue || 0) + snap.offlineEarnings * seconds,
+      eggsDelivered: { ...currentState.eggsDelivered, [currentState.currentEgg]: (currentState.eggsDelivered[currentState.currentEgg] || 0) + passiveEggs },
+    };
 
     // Decoration for the action store
     const finalSnap = computeSnapshot(currentState, context, { skipGrowth: true });
@@ -204,8 +210,8 @@ export function runK3(
     const snap = computeSnapshot(currentState, context, { skipGrowth: true });
     currentState.bankValue += snap.offlineEarnings * waitDuration;
 
-    currentState.eggsDelivered['kindness'] = teResult.finalEggsDelivered;
-    currentState.teEarned['kindness'] = (currentState.teEarned['kindness'] || 0) + teResult.teEarned;
+    currentState.eggsDelivered = { ...currentState.eggsDelivered, kindness: teResult.finalEggsDelivered };
+    currentState.teEarned = { ...currentState.teEarned, kindness: (currentState.teEarned['kindness'] || 0) + teResult.teEarned };
     currentState.te = Object.values(currentState.teEarned).reduce((a, b) => (a as number) + (b as number), 0);
     
     // Decoration

--- a/wasmegg/ascension-planner/src/auto/shifts/quickWins.ts
+++ b/wasmegg/ascension-planner/src/auto/shifts/quickWins.ts
@@ -31,7 +31,7 @@ import {
   type ResearchCostModifiers,
 } from '../../calculations/commonResearch';
 import { computeSnapshot } from '../../engine/compute';
-import { applyAction } from '../../engine/apply';
+import { applyAction, calculateEggsDeliveredForTime } from '../../engine/apply';
 import { createSimAction } from '@/types/actions/meta';
 import { isResearchSaleActive } from '../calendar';
 
@@ -107,10 +107,12 @@ export function runQuickWins(
     // and skip boundary detection (inconsequential inside ≤3s per user preference).
     if (timeToSave > 0) {
       const waitAction = createSimAction('wait_for_time', { totalTimeSeconds: timeToSave });
+      const passiveEggs = calculateEggsDeliveredForTime(timeToSave, approximateSnap);
       currentState = {
         ...currentState,
         lastStepTime: (currentState.lastStepTime || 0) + timeToSave,
         bankValue: bankValue + offlineEarnings * timeToSave,
+        eggsDelivered: { ...currentState.eggsDelivered, [currentState.currentEgg]: (currentState.eggsDelivered[currentState.currentEgg] || 0) + passiveEggs },
       };
       waitAction.endState = approximateSnap;
       waitAction.totalTimeSeconds = timeToSave;

--- a/wasmegg/ascension-planner/src/auto/shifts/r1.ts
+++ b/wasmegg/ascension-planner/src/auto/shifts/r1.ts
@@ -1,7 +1,7 @@
 import type { Action } from '@/types/actions/meta';
 import type { EngineState, SimulationContext, ShiftResult } from '../types';
 import { computeSnapshot } from '../../engine/compute';
-import { applyAction } from '../../engine/apply';
+import { applyAction, calculateEggsDeliveredForTime } from '../../engine/apply';
 import { createSimAction } from '@/types/actions/meta';
 import { shiftCost } from 'lib';
 import { nextSiloCost, MAX_SILOS } from '../../stores/silos';
@@ -26,10 +26,16 @@ export function runR1(
     if (seconds <= 0) return;
     const snap = computeSnapshot(currentState, context, { skipGrowth: true });
     const waitAction = createSimAction('wait_for_time', { totalTimeSeconds: seconds });
-    
+    const passiveEggs = calculateEggsDeliveredForTime(seconds, snap);
+
     currentState = applyAction(currentState, waitAction);
     // applyAction doesn't update bankValue or lastStepTime for wait actions, so we credit them manually
-    currentState = { ...currentState, lastStepTime: (currentState.lastStepTime || 0) + seconds, bankValue: (currentState.bankValue || 0) + snap.offlineEarnings * seconds };
+    currentState = {
+      ...currentState,
+      lastStepTime: (currentState.lastStepTime || 0) + seconds,
+      bankValue: (currentState.bankValue || 0) + snap.offlineEarnings * seconds,
+      eggsDelivered: { ...currentState.eggsDelivered, [currentState.currentEgg]: (currentState.eggsDelivered[currentState.currentEgg] || 0) + passiveEggs },
+    };
     
     // Decoration for the action store
     const finalSnap = computeSnapshot(currentState, context, { skipGrowth: true });

--- a/wasmegg/ascension-planner/src/auto/shifts/te-wait.ts
+++ b/wasmegg/ascension-planner/src/auto/shifts/te-wait.ts
@@ -163,8 +163,8 @@ export function runTEWaitShift(
       currentState.lastStepTime = (currentState.lastStepTime || 0) + waitTime;
       currentState.bankValue += snap.offlineEarnings * waitTime;
       
-      currentState.eggsDelivered[egg] = teResult.finalEggsDelivered;
-      currentState.teEarned[egg] = (currentState.teEarned[egg] || 0) + teResult.teEarned;
+      currentState.eggsDelivered = { ...currentState.eggsDelivered, [egg]: teResult.finalEggsDelivered };
+      currentState.teEarned = { ...currentState.teEarned, [egg]: (currentState.teEarned[egg] || 0) + teResult.teEarned };
       currentState.te += teResult.teEarned;
       
       // Decoration

--- a/wasmegg/ascension-planner/src/components/ActionGroup.vue
+++ b/wasmegg/ascension-planner/src/components/ActionGroup.vue
@@ -39,7 +39,7 @@
           </div>
           <div class="flex flex-col items-start gap-0.5">
             <div class="text-[9px] sm:text-[10px] font-bold text-slate-400 tracking-tight">Time: {{ formattedTimeElapsed }}</div>
-            <div v-if="props.eggsDelivered > 0" class="text-[9px] sm:text-[10px] font-black text-slate-900 tracking-widest">
+            <div class="text-[9px] sm:text-[10px] font-black text-slate-900 tracking-widest">
               {{ formatNumber(props.eggsDelivered, 3) }} Eggs
             </div>
           </div>

--- a/wasmegg/ascension-planner/src/components/actions/ArtifactActions.vue
+++ b/wasmegg/ascension-planner/src/components/actions/ArtifactActions.vue
@@ -63,6 +63,11 @@
               </button>
             </template>
           </div>
+
+          <div v-if="selectedTab === 'earnings' && earningsClothedTe !== null" class="flex items-center gap-1.5">
+            <span class="text-[10px] font-bold text-gray-400 uppercase tracking-wider">Clothed TE</span>
+            <span class="text-xs font-mono-premium font-bold text-gray-900">{{ Math.round(earningsClothedTe) }}</span>
+          </div>
         </div>
 
         <div v-if="selectedTab === 'elr'" class="flex flex-wrap items-center justify-end gap-y-2 gap-x-4 border-t border-gray-200/60 pt-2 -mt-1">
@@ -163,7 +168,7 @@ import {
   summarizeLoadout,
   calculateArtifactModifiers,
 } from '@/lib/artifacts';
-import { getOptimalELRSet, isFunctionallyIdentical } from '@/lib/artifacts/virtue';
+import { getOptimalELRSet, isFunctionallyIdentical, calculateClothedTEForSet } from '@/lib/artifacts/virtue';
 import { useActionExecutor } from '@/composables/useActionExecutor';
 import { computeDependencies } from '@/lib/actions/executor';
 import { calculateHabCapacity_Full } from '@/calculations/habCapacity';
@@ -184,6 +189,19 @@ const selectedTab = ref<ArtifactSetName>('earnings');
 const localLoadout = ref<EquippedArtifact[]>(createEmptyLoadout());
 const assumeMaxHabsVehicles = ref(true);
 const excludeGusset = ref(false);
+
+// Clothed TE for the earnings set currently being viewed (localLoadout may hold
+// unsaved edits), regardless of whether it's the equipped set.
+const earningsClothedTe = computed<number | null>(() => {
+  if (selectedTab.value !== 'earnings') return null;
+  const context = getSimulationContext();
+  return calculateClothedTEForSet(localLoadout.value, {
+    truthEggs: actionsStore.effectiveSnapshot.te,
+    colleggtibleModifiers: context.colleggtibleModifiers,
+    labUpgradeLevel: context.epicResearchLevels['cheaper_research'] ?? 0,
+    permitLevel: initialStateStore.rawBackup?.game?.permitLevel ?? null,
+  });
+});
 
 const isOptimalELR = computed(() => {
   if (!initialStateStore.rawBackup) return false;

--- a/wasmegg/ascension-planner/src/components/actions/ElrViewControls.vue
+++ b/wasmegg/ascension-planner/src/components/actions/ElrViewControls.vue
@@ -36,11 +36,37 @@
         </button>
       </div>
     </div>
+    <div class="flex items-center gap-3">
+      <span class="text-[10px] font-bold text-gray-400 uppercase tracking-wider w-14 shrink-0">ROI Display</span>
+      <div class="flex items-center gap-1.5">
+        <div class="flex gap-1 p-0.5 bg-gray-100 rounded-md shadow-inner">
+          <button
+            v-for="option in roiDisplayOptions"
+            :key="option.id"
+            @click="$emit('update:roiDisplayMode', option.id)"
+            class="px-2.5 py-1 text-[11px] font-medium rounded transition-all whitespace-nowrap"
+            :class="
+              roiDisplayMode === option.id
+                ? 'bg-white text-blue-600 shadow-sm'
+                : 'text-gray-500 hover:text-gray-700 hover:bg-gray-200'
+            "
+          >
+            {{ option.label }}
+          </button>
+        </div>
+        <span
+          class="w-4 h-4 inline-flex items-center justify-center rounded-full bg-gray-100 text-gray-400 text-[9px] cursor-help hover:bg-gray-200 transition-colors leading-none shrink-0"
+          v-tippy="
+            'HPP: hours of buy-time per 1% Delivery Rate impact. Lower is better.\n\nDelivery Time: how long, laying at the boosted rate, it takes for the extra production to pay back what it cost to buy this research.'
+          "
+        >?</span>
+      </div>
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { type ElrViewMode, type ElrSortMode } from '@/composables/useResearchViews';
+import { type ElrViewMode, type ElrSortMode, type ElrRoiDisplayMode } from '@/composables/useResearchViews';
 
 const viewOptions = [
   { id: 'realistic' as ElrViewMode, label: 'Realistic' },
@@ -52,10 +78,16 @@ const sortOptions = [
   { id: 'impact' as ElrSortMode, label: 'Impact' },
 ];
 
+const roiDisplayOptions = [
+  { id: 'hpp' as ElrRoiDisplayMode, label: 'HPP' },
+  { id: 'time' as ElrRoiDisplayMode, label: 'Delivery Time' },
+];
+
 defineProps<{
   viewMode: ElrViewMode;
   sortMode: ElrSortMode;
+  roiDisplayMode: ElrRoiDisplayMode;
 }>();
 
-defineEmits(['update:viewMode', 'update:sortMode']);
+defineEmits(['update:viewMode', 'update:sortMode', 'update:roiDisplayMode']);
 </script>

--- a/wasmegg/ascension-planner/src/components/actions/HabActions.vue
+++ b/wasmegg/ascension-planner/src/components/actions/HabActions.vue
@@ -158,7 +158,7 @@ import { useEventExpiry } from '@/composables/useEventExpiry';
 import EventExpiryDialog from '../EventExpiryDialog.vue';
 import { calculateHabCapacity, calculateTotalResearchMultipliers } from '@/calculations/habCapacity';
 import { calculateArtifactModifiers } from '@/lib/artifacts';
-import { calculateEarningsForTime, getTimeToSave } from '@/engine/apply';
+import { getTimeToSave } from '@/engine/apply';
 
 const habCapacityStore = useHabCapacityStore();
 const initialStateStore = useInitialStateStore();
@@ -370,63 +370,164 @@ function handleToggleSale() {
   );
 }
 
-const maxHabsSeconds = computed(() => {
-  const CHICKEN_UNIVERSE_ID = 18;
-  const snapshot = actionsStore.effectiveSnapshot;
-  const offlineEarnings = snapshot.offlineEarnings;
+const CHICKEN_UNIVERSE_ID = 18;
 
-  if (offlineEarnings <= 0) return Infinity;
+interface HabPurchaseStep {
+  slotIndex: number;
+  habId: number;
+  cost: number;
+  waitSeconds: number;
+}
 
-  const shippingCapacity = snapshot.shippingCapacity;
-  let totalSeconds = 0;
-  let virtualHabIds = [...snapshot.habIds];
-  let virtualBank = snapshot.bankValue || 0;
+interface HabSimResult {
+  steps: HabPurchaseStep[];
+  totalSeconds: number;
+  allMaxed: boolean;
+}
 
-  // Clone snapshot for virtual simulation
-  let virtualSnapshot = { ...snapshot, bankValue: virtualBank };
+// How soon a hab has to become affordable to count as a "quick interim buy" -
+// matches the threshold src/auto/shifts/i1.ts uses for the same decision.
+const INTERIM_HAB_THRESHOLD_SECONDS = 10;
 
-  for (let i = 0; i < 4; i++) {
-    const currentId = virtualHabIds[i];
-    if (currentId === CHICKEN_UNIVERSE_ID) continue;
+/**
+ * Pick the next hab purchase (any slot, any hab level above that slot's current one)
+ * from the given virtual snapshot. Prefers the highest-tier hab reachable within
+ * INTERIM_HAB_THRESHOLD_SECONDS over a "better ROI" small upgrade - e.g. if a
+ * Planet Portal is affordable in 0s, buy it outright instead of stepping through
+ * every cheaper hab on the way there. Only falls back to whichever upgrade becomes
+ * affordable soonest when nothing is reachable within the threshold, since then
+ * there's no quick win available and we just need to keep progressing.
+ */
+function findBestNextHabPurchase(
+  virtualSnapshot: typeof actionsStore.effectiveSnapshot,
+  virtualHabIds: (number | null)[]
+) {
+  const candidates: { slotIndex: number; habId: number; cost: number; waitSeconds: number }[] = [];
 
-    const hab = getHabById(CHICKEN_UNIVERSE_ID);
-    if (!hab) continue;
+  for (let slotIndex = 0; slotIndex < 4; slotIndex++) {
+    const currentId = virtualHabIds[slotIndex];
+    const startId = currentId === null ? 0 : currentId + 1;
 
-    const otherHabs = virtualHabIds.filter((_, idx) => idx !== i);
-    const existingCount = countHabsOfType(otherHabs, CHICKEN_UNIVERSE_ID);
-    const price = getDiscountedHabPrice(hab, existingCount, costModifiers.value, isHabSaleActive.value);
+    for (let habId = startId; habId <= CHICKEN_UNIVERSE_ID; habId++) {
+      const hab = getHabById(habId as HabId);
+      if (!hab) continue;
 
-    const seconds = getTimeToSave(price, virtualSnapshot);
-    if (seconds === Infinity) return Infinity;
+      const currentCap = currentId !== null ? getHabCapacity(currentId) : 0;
+      const newCap = getHabCapacity(habId);
+      if (newCap - currentCap <= 0) continue;
 
-    totalSeconds += seconds;
+      const otherHabs = virtualHabIds.filter((_, i) => i !== slotIndex);
+      const existingCount = countHabsOfType(otherHabs, habId);
+      const cost = getDiscountedHabPrice(hab, existingCount, costModifiers.value, isHabSaleActive.value);
 
-    // Advance virtual state during wait
-    const I = virtualSnapshot.offlineIHR / 60;
-    virtualSnapshot.population = Math.min(virtualSnapshot.habCapacity, virtualSnapshot.population + I * seconds);
+      const waitSeconds = getTimeToSave(cost, virtualSnapshot);
+      if (waitSeconds === Infinity) continue;
 
-    // Update bank after wait and purchase (if seconds > 0, we waited until we had exactly price)
-    virtualSnapshot.bankValue = seconds > 0 ? 0 : Math.max(0, virtualSnapshot.bankValue - price);
-
-    // Apply outcome of purchase
-    const oldHabCap = currentId !== null ? getHabCapacity(currentId) : 0;
-    const newHabCap = getHabCapacity(CHICKEN_UNIVERSE_ID);
-    const deltaCap = newHabCap - oldHabCap;
-
-    virtualHabIds[i] = CHICKEN_UNIVERSE_ID;
-    virtualSnapshot.habCapacity += deltaCap;
-
-    // Update earnings metrics based on new population (population grew during wait)
-    const layRatePerChicken = snapshot.population > 0 ? snapshot.layRate / snapshot.population : 0;
-    virtualSnapshot.layRate = virtualSnapshot.population * layRatePerChicken;
-    virtualSnapshot.elr = Math.min(virtualSnapshot.layRate, virtualSnapshot.shippingCapacity);
-
-    const earningsPerEgg = snapshot.elr > 0 ? snapshot.offlineEarnings / snapshot.elr : 0;
-    virtualSnapshot.offlineEarnings = virtualSnapshot.elr * earningsPerEgg;
+      candidates.push({ slotIndex, habId, cost, waitSeconds });
+    }
   }
 
-  return totalSeconds;
-});
+  if (candidates.length === 0) return null;
+
+  const quickCandidates = candidates.filter(c => c.waitSeconds <= INTERIM_HAB_THRESHOLD_SECONDS);
+
+  if (quickCandidates.length > 0) {
+    // A quick win is available - grab the highest-tier one, not the best-ROI one.
+    return quickCandidates.reduce((best, c) => {
+      if (c.habId > best.habId) return c;
+      if (c.habId === best.habId && c.waitSeconds < best.waitSeconds) return c;
+      return best;
+    });
+  }
+
+  // Nothing is reachable quickly - just take whichever becomes affordable soonest.
+  return candidates.reduce((best, c) => {
+    if (c.waitSeconds < best.waitSeconds) return c;
+    if (c.waitSeconds === best.waitSeconds && c.habId > best.habId) return c;
+    return best;
+  });
+}
+
+/**
+ * Simulate buying hab upgrades forward in time, always taking whichever upgrade
+ * becomes affordable soonest across all slots and levels. This lets a cheap interim
+ * hab get bought ahead of a distant Chicken Universe purchase whenever doing so
+ * raises earnings enough to shorten the overall wait - the same idea as the
+ * interim-hab step in src/auto/shifts/i1.ts, generalized to any number of interim
+ * purchases in any slot instead of a single hardcoded lookahead.
+ *
+ * `shouldStop` is checked against the elapsed time a prospective purchase would
+ * bring us to, so callers can cut the simulation off at a time budget (5-min button)
+ * or let it run until every slot holds a Chicken Universe (max habs button).
+ */
+function simulateHabPurchases(shouldStop: (elapsedSeconds: number) => boolean): HabSimResult {
+  const snapshot = actionsStore.effectiveSnapshot;
+  const steps: HabPurchaseStep[] = [];
+  let elapsedSeconds = 0;
+
+  let virtualHabIds = [...snapshot.habIds];
+  let virtualBank = snapshot.bankValue || 0;
+  let virtualPopulation = snapshot.population;
+  let virtualHabCapacity = snapshot.habCapacity;
+
+  // layRate/population and offlineEarnings/elr are fixed ratios of the game state
+  // (hab purchases change capacity, not per-chicken rates), so we hold them fixed
+  // and re-derive layRate/elr/offlineEarnings from the virtual population each step.
+  const layRatePerChicken = snapshot.population > 0 ? snapshot.layRate / snapshot.population : 0;
+  const earningsPerEgg = snapshot.elr > 0 ? snapshot.offlineEarnings / snapshot.elr : 0;
+
+  const maxIterations = 4 * habTypes.length; // at most one purchase per hab tier per slot
+
+  for (let i = 0; i < maxIterations; i++) {
+    if (virtualHabIds.every(id => id === CHICKEN_UNIVERSE_ID)) break;
+    if (shouldStop(elapsedSeconds)) break;
+
+    const layRate = virtualPopulation * layRatePerChicken;
+    const elr = Math.min(layRate, snapshot.shippingCapacity);
+    const offlineEarnings = elr * earningsPerEgg;
+
+    const virtualSnapshot = {
+      ...snapshot,
+      habIds: virtualHabIds,
+      bankValue: virtualBank,
+      population: virtualPopulation,
+      habCapacity: virtualHabCapacity,
+      layRate,
+      elr,
+      offlineEarnings,
+    };
+
+    const best = findBestNextHabPurchase(virtualSnapshot, virtualHabIds);
+    if (!best) break;
+    if (shouldStop(elapsedSeconds + best.waitSeconds)) break;
+
+    // Advance virtual population/bank through the wait
+    const I = snapshot.offlineIHR / 60;
+    virtualPopulation = Math.min(virtualHabCapacity, virtualPopulation + I * best.waitSeconds);
+    virtualBank = best.waitSeconds > 0 ? 0 : Math.max(0, virtualBank - best.cost);
+
+    // Apply the purchase
+    const currentId = virtualHabIds[best.slotIndex];
+    const currentCap = currentId !== null ? getHabCapacity(currentId) : 0;
+    virtualHabIds = virtualHabIds.map((id, idx) => (idx === best.slotIndex ? best.habId : id));
+    virtualHabCapacity += getHabCapacity(best.habId) - currentCap;
+
+    elapsedSeconds += best.waitSeconds;
+    steps.push({ slotIndex: best.slotIndex, habId: best.habId, cost: best.cost, waitSeconds: best.waitSeconds });
+  }
+
+  return {
+    steps,
+    totalSeconds: elapsedSeconds,
+    allMaxed: virtualHabIds.every(id => id === CHICKEN_UNIVERSE_ID),
+  };
+}
+
+// Max Habs never gives up on a time budget - people may be fine waiting days or
+// months, so it only stops once every slot holds a Chicken Universe.
+const maxHabsSim = computed(() => simulateHabPurchases(() => false));
+
+const maxHabsSeconds = computed(() => (maxHabsSim.value.allMaxed ? maxHabsSim.value.totalSeconds : Infinity));
 
 const maxHabsTime = computed(() => {
   const seconds = maxHabsSeconds.value;
@@ -435,78 +536,32 @@ const maxHabsTime = computed(() => {
   return formatDuration(seconds);
 });
 
-const canBuyMax = computed(() => {
-  const CHICKEN_UNIVERSE_ID = 18;
-  return habIds.value.some(id => id !== CHICKEN_UNIVERSE_ID);
-});
+const canBuyMax = computed(() => habIds.value.some(id => id !== CHICKEN_UNIVERSE_ID));
 
 function handleBuyMax() {
-  const CHICKEN_UNIVERSE_ID = 18;
-  withExpiryCheck(maxHabsSeconds.value, false, () => {
+  const sim = maxHabsSim.value;
+  if (sim.steps.length === 0) return;
+
+  withExpiryCheck(sim.totalSeconds, false, () => {
     batch(() => {
-      for (let i = 0; i < 4; i++) {
-        const currentId = habIds.value[i];
-        if (currentId !== CHICKEN_UNIVERSE_ID) {
-          handleHabChange(i, CHICKEN_UNIVERSE_ID);
-        }
+      for (const step of sim.steps) {
+        handleHabChange(step.slotIndex, step.habId);
       }
     });
   });
 }
 
 function handleBuy5MinSpace() {
-  const snapshot = actionsStore.effectiveSnapshot;
-  const offlineEarnings = snapshot.offlineEarnings;
-  if (offlineEarnings <= 0) return;
+  const FIVE_MINUTES = 5 * 60;
+  const sim = simulateHabPurchases(seconds => seconds > FIVE_MINUTES);
+  if (sim.steps.length === 0) return;
 
-  const maxBudget = calculateEarningsForTime(5 * 60, snapshot);
-  let spent = 0;
-
-  // Track virtual state
-  const virtualHabIds = [...habIds.value];
-
-  batch(() => {
-    while (spent < maxBudget) {
-      let bestAction: { slotIndex: number; habId: number; cost: number } | null = null;
-      let bestRoi = -1;
-
-      for (let i = 0; i < virtualHabIds.length; i++) {
-        const currentId = virtualHabIds[i];
-        const startId = currentId === null ? 0 : currentId + 1;
-
-        for (let nextId = startId; nextId <= 18; nextId++) {
-          const otherHabs = virtualHabIds.filter((_, idx) => idx !== i);
-          const existingCount = countHabsOfType(otherHabs, nextId);
-          const hab = getHabById(nextId as HabId);
-          if (!hab) continue;
-
-          const cost = getDiscountedHabPrice(hab, existingCount, costModifiers.value, isHabSaleActive.value);
-
-          if (spent + cost <= maxBudget) {
-            const currentCap = currentId !== null ? getHabCapacity(currentId) : 0;
-            const nextCap = getHabCapacity(nextId);
-            const deltaCap = nextCap - currentCap;
-
-            if (deltaCap > 0) {
-              const roi = deltaCap / Math.max(cost, 1e-10);
-              const score = deltaCap > 1000 ? deltaCap * 1000 + roi : roi;
-              if (score > bestRoi) {
-                bestRoi = score;
-                bestAction = { slotIndex: i, habId: nextId, cost };
-              }
-            }
-          }
-        }
+  withExpiryCheck(sim.totalSeconds, false, () => {
+    batch(() => {
+      for (const step of sim.steps) {
+        handleHabChange(step.slotIndex, step.habId);
       }
-
-      if (!bestAction) break;
-
-      // Apply action
-      handleHabChange(bestAction!.slotIndex, bestAction!.habId);
-
-      virtualHabIds[bestAction.slotIndex] = bestAction.habId;
-      spent += bestAction.cost;
-    }
+    });
   });
 }
 </script>

--- a/wasmegg/ascension-planner/src/components/actions/ResearchActions.vue
+++ b/wasmegg/ascension-planner/src/components/actions/ResearchActions.vue
@@ -59,8 +59,10 @@
       v-if="currentView === 'elr'"
       :view-mode="elrViewMode"
       :sort-mode="elrSortMode"
+      :roi-display-mode="elrRoiDisplayMode"
       @update:view-mode="elrViewMode = $event"
       @update:sort-mode="elrSortMode = $event"
+      @update:roi-display-mode="elrRoiDisplayMode = $event"
     />
 
     <MilestoneTargetPicker
@@ -188,6 +190,7 @@
       :milestone-target-selected="!!milestoneTarget"
       :get-research-time-to-buy="getTimeToBuy"
       :get-research-time-to-buy-seconds="getTimeToBuySeconds"
+      :roi-display-mode="elrRoiDisplayMode"
       @buy="handleBuyResearch"
       @max="handleMaxResearch"
       @buy-to-here="handleBuyToHere"
@@ -255,6 +258,7 @@ const {
   currentView,
   elrViewMode,
   elrSortMode,
+  elrRoiDisplayMode,
   deliveryImpactOnly,
   roiMode,
   milestoneTarget,

--- a/wasmegg/ascension-planner/src/components/actions/ResearchFlatView.vue
+++ b/wasmegg/ascension-planner/src/components/actions/ResearchFlatView.vue
@@ -58,6 +58,8 @@
         :extra-label="item.extraLabel"
         :extra-seconds="item.extraSeconds"
         :hpp="item.hpp"
+        :time-roi-seconds="item.timeRoiSeconds"
+        :roi-display-mode="roiDisplayMode"
         :realistic-stats="item.realisticStats"
         :lookahead="item.lookahead"
         :recommendation-note="item.recommendationNote"
@@ -99,7 +101,7 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import { type CommonResearch } from '@/calculations/commonResearch';
-import { type ViewType } from '@/composables/useResearchViews';
+import { type ViewType, type ElrRoiDisplayMode } from '@/composables/useResearchViews';
 import { useInitialStateStore } from '@/stores/initialState';
 import { useActionsStore } from '@/stores/actions';
 import { useVirtueStore } from '@/stores/virtue';
@@ -125,6 +127,7 @@ interface SortedResearchItem {
   extraLabel?: string;
   extraSeconds?: number;
   hpp?: number;
+  timeRoiSeconds?: number;
   realisticStats?: { layRate: number; shippingRate: number; elr: number; elrDelta: number };
   lookahead?: { minLevels: number; impact: number; hpp: number };
   recommendationNote?: string;
@@ -139,6 +142,7 @@ const props = defineProps<{
   milestoneTargetSelected?: boolean;
   getResearchTimeToBuy: (r: CommonResearch) => string;
   getResearchTimeToBuySeconds: (r: CommonResearch) => number;
+  roiDisplayMode?: ElrRoiDisplayMode;
 }>();
 
 const initialStateStore = useInitialStateStore();

--- a/wasmegg/ascension-planner/src/components/actions/ResearchGameView.vue
+++ b/wasmegg/ascension-planner/src/components/actions/ResearchGameView.vue
@@ -96,8 +96,31 @@ const props = defineProps<{
 
 defineEmits(['buy', 'max', 'max-tier']);
 
-const expandedTiers = ref(new Set<number>());
+const EXPANDED_TIERS_STORAGE_KEY = 'ascension_research_expanded_tiers';
+
+function loadStoredExpandedTiers(): Set<number> | null {
+  const stored = localStorage.getItem(EXPANDED_TIERS_STORAGE_KEY);
+  if (!stored) return null;
+  try {
+    const parsed = JSON.parse(stored);
+    if (Array.isArray(parsed)) {
+      return new Set(parsed.filter((t): t is number => typeof t === 'number'));
+    }
+  } catch {
+    // ignore malformed storage
+  }
+  return null;
+}
+
+const storedExpandedTiers = loadStoredExpandedTiers();
+const expandedTiers = ref(new Set<number>(storedExpandedTiers ?? []));
 const autoExpanded = new Set<number>();
+
+watch(
+  expandedTiers,
+  tiersSet => localStorage.setItem(EXPANDED_TIERS_STORAGE_KEY, JSON.stringify(Array.from(tiersSet))),
+  { deep: true }
+);
 
 const actionsStore = useActionsStore();
 const virtueStore = useVirtueStore();
@@ -117,13 +140,21 @@ function isTierMaxed(tier: number): boolean {
 
 // Auto-expand any tier that is unlocked and has research available.
 // We track autoExpanded to avoid re-expanding a tier the user manually collapsed.
+// If expand/collapse state was restored from storage, tiers already unlocked at mount
+// have already had their auto-expand decision made (respect the user's saved choice) —
+// only tiers that unlock later this session should be auto-expanded.
 watch(
   () => props.tierSummaries,
   summaries => {
     if (!summaries) return;
     for (const tier of props.tiers) {
+      if (autoExpanded.has(tier)) continue;
       const summary = summaries[tier];
-      if (summary?.isUnlocked && !isTierMaxed(tier) && !autoExpanded.has(tier)) {
+      if (storedExpandedTiers && summary?.isUnlocked) {
+        autoExpanded.add(tier);
+        continue;
+      }
+      if (summary?.isUnlocked && !isTierMaxed(tier)) {
         expandedTiers.value.add(tier);
         autoExpanded.add(tier);
       }

--- a/wasmegg/ascension-planner/src/components/actions/ResearchItem.vue
+++ b/wasmegg/ascension-planner/src/components/actions/ResearchItem.vue
@@ -96,9 +96,11 @@
               class="text-[9px] font-bold text-gray-400 uppercase tracking-tighter"
               :class="{ 'cursor-help': hpp !== undefined }"
               v-tippy="
-                hpp !== undefined
-                  ? 'Estimated waiting time (hours) per 1% Egg Laying Rate impact based on current earnings. Lower is better.'
-                  : undefined
+                hpp === undefined
+                  ? undefined
+                  : roiDisplayMode === 'time'
+                    ? 'Time, laying at the boosted rate, for the extra production to pay back what it cost to buy this research.'
+                    : 'Estimated waiting time (hours) per 1% Egg Laying Rate impact based on current earnings. Lower is better.'
               "
             >
               {{ extraLabel }}
@@ -121,7 +123,12 @@
               </span>
             </div>
             <div v-if="hpp !== undefined" class="text-[9px] font-mono text-gray-400 leading-none pb-[1px]">
-              {{ hpp === Infinity || isNaN(hpp) ? '∞' : hpp.toFixed(1) }} hr/%
+              <template v-if="roiDisplayMode === 'time'">
+                {{ formatDuration(timeRoiSeconds ?? Infinity) }}
+              </template>
+              <template v-else>
+                {{ hpp === Infinity || isNaN(hpp) ? '∞' : hpp.toFixed(1) }} hr/%
+              </template>
             </div>
           </div>
         </div>
@@ -247,6 +254,8 @@ const props = defineProps<{
   buyToHereSeconds?: number;
   buyToHereTooltip?: string;
   extraSeconds?: number;
+  timeRoiSeconds?: number;
+  roiDisplayMode?: 'hpp' | 'time';
   realisticStats?: { layRate: number; shippingRate: number; elr: number; elrDelta: number };
   lookahead?: { minLevels: number; impact: number; hpp: number };
   showSaleWarning?: boolean;

--- a/wasmegg/ascension-planner/src/components/actions/WaitWithoutEarningsActions.vue
+++ b/wasmegg/ascension-planner/src/components/actions/WaitWithoutEarningsActions.vue
@@ -8,7 +8,7 @@
             ref="inputEl"
             v-model="inputDuration"
             type="text"
-            placeholder="e.g. 8 or 8h30m"
+            placeholder="e.g. 8h30m, 12:30pm, or +0"
             class="w-full sm:flex-1 px-4 py-2.5 text-sm font-mono-premium font-bold bg-slate-50 border border-slate-100 rounded-xl focus:ring-2 focus:ring-slate-900/10 focus:border-slate-300 outline-none transition-all placeholder:text-slate-300"
             @keyup.enter="handleWaitTime"
           />
@@ -21,9 +21,17 @@
           </button>
         </div>
         <p class="mt-3 text-[10px] text-slate-400 font-medium leading-relaxed">
-          Enter hours (e.g. <span class="font-mono-premium text-slate-600 bg-slate-100 px-1 py-0.5 rounded">8</span> for
-          8h) or format like
-          <span class="font-mono-premium text-slate-600 bg-slate-100 px-1 py-0.5 rounded">1d12h</span>.
+          Enter duration (e.g.
+          <span class="font-mono-premium text-slate-600 bg-slate-100 px-1 py-0.5 rounded">8h</span> or
+          <span class="font-mono-premium text-slate-600 bg-slate-100 px-1 py-0.5 rounded">1d12h</span>), clock time
+          (e.g.
+          <span class="font-mono-premium text-slate-600 bg-slate-100 px-1 py-0.5 rounded">12:30pm</span> or
+          <span class="font-mono-premium text-slate-600 bg-slate-100 px-1 py-0.5 rounded">14:30</span>), or Egg Relative
+          Time (e.g.
+          <span class="font-mono-premium text-slate-600 bg-slate-100 px-1 py-0.5 rounded">+0</span>,
+          <span class="font-mono-premium text-slate-600 bg-slate-100 px-1 py-0.5 rounded">+2</span>, or
+          <span class="font-mono-premium text-slate-600 bg-slate-100 px-1 py-0.5 rounded">-2</span>
+          ).
         </p>
       </div>
 
@@ -83,6 +91,7 @@ import { useActionExecutor } from '@/composables/useActionExecutor';
 import { generateActionId } from '@/types';
 import { computeDependencies } from '@/lib/actions/executor';
 import { formatDuration, parseDuration, formatAbsoluteTime } from '@/lib/format';
+import { getNextTimeInTimezone, PACIFIC_TIMEZONE } from '@/lib/events';
 import { useEventExpiry } from '@/composables/useEventExpiry';
 import EventExpiryDialog from '../EventExpiryDialog.vue';
 
@@ -101,7 +110,52 @@ const {
 const inputDuration = ref('');
 
 const parsedSeconds = computed(() => {
-  const seconds = parseDuration(inputDuration.value);
+  const str = inputDuration.value.trim();
+  if (!str) return 0;
+
+  const currentSimTime = Math.floor(baseTimestamp.value / 1000);
+
+  // 1. Egg Relative Time (+n, -n)
+  const relativeMatch = str.match(/^([+-])(\d{1,2})$/);
+  if (relativeMatch) {
+    const sign = relativeMatch[1];
+    const n = parseInt(relativeMatch[2]);
+    if (n >= 0 && n <= 23) {
+      // Base is 9 AM Pacific. +0 = 9 AM, +1 = 10 AM, -5 = 4 AM.
+      const offset = sign === '+' ? n : -n;
+      const targetHour = (9 + offset + 24) % 24;
+      const targetTS = getNextTimeInTimezone(targetHour, 0, currentSimTime, PACIFIC_TIMEZONE);
+      return Math.max(0, targetTS - currentSimTime);
+    }
+  }
+
+  // 2. Clock Time (12:30pm, 14:30, 5pm, etc.)
+  // Matches 12:30, 12:30pm, 5pm, etc.
+  // We distinguish from duration by checking for colon or am/pm suffix.
+  if (str.includes(':') || /am$|pm$/i.test(str)) {
+    const clockMatch = str.match(/^(\d{1,2})(?::(\d{2}))?\s*([ap]m)?$/i);
+    if (clockMatch) {
+      let hour = parseInt(clockMatch[1]);
+      const minute = clockMatch[2] ? parseInt(clockMatch[2]) : 0;
+      const ampm = clockMatch[3]?.toLowerCase();
+
+      if (ampm === 'pm' && hour < 12) hour += 12;
+      if (ampm === 'am' && hour === 12) hour = 0;
+
+      if (hour >= 0 && hour <= 23 && minute >= 0 && minute <= 59) {
+        const targetTS = getNextTimeInTimezone(
+          hour,
+          minute,
+          currentSimTime,
+          virtueStore.ascensionTimezone
+        );
+        return Math.max(0, targetTS - currentSimTime);
+      }
+    }
+  }
+
+  // 3. Standard Duration
+  const seconds = parseDuration(str);
   return isNaN(seconds) ? 0 : seconds;
 });
 

--- a/wasmegg/ascension-planner/src/components/auto/AutomaticPlanner.vue
+++ b/wasmegg/ascension-planner/src/components/auto/AutomaticPlanner.vue
@@ -62,6 +62,21 @@
           </div>
         </div>
 
+        <div
+          v-if="showLowClothedTEWarning"
+          class="mt-8 p-4 bg-amber-50 border border-amber-200 rounded-xl text-xs text-amber-800 flex gap-3"
+        >
+          <svg class="w-4 h-4 flex-shrink-0 mt-0.5 text-amber-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+          </svg>
+          <p class="leading-relaxed">
+            Auto-AP is really built for players farther along — below 200 Clothed TE, its assumptions (like habs
+            staying full throughout) don't hold up well, so the plan it generates may be pretty suboptimal for
+            you right now. You're welcome to generate one anyway just to see what it does, but for a plan you can
+            actually rely on, raise your Clothed TE in the Virtue Progress section above first.
+          </p>
+        </div>
+
         <button
           class="btn-premium btn-primary w-full py-4 mt-8 text-sm shadow-xl shadow-indigo-500/20 active:scale-[0.98]"
           :disabled="isGenerating || !isA1Dirty"
@@ -209,6 +224,7 @@ import { useAutoPlannerStore } from '@/stores/autoPlanner';
 import { useVirtueStore } from '@/stores/virtue';
 import { useTruthEggsStore } from '@/stores/truthEggs';
 import { useAscensionGenerator } from '@/auto/useAscensionGenerator';
+import { useEarningsClothedTE } from '@/composables/useEarningsClothedTE';
 import SchedulingInputs from './SchedulingInputs.vue';
 import VirtueProgressSection from './VirtueProgressSection.vue';
 import ChainSummaryBar from './ChainSummaryBar.vue';
@@ -229,6 +245,9 @@ const visibleTotal = computed(() => {
   const lastIsForced = chain.length > 0 && !!chain[chain.length - 1].forcedTarget490;
   return chain.length - (lastIsForced ? 1 : 0);
 });
+const { clothedTE: earningsClothedTe } = useEarningsClothedTE();
+const showLowClothedTEWarning = computed(() => earningsClothedTe.value !== null && earningsClothedTe.value < 200);
+
 const targetInput = ref<HTMLInputElement | null>(null);
 const isCollapsed = ref(typeof window !== 'undefined' ? window.innerWidth < 768 : false);
 

--- a/wasmegg/ascension-planner/src/components/auto/VirtueProgressSection.vue
+++ b/wasmegg/ascension-planner/src/components/auto/VirtueProgressSection.vue
@@ -14,6 +14,10 @@
             <span v-if="truthEggsStore.totalPendingTE > 0" class="text-[10px] font-black text-emerald-500 uppercase">
               +{{ truthEggsStore.totalPendingTE }} Pending
             </span>
+            <span v-if="earningsClothedTe !== null" class="w-1 h-1 bg-slate-200 rounded-full"></span>
+            <span v-if="earningsClothedTe !== null" class="text-[10px] font-black text-indigo-500 uppercase"
+              >Clothed TE {{ Math.round(earningsClothedTe) }}</span
+            >
             <span class="w-1 h-1 bg-slate-200 rounded-full"></span>
             <span class="text-[10px] font-black text-slate-500">Delivery Rate {{ formatNumber(currentELR * 3600, 3) }}/hr</span>
           </div>
@@ -82,6 +86,7 @@ import { useSilosStore } from '@/stores/silos';
 import { countTEThresholdsPassed } from '@/lib/truthEggs';
 import { getSimulationContext, createBaseEngineState } from '@/engine/adapter';
 import { getArtifactLoadoutFromBackup, getOptimalEarningsSet } from '@/lib/artifacts';
+import { useEarningsClothedTE } from '@/composables/useEarningsClothedTE';
 import { computeSnapshot } from '@/engine/compute';
 import { rollUpPendingTE } from '@/lib/modes';
 import type { VirtueEgg } from '@/types';
@@ -106,6 +111,9 @@ const currentTE = computed(() => {
   if (!snapshot?.teEarned) return 0;
   return Object.values(snapshot.teEarned).reduce((a, b) => a + b, 0);
 });
+
+// Clothed TE for the earnings set as of the current simulation snapshot.
+const { clothedTE: earningsClothedTe } = useEarningsClothedTE();
 
 const currentELR = computed(() => {
   const farmState = initialStateStore.currentFarmState;

--- a/wasmegg/ascension-planner/src/components/containers/InitialStateContainer.vue
+++ b/wasmegg/ascension-planner/src/components/containers/InitialStateContainer.vue
@@ -22,6 +22,7 @@
     :artifact-sets="store.artifactSets"
     :active-artifact-set="store.activeArtifactSet"
     :colleggtible-tiers="store.colleggtibleTiers"
+    :clothed-te="earningsClothedTe"
     @set-epic-research-level="handleSetEpicResearchLevel"
     @update:artifact-loadout="handleArtifactLoadout"
     @set-initial-egg="handleSetInitialEgg"
@@ -64,6 +65,7 @@ import InitialStateDisplay from '@/components/presenters/InitialStateDisplay.vue
 import type { VirtueEgg, Action, ArtifactSetName } from '@/types';
 import { VIRTUE_EGGS } from '@/types';
 import type { EquippedArtifact } from '@/lib/artifacts';
+import { calculateClothedTEForSet } from '@/lib/artifacts';
 
 const store = useInitialStateStore();
 const virtueStore = useVirtueStore();
@@ -90,6 +92,18 @@ function updateInitialSnapshotAndRecalculate() {
 }
 
 const initialTotalTe = computed(() => Object.values(store.initialTeEarned).reduce((sum, val) => sum + val, 0));
+
+// Clothed TE for the earnings artifact set, computed from live initial-state inputs
+// (not the frozen backup snapshot) so it stays in sync as the player edits research/colleggtibles.
+const earningsClothedTe = computed<number | null>(() => {
+  if (!store.artifactSets.earnings) return null;
+  return calculateClothedTEForSet(store.artifactSets.earnings, {
+    truthEggs: initialTotalTe.value,
+    colleggtibleModifiers: store.colleggtibleModifiers,
+    labUpgradeLevel: store.epicResearchLevels['cheaper_research'] ?? 0,
+    permitLevel: store.rawBackup?.game?.permitLevel ?? null,
+  });
+});
 
 
 function handleSetEpicResearchLevel(id: string, level: number) {

--- a/wasmegg/ascension-planner/src/components/presenters/InitialStateDisplay.vue
+++ b/wasmegg/ascension-planner/src/components/presenters/InitialStateDisplay.vue
@@ -284,6 +284,10 @@
         </div>
       </div>
       <div class="p-4">
+        <div v-if="activeSetTab === 'earnings' && clothedTe !== null" class="mt-4 flex justify-between items-center px-1">
+          <span class="text-[10px] font-black text-slate-400 uppercase tracking-widest">Clothed TE</span>
+          <span class="text-sm font-mono-premium font-bold text-slate-900">{{ Math.round(clothedTe) }}</span>
+        </div>
         <template v-if="!hasArtifactSets">
           <div class="mb-4">
             <ArtifactSelector
@@ -651,6 +655,7 @@ const props = defineProps<{
   artifactSets: Record<import('@/types').ArtifactSetName, EquippedArtifact[] | null>;
   activeArtifactSet: import('@/types').ArtifactSetName | null;
   colleggtibleTiers: import('lib/collegtibles').ColleggtibleTiers;
+  clothedTe: number | null;
 }>();
 
 function handleInitialEggClick(egg: VirtueEgg) {

--- a/wasmegg/ascension-planner/src/composables/useEarningsClothedTE.ts
+++ b/wasmegg/ascension-planner/src/composables/useEarningsClothedTE.ts
@@ -1,0 +1,35 @@
+/**
+ * Composable for the earnings artifact set's Clothed TE, evaluated at the
+ * current simulation snapshot.
+ */
+
+import { computed, type ComputedRef } from 'vue';
+import { useActionsStore } from '@/stores/actions';
+import { useInitialStateStore } from '@/stores/initialState';
+import { getSimulationContext } from '@/engine/adapter';
+import { calculateClothedTEForSet } from '@/lib/artifacts/virtue';
+
+export function useEarningsClothedTE(): {
+  clothedTE: ComputedRef<number | null>;
+} {
+  const actionsStore = useActionsStore();
+  const initialStateStore = useInitialStateStore();
+
+  const clothedTE = computed<number | null>(() => {
+    const snapshot = actionsStore.effectiveSnapshot;
+    const earningsSet = snapshot?.artifactSets?.earnings;
+    if (!earningsSet) return null;
+
+    const truthEggs = snapshot.teEarned ? Object.values(snapshot.teEarned).reduce((a, b) => a + b, 0) : 0;
+    const context = getSimulationContext();
+
+    return calculateClothedTEForSet(earningsSet, {
+      truthEggs,
+      colleggtibleModifiers: context.colleggtibleModifiers,
+      labUpgradeLevel: context.epicResearchLevels['cheaper_research'] ?? 0,
+      permitLevel: initialStateStore.rawBackup?.game?.permitLevel ?? null,
+    });
+  });
+
+  return { clothedTE };
+}

--- a/wasmegg/ascension-planner/src/composables/useResearchViews.ts
+++ b/wasmegg/ascension-planner/src/composables/useResearchViews.ts
@@ -34,6 +34,7 @@ import { createSimAction } from '@/types/actions/meta';
 export type ViewType = 'game' | 'cheapest' | 'roi' | 'elr' | 'milestones';
 export type ElrViewMode = 'realistic' | 'potential';
 export type ElrSortMode = 'efficiency' | 'impact';
+export type ElrRoiDisplayMode = 'hpp' | 'time';
 export type RoiMode = 'immediate' | 'maxed_vehicles';
 
 export type MilestoneTarget =
@@ -108,6 +109,7 @@ export const VIEWS = [
 const RESEARCH_VIEW_STORAGE_KEY = 'ascension_research_view';
 const ELR_VIEW_MODE_STORAGE_KEY = 'ascension_research_elr_view_mode';
 const ELR_SORT_MODE_STORAGE_KEY = 'ascension_research_elr_sort_mode';
+const ELR_ROI_DISPLAY_MODE_STORAGE_KEY = 'ascension_research_elr_roi_display_mode';
 const DELIVERY_IMPACT_ONLY_STORAGE_KEY = 'ascension_research_delivery_impact_only';
 const ROI_MODE_STORAGE_KEY = 'ascension_research_roi_mode';
 const MILESTONE_TARGET_STORAGE_KEY = 'ascension_research_milestone_target';
@@ -125,6 +127,11 @@ function loadStoredElrViewMode(): ElrViewMode {
 function loadStoredElrSortMode(): ElrSortMode {
   const stored = localStorage.getItem(ELR_SORT_MODE_STORAGE_KEY);
   return stored === 'efficiency' || stored === 'impact' ? stored : 'efficiency';
+}
+
+function loadStoredElrRoiDisplayMode(): ElrRoiDisplayMode {
+  const stored = localStorage.getItem(ELR_ROI_DISPLAY_MODE_STORAGE_KEY);
+  return stored === 'hpp' || stored === 'time' ? stored : 'hpp';
 }
 
 function loadStoredDeliveryImpactOnly(): boolean {
@@ -194,6 +201,8 @@ export function useResearchViews() {
   watch(elrViewMode, v => localStorage.setItem(ELR_VIEW_MODE_STORAGE_KEY, v));
   const elrSortMode = ref<ElrSortMode>(loadStoredElrSortMode());
   watch(elrSortMode, v => localStorage.setItem(ELR_SORT_MODE_STORAGE_KEY, v));
+  const elrRoiDisplayMode = ref<ElrRoiDisplayMode>(loadStoredElrRoiDisplayMode());
+  watch(elrRoiDisplayMode, v => localStorage.setItem(ELR_ROI_DISPLAY_MODE_STORAGE_KEY, v));
   const deliveryImpactOnly = ref(loadStoredDeliveryImpactOnly());
   watch(deliveryImpactOnly, v => localStorage.setItem(DELIVERY_IMPACT_ONLY_STORAGE_KEY, String(v)));
   const roiMode = ref<RoiMode>(loadStoredRoiMode());
@@ -1303,6 +1312,7 @@ export function useResearchViews() {
         isMaxed: boolean;
         impact: number;
         hpp: number;
+        timeRoiSeconds: number;
         realisticStats?: { layRate: number; shippingRate: number; elr: number; elrDelta: number };
         showDeadlineWarning: boolean;
       }[];
@@ -1354,9 +1364,21 @@ export function useResearchViews() {
             const secondsToBuyWithBank = getTimeToSave(price, actionsStore.effectiveSnapshot);
             const hoursToBuy = secondsToBuyNoBank / 3600;
             const hpp = impact > 0 ? hoursToBuy / (impact * 100) : Infinity;
+            // Time-to-ROI: how long, laying at the new (boosted) rate, it takes for the
+            // extra production to pay back the buy-time cost (expressed in egg-equivalent
+            // terms via the baseline rate). Equivalent to hpp * 100, in seconds.
+            const timeRoiSeconds = impact > 0 ? secondsToBuyNoBank / impact : Infinity;
 
             // Lookahead: find minimum N levels that unlock positive ELR impact.
-            let lookahead: { minLevels: number; impact: number; hpp: number; realisticStats: { layRate: number; shippingRate: number; elr: number; elrDelta: number } } | undefined;
+            let lookahead:
+              | {
+                  minLevels: number;
+                  impact: number;
+                  hpp: number;
+                  timeRoiSeconds: number;
+                  realisticStats: { layRate: number; shippingRate: number; elr: number; elrDelta: number };
+                }
+              | undefined;
             if (impact <= 0 && level + 1 < r.levels) {
               for (let n = 2; n <= r.levels - level; n++) {
                 const laLevels = { ...researchLevels, [r.id]: level + n };
@@ -1375,11 +1397,13 @@ export function useResearchViews() {
                   for (let l = level; l < level + n; l++) {
                     totalPriceForN += getDiscountedVirtuePrice(r, l, mods, isSale);
                   }
-                  const totalHoursForN = getTimeToSave(totalPriceForN, noBankSnapshot) / 3600;
+                  const totalSecondsForN = getTimeToSave(totalPriceForN, noBankSnapshot);
+                  const totalHoursForN = totalSecondsForN / 3600;
                   lookahead = {
                     minLevels: n,
                     impact: laImpact,
                     hpp: totalHoursForN / (laImpact * 100),
+                    timeRoiSeconds: totalSecondsForN / laImpact,
                     realisticStats: {
                       layRate: laStats.layRate * 3600,
                       shippingRate: laStats.shippingRate * 3600,
@@ -1402,6 +1426,7 @@ export function useResearchViews() {
               isMaxed: false,
               impact,
               hpp,
+              timeRoiSeconds,
               lookahead,
               realisticStats: {
                 layRate: stats.layRate * 3600,
@@ -1449,6 +1474,7 @@ export function useResearchViews() {
             const secondsToBuyWithBank = getTimeToSave(price, actionsStore.effectiveSnapshot);
             const hoursToBuy = secondsToBuyNoBank / 3600;
             const hpp = impact > 0 ? hoursToBuy / (impact * 100) : Infinity;
+            const timeRoiSeconds = impact > 0 ? secondsToBuyNoBank / impact : Infinity;
 
             return {
               research: r,
@@ -1460,6 +1486,7 @@ export function useResearchViews() {
               isMaxed: false,
               impact,
               hpp,
+              timeRoiSeconds,
               showDeadlineWarning: isSale && (absoluteSimTime + secondsToBuyWithBank > researchSaleDeadline.value),
             };
           })
@@ -1484,12 +1511,17 @@ export function useResearchViews() {
       }
 
       return candidates.map(c => {
-        const la = (c as { lookahead?: { minLevels: number; impact: number; hpp: number; realisticStats: typeof c.realisticStats } }).lookahead;
+        const la = (
+          c as {
+            lookahead?: { minLevels: number; impact: number; hpp: number; timeRoiSeconds: number; realisticStats: typeof c.realisticStats };
+          }
+        ).lookahead;
         return {
           ...c,
           extraStats: la ? `+${(la.impact * 100).toFixed(3)}%` : `+${(c.impact * 100).toFixed(3)}%`,
           extraLabel: la ? `${la.minLevels}-lvl impact` : 'Impact',
           hpp: la ? la.hpp : c.hpp,
+          timeRoiSeconds: la ? la.timeRoiSeconds : c.timeRoiSeconds,
           realisticStats: la ? la.realisticStats : c.realisticStats,
           lookahead: la ? { minLevels: la.minLevels, impact: la.impact, hpp: la.hpp } : undefined,
         };
@@ -1507,6 +1539,7 @@ export function useResearchViews() {
     currentView,
     elrViewMode,
     elrSortMode,
+    elrRoiDisplayMode,
     deliveryImpactOnly,
     roiMode,
     milestoneTarget,

--- a/wasmegg/ascension-planner/src/composables/useResearchViews.ts
+++ b/wasmegg/ascension-planner/src/composables/useResearchViews.ts
@@ -106,10 +106,51 @@ export const VIEWS = [
 ] as const;
 
 const RESEARCH_VIEW_STORAGE_KEY = 'ascension_research_view';
+const ELR_VIEW_MODE_STORAGE_KEY = 'ascension_research_elr_view_mode';
+const ELR_SORT_MODE_STORAGE_KEY = 'ascension_research_elr_sort_mode';
+const DELIVERY_IMPACT_ONLY_STORAGE_KEY = 'ascension_research_delivery_impact_only';
+const ROI_MODE_STORAGE_KEY = 'ascension_research_roi_mode';
+const MILESTONE_TARGET_STORAGE_KEY = 'ascension_research_milestone_target';
 
 function loadStoredResearchView(): ViewType {
   const stored = localStorage.getItem(RESEARCH_VIEW_STORAGE_KEY);
   return VIEWS.some(v => v.id === stored) ? (stored as ViewType) : 'game';
+}
+
+function loadStoredElrViewMode(): ElrViewMode {
+  const stored = localStorage.getItem(ELR_VIEW_MODE_STORAGE_KEY);
+  return stored === 'realistic' || stored === 'potential' ? stored : 'realistic';
+}
+
+function loadStoredElrSortMode(): ElrSortMode {
+  const stored = localStorage.getItem(ELR_SORT_MODE_STORAGE_KEY);
+  return stored === 'efficiency' || stored === 'impact' ? stored : 'efficiency';
+}
+
+function loadStoredDeliveryImpactOnly(): boolean {
+  return localStorage.getItem(DELIVERY_IMPACT_ONLY_STORAGE_KEY) === 'true';
+}
+
+function loadStoredRoiMode(): RoiMode {
+  const stored = localStorage.getItem(ROI_MODE_STORAGE_KEY);
+  return stored === 'immediate' || stored === 'maxed_vehicles' ? stored : 'immediate';
+}
+
+function loadStoredMilestoneTarget(): MilestoneTarget | null {
+  const stored = localStorage.getItem(MILESTONE_TARGET_STORAGE_KEY);
+  if (!stored) return null;
+  try {
+    const parsed = JSON.parse(stored);
+    if (parsed?.kind === 'tier' && typeof parsed.tier === 'number') {
+      return { kind: 'tier', tier: parsed.tier };
+    }
+    if (parsed?.kind === 'research' && typeof parsed.researchId === 'string' && typeof parsed.targetLevel === 'number') {
+      return { kind: 'research', researchId: parsed.researchId, targetLevel: parsed.targetLevel };
+    }
+  } catch {
+    // ignore malformed storage
+  }
+  return null;
 }
 
 // Evaluation IDs for ELR Impact
@@ -149,11 +190,26 @@ export function useResearchViews() {
 
   const currentView = ref<ViewType>(loadStoredResearchView());
   watch(currentView, v => localStorage.setItem(RESEARCH_VIEW_STORAGE_KEY, v));
-  const elrViewMode = ref<ElrViewMode>('realistic');
-  const elrSortMode = ref<ElrSortMode>('efficiency');
-  const deliveryImpactOnly = ref(false);
-  const roiMode = ref<RoiMode>('immediate');
-  const milestoneTarget = ref<MilestoneTarget | null>(null);
+  const elrViewMode = ref<ElrViewMode>(loadStoredElrViewMode());
+  watch(elrViewMode, v => localStorage.setItem(ELR_VIEW_MODE_STORAGE_KEY, v));
+  const elrSortMode = ref<ElrSortMode>(loadStoredElrSortMode());
+  watch(elrSortMode, v => localStorage.setItem(ELR_SORT_MODE_STORAGE_KEY, v));
+  const deliveryImpactOnly = ref(loadStoredDeliveryImpactOnly());
+  watch(deliveryImpactOnly, v => localStorage.setItem(DELIVERY_IMPACT_ONLY_STORAGE_KEY, String(v)));
+  const roiMode = ref<RoiMode>(loadStoredRoiMode());
+  watch(roiMode, v => localStorage.setItem(ROI_MODE_STORAGE_KEY, v));
+  const milestoneTarget = ref<MilestoneTarget | null>(loadStoredMilestoneTarget());
+  watch(
+    milestoneTarget,
+    v => {
+      if (v) {
+        localStorage.setItem(MILESTONE_TARGET_STORAGE_KEY, JSON.stringify(v));
+      } else {
+        localStorage.removeItem(MILESTONE_TARGET_STORAGE_KEY);
+      }
+    },
+    { deep: true }
+  );
 
   const realisticSummary = computed(() => {
     const rawBackup = initialStateStore.rawBackup;

--- a/wasmegg/ascension-planner/src/lib/artifacts/utils.ts
+++ b/wasmegg/ascension-planner/src/lib/artifacts/utils.ts
@@ -74,6 +74,32 @@ export function libArtifactToEquippedArtifact(afx: Artifact): EquippedArtifact {
 }
 
 /**
+ * Convert the planner's EquippedArtifact format (with stones) into lib `Artifact[]`,
+ * the format consumed by the shared Clothed TE formulas (`cteFromArtifacts`, etc).
+ * Inverse of {@link libArtifactToEquippedArtifact}.
+ */
+export function equippedArtifactsToLibArtifacts(loadout: EquippedArtifact[]): Artifact[] {
+  const result: Artifact[] = [];
+  for (const slot of loadout) {
+    const option = getArtifact(slot.artifactId);
+    if (!option) continue;
+    const tier = allPossibleTiers.find(t => t.family.id === option.familyId && t.tier_number === option.tier);
+    if (!tier) continue;
+
+    const host = newItem({ name: option.afxId, level: tier.afx_level, rarity: option.rarity });
+    const stones = slot.stones
+      .map(id => getStone(id))
+      .filter((s): s is NonNullable<typeof s> => s !== null)
+      .map(stone => allPossibleTiers.find(t => t.family.id === stone.familyId && t.tier_number === stone.tier))
+      .filter((t): t is NonNullable<typeof t> => t !== undefined)
+      .map(t => newItem({ name: t.afx_id, level: t.afx_level, rarity: ei.ArtifactSpec.Rarity.COMMON }));
+
+    result.push(new Artifact(host, stones));
+  }
+  return result;
+}
+
+/**
  * Parse equipped artifacts and stones from a player backup.
  */
 export function getArtifactLoadoutFromBackup(backup: ei.IBackup): EquippedArtifact[] {

--- a/wasmegg/ascension-planner/src/lib/artifacts/virtue.ts
+++ b/wasmegg/ascension-planner/src/lib/artifacts/virtue.ts
@@ -8,15 +8,16 @@ import {
   contenderToArtifactSet,
   newItem,
 } from 'lib/artifacts';
-import { allModifiersFromColleggtibles, maxModifierFromColleggtibles } from 'lib/collegtibles';
+import { allModifiersFromColleggtibles, maxModifierFromColleggtibles, Modifiers } from 'lib/collegtibles';
 import { getNumTruthEggs } from 'lib/earning_bonus';
+import { cteFromArtifacts, cteFromColleggtibles, cteFromLabUpgrade, multiplierToTE } from 'lib/virtue';
 import {
   eggValueMultiplier,
   awayEarningsMultiplier,
   researchPriceMultiplierFromArtifacts,
 } from 'lib/artifacts/virtue_effects';
 import { EquippedArtifact } from './types';
-import { libArtifactToEquippedArtifact } from './utils';
+import { libArtifactToEquippedArtifact, equippedArtifactsToLibArtifacts } from './utils';
 import {
   calculateArtifactModifiers,
   createEmptyLoadout,
@@ -70,6 +71,34 @@ export function getOptimalEarningsSet(backup: ei.IBackup): EquippedArtifact[] {
   const { artifactSet } = contenderToArtifactSet(contender, equipped, inventory);
 
   return artifactSet.artifacts.map(libArtifactToEquippedArtifact);
+}
+
+/**
+ * Calculate Clothed TE for an arbitrary artifact set (e.g. a candidate set the
+ * player hasn't equipped yet), driven by the planner's own live initial-state
+ * inputs rather than a frozen backup snapshot. Mirrors virtue-companion's
+ * `calculateClothedTE`, composed from the same shared `lib/virtue` primitives.
+ */
+export function calculateClothedTEForSet(
+  loadout: EquippedArtifact[],
+  options: {
+    truthEggs: number;
+    colleggtibleModifiers: Modifiers;
+    labUpgradeLevel: number;
+    permitLevel?: number | null;
+  }
+): number {
+  const artifacts = equippedArtifactsToLibArtifacts(loadout);
+  // Standard permit halves offline earnings; Pro permit (permitLevel === 1) does not.
+  const permitPenalty = options.permitLevel === 1 ? 0 : multiplierToTE(0.5);
+
+  return (
+    options.truthEggs +
+    cteFromArtifacts(artifacts) +
+    cteFromColleggtibles(options.colleggtibleModifiers) +
+    cteFromLabUpgrade(options.labUpgradeLevel) +
+    permitPenalty
+  );
 }
 
 // Internal candidate representation used by the pool-based ELR optimizer.

--- a/wasmegg/ascension-planner/src/stores/actions/index.ts
+++ b/wasmegg/ascension-planner/src/stores/actions/index.ts
@@ -383,6 +383,20 @@ export const useActionsStore = defineStore('actions', {
         a.dependents = a.dependents.filter(depId => !toRemove.has(depId));
       });
       this.actions = newActions;
+
+      // If we're editing a shift and it's now the last shift in the plan (because a later
+      // shift and its actions were just undone), stop editing it. Editing exists to modify a
+      // past shift; once it's the last shift, it's already the default edit target.
+      if (this.editingGroupId) {
+        const headerIndex = this.actions.findIndex(a => a.id === this.editingGroupId);
+        if (headerIndex !== -1) {
+          const hasLaterShift = this.actions.some((a, idx) => idx > headerIndex && a.type === 'shift');
+          if (!hasLaterShift) {
+            this.editingGroupId = null;
+          }
+        }
+      }
+
       await this.recalculateFrom(minIndex === Infinity ? 0 : minIndex);
       if (restoreCallback) restoreCallback(this.effectiveSnapshot);
     },

--- a/wasmegg/ascension-planner/src/stores/actions/index.ts
+++ b/wasmegg/ascension-planner/src/stores/actions/index.ts
@@ -689,8 +689,8 @@ export const useActionsStore = defineStore('actions', {
       
       // NEW: Skip recalculation if the plan already contains calculated result data (endState).
       // Since the user is in a long session, we trust the cached calculations in the library.
-      const isPreCalculated = data.actions && 
-                             data.actions.length > 0 && 
+      const isPreCalculated = data.actions &&
+                             data.actions.length > 0 &&
                              data.actions.every((a: Action) => a.endState !== undefined);
 
       if (isPreCalculated) {

--- a/wasmegg/ascension-planner/src/stores/actions/io.ts
+++ b/wasmegg/ascension-planner/src/stores/actions/io.ts
@@ -161,7 +161,12 @@ export function importPlanLogic(jsonString: string) {
       cost: 0, elrDelta: 0, offlineEarningsDelta: 0, eggValueDelta: 0,
       habCapacityDelta: 0, layRateDelta: 0, shippingCapacityDelta: 0,
       ihrDelta: 0, bankDelta: 0, populationDelta: 0, totalTimeSeconds: 0,
-      endState: createEmptySnapshot(),
+      endState: {
+        ...createEmptySnapshot(),
+        currentEgg: 'curiosity',
+        eggsDelivered: { ...(data.truthEggsState?.eggsDelivered || {}) },
+        teEarned: { ...(data.truthEggsState?.teEarned || {}) },
+      },
       dependsOn: [], dependents: []
     };
     data.actions = [startAction, ...data.actions];


### PR DESCRIPTION
* Major bug fix where Auto AP plans were inaccurate because steps other than Wait for TE weren't counting eggs delivered.
* Add CTE to various parts of AP (reused existing lib for calculations)
* Allow absolute times in Wait With Empty Silos input
* Make Hab buttons (max and 5-min max) smarter about buying
* Show delivery time ROI vs HPP (hour per percentage) choice on Delivery Rate research
* Cache research view sub-options in browser cache along with the main view.