### PR TITLE
Update XP to level comparison to be properly gated

### DIFF
--- a/lib/artifacts/data.ts
+++ b/lib/artifacts/data.ts
@@ -173,7 +173,7 @@ export function getCraftingLevelFromXp(craftingXp: number): PlayerCraftingLevel 
 
     const levelTargetXp = levelBaseXp + xpRequired;
 
-    if (craftingXp <= levelTargetXp || level == numLevels) {
+    if (craftingXp < levelTargetXp || level == numLevels) {
       return { level, rarityMult };
     }
 


### PR DESCRIPTION
With <=, feeding the XP from getXPFromCraftingLevel into getCraftingLevelFromXP would return a different value from the original crafting level fed in. It consistently returns the correct value with this update