### PR TITLE
Add mobile specific display for ship overrides

### DIFF
--- a/wasmegg/artifact-explorer/src/components/PlayerOverridesModal.vue
+++ b/wasmegg/artifact-explorer/src/components/PlayerOverridesModal.vue
@@ -91,33 +91,41 @@
 
             <template v-else>
               <!-- Save loaded: per-ship choice between save values and manual values. -->
+              <!-- Column headers (desktop only; mobile uses inline labels per card). -->
               <div
-                class="grid grid-cols-[minmax(0,1fr)_auto_auto_auto] gap-x-3 items-center px-1 text-[11px] font-medium uppercase tracking-wide text-gray-400"
+                class="hidden sm:grid grid-cols-[minmax(0,1fr)_auto_auto_auto] gap-x-3 items-center px-1 text-[11px] font-medium uppercase tracking-wide text-gray-400"
               >
                 <span>Ship</span>
                 <span class="w-40">From save</span>
                 <span class="w-14 text-center">Override?</span>
                 <span class="w-44">Custom value</span>
               </div>
-              <p class="text-xs text-gray-400 px-1 -mt-1">
+              <p class="text-xs text-gray-400 px-1 sm:-mt-1">
                 The checkbox marks a ship as launchable; the stars are its level. The optimizer uses whichever side
                 isn't grayed out.
               </p>
 
-              <div class="border-t border-gray-100 divide-y divide-gray-50">
+              <div class="border-t border-gray-100 divide-y divide-gray-100 sm:divide-gray-50">
                 <div
                   v-for="ship in spaceshipList"
                   :key="ship"
-                  class="grid grid-cols-[minmax(0,1fr)_auto_auto_auto] gap-x-3 items-center px-1 py-1.5"
+                  class="px-1 py-2 sm:py-1.5 sm:grid sm:grid-cols-[minmax(0,1fr)_auto_auto_auto] sm:gap-x-3 sm:items-center"
                 >
-                  <span class="text-sm text-gray-700 truncate">{{ spaceshipName(ship) }}</span>
+                  <span class="block text-sm font-medium text-gray-700 truncate sm:font-normal">{{
+                    spaceshipName(ship)
+                  }}</span>
 
                   <!-- Save values (read-only) -->
                   <div
-                    class="flex items-center gap-1.5 w-40"
+                    class="flex items-center gap-1.5 mt-2 sm:mt-0 sm:w-40"
                     :class="isManual(ship) ? 'opacity-40' : ''"
                     :title="isManual(ship) ? 'Ignored while manual is on' : 'Currently in use'"
                   >
+                    <span
+                      class="sm:hidden w-20 flex-shrink-0 text-[11px] uppercase tracking-wide text-gray-400"
+                    >
+                      From save
+                    </span>
                     <span
                       class="text-sm w-4 text-center flex-shrink-0"
                       :class="player.shipVisibility[ship] ? 'text-green-600' : 'text-gray-400'"
@@ -132,20 +140,34 @@
                   </div>
 
                   <!-- Manual toggle -->
-                  <input
-                    type="checkbox"
-                    class="justify-self-center h-3.5 w-3.5 text-amber-600 border-gray-300 rounded focus:ring-amber-500"
-                    :checked="isManual(ship)"
-                    :title="isManual(ship) ? 'Untick to go back to your save values' : 'Tick to set this ship manually'"
-                    @change="setManual(ship, ($event.target as HTMLInputElement).checked)"
-                  />
+                  <div class="flex items-center gap-1.5 mt-1 sm:mt-0 sm:justify-self-center">
+                    <span
+                      class="sm:hidden w-20 flex-shrink-0 text-[11px] uppercase tracking-wide text-gray-400"
+                    >
+                      Override?
+                    </span>
+                    <input
+                      type="checkbox"
+                      class="h-3.5 w-3.5 text-amber-600 border-gray-300 rounded focus:ring-amber-500"
+                      :checked="isManual(ship)"
+                      :title="
+                        isManual(ship) ? 'Untick to go back to your save values' : 'Tick to set this ship manually'
+                      "
+                      @change="setManual(ship, ($event.target as HTMLInputElement).checked)"
+                    />
+                  </div>
 
                   <!-- Manual values (editable once manual is on) -->
                   <div
-                    class="flex items-center gap-1.5 w-44"
+                    class="flex items-center gap-1.5 mt-1 sm:mt-0 sm:w-44"
                     :class="isManual(ship) ? '' : 'opacity-40'"
                     :title="isManual(ship) ? 'Currently in use' : 'Ignored until manual is on'"
                   >
+                    <span
+                      class="sm:hidden w-20 flex-shrink-0 text-[11px] uppercase tracking-wide text-gray-400"
+                    >
+                      Custom
+                    </span>
                     <input
                       type="checkbox"
                       class="h-3.5 w-3.5 text-green-600 border-gray-300 rounded focus:ring-green-500 flex-shrink-0 disabled:cursor-not-allowed"


### PR DESCRIPTION
The initial release of the Artifact Optimizer had a bug where the Ship labels in the Ship Override window wouldn't be visible on mobile. This update introduces a mobile-specific display where the labels are more obvious and the buttons should be easier to click.