### PR TITLE
Add maximum cost filter for missions

### DIFF
--- a/lib/missions.ts
+++ b/lib/missions.ts
@@ -491,6 +491,9 @@ export class MissionType {
     const fuels = virtue ? this.virtueFuels : this.defaultFuels;
     return new Map(fuels.map(fuel => [fuel.egg, fuel.amount]));
   }
+  get virtueGemCost(): number {
+    return virtueShipGemCosts[this.shipType];
+  }
 
   boostedCapacity(config: ShipsConfig): number {
     return Math.floor(
@@ -1096,6 +1099,23 @@ const virtueMissionFuelsInfo: MissionTypeMap<MissionFuels> = {
       new MissionFuel(ei.Egg.RESILIENCE, 40e12),
     ],
   },
+};
+
+// Gem cost to purchase each virtue ship for launch on the Egg of Humility.
+// Constant per ship; mission duration and ship level have no effect.
+// https://egg-inc.fandom.com/wiki/Path_of_Virtue/Egg_of_Humility
+export const virtueShipGemCosts: Record<Spaceship, number> = {
+  [Spaceship.CHICKEN_ONE]: 9.7e9,
+  [Spaceship.CHICKEN_NINE]: 19e12,
+  [Spaceship.CHICKEN_HEAVY]: 35e15,
+  [Spaceship.BCR]: 60e18,
+  [Spaceship.MILLENIUM_CHICKEN]: 2.4e21,
+  [Spaceship.CORELLIHEN_CORVETTE]: 600e21,
+  [Spaceship.GALEGGTICA]: 129e24,
+  [Spaceship.CHICKFIANT]: 29e27,
+  [Spaceship.VOYEGGER]: 39e30,
+  [Spaceship.HENERPRISE]: 310e33,
+  [Spaceship.ATREGGIES]: 419e36,
 };
 
 export function requiredTotalLaunchesToUnlockNextShip(shipType: Spaceship): number {

--- a/wasmegg/artifact-explorer/src/components/ArtifactMissionOptimizer.vue
+++ b/wasmegg/artifact-explorer/src/components/ArtifactMissionOptimizer.vue
@@ -140,6 +140,7 @@ export default defineComponent({
       const minDurationSeconds = missionFilters.value.minDurationHoursEnabled
         ? missionFilters.value.minDurationHours * 3600
         : undefined;
+      const maxGemCost = missionFilters.value.maxGemCostEnabled ? missionFilters.value.maxGemCost : undefined;
       computedResults.value = optimize(
         {
           // Eventually, this will be expanded to allow multiple artifacts
@@ -152,7 +153,8 @@ export default defineComponent({
         effectiveConfig.value,
         recipeDag.value,
         playerBaseYield.value,
-        minDurationSeconds
+        minDurationSeconds,
+        maxGemCost
       );
       pendingCompute.value = false;
     }

--- a/wasmegg/artifact-explorer/src/components/optimizer/OptimizerSidebar.vue
+++ b/wasmegg/artifact-explorer/src/components/optimizer/OptimizerSidebar.vue
@@ -55,6 +55,32 @@
           </div>
         </div>
 
+        <div>
+          <label class="flex items-center gap-2 text-sm text-gray-600 cursor-pointer select-none">
+            <input
+              type="checkbox"
+              class="h-4 w-4 text-green-600 border-gray-300 rounded focus:ring-green-500"
+              :checked="missionFilters.maxGemCostEnabled"
+              @change="setMaxGemCostEnabled(($event.target as HTMLInputElement).checked)"
+            />
+            Maximum purchase cost
+          </label>
+          <div class="mt-1 flex items-center gap-2">
+            <input
+              type="text"
+              :disabled="!missionFilters.maxGemCostEnabled"
+              :value="maxGemCostDisplay"
+              placeholder="e.g. 10S"
+              class="block w-24 sm:text-sm rounded-md focus:outline-none focus:ring-blue-500 focus:border-blue-500 px-2 py-1 border border-gray-300 disabled:bg-gray-50 disabled:text-gray-400"
+              @input="onGemCostInput($event)"
+            />
+            <span class="text-xs text-gray-500">gems</span>
+          </div>
+          <p v-if="missionFilters.maxGemCostEnabled" class="mt-1 text-xs text-gray-400">
+            Only schedule ships costing at most this many gems (e.g. 10S = 10 septillion)
+          </p>
+        </div>
+
         <label class="flex items-center gap-2 text-sm text-gray-600 cursor-pointer select-none">
           <input
             id="sidebar_show_nodata"
@@ -181,7 +207,7 @@
 <script lang="ts">
 import { computed, defineComponent } from 'vue';
 
-import { formatEIValue, fuelTankSizes, spaceshipList } from 'lib';
+import { formatEIValue, fuelTankSizes, parseValueWithUnit, spaceshipList } from 'lib';
 import BaseInput from 'ui/components/BaseInput.vue';
 import PlayerIdForm from 'ui/components/PlayerIdForm.vue';
 import LootDataCredit from '@/components/LootDataCredit.vue';
@@ -203,6 +229,8 @@ import {
   setCraftingLevel,
   setEpicResearchFTLLevel,
   setEpicResearchZerogLevel,
+  setMaxGemCost,
+  setMaxGemCostEnabled,
   setMinDurationHours,
   setMinDurationHoursEnabled,
   setOverrideCraftingLevel,
@@ -250,6 +278,18 @@ export default defineComponent({
       setMinDurationHours(n);
     }
 
+    // Shown value for the gem cost filter, in Egg, Inc. order-of-magnitude
+    // notation (e.g. 10S). Input is parsed back through the same notation.
+    const maxGemCostDisplay = computed(() => formatEIValue(missionFilters.value.maxGemCost, { trim: true }));
+
+    function onGemCostInput(event: Event) {
+      const raw = (event.target as HTMLInputElement).value.trim();
+      if (!raw) return;
+      const n = parseValueWithUnit(raw, false);
+      if (n === null || n < 0) return;
+      setMaxGemCost(n);
+    }
+
     return {
       hasPlayerData,
       maxTankLevel,
@@ -257,6 +297,8 @@ export default defineComponent({
       totalShips,
       shipsVisibleCount,
       onDurationInput,
+      maxGemCostDisplay,
+      onGemCostInput,
       // store state
       config,
       extras,
@@ -280,6 +322,7 @@ export default defineComponent({
       setOverrideFTL,
       setOverrideZerog,
       setMinDurationHoursEnabled,
+      setMaxGemCostEnabled,
       openPlayerOverridesModal,
     };
   },

--- a/wasmegg/artifact-explorer/src/lib/index.ts
+++ b/wasmegg/artifact-explorer/src/lib/index.ts
@@ -115,10 +115,11 @@ export function optimize(
   playerConfig: ShipsConfig,
   dag: RecipeDAG,
   baseYield: Map<string, number>,
-  minDurationSeconds?: number
+  minDurationSeconds?: number,
+  maxGemCost?: number
 ) {
   const { desiredArtifactNodeIds, fuelTankCapacity, timeBudgetSeconds } = config;
-  const options = enumerateLaunchOptions(playerConfig, dag, minDurationSeconds);
+  const options = enumerateLaunchOptions(playerConfig, dag, minDurationSeconds, maxGemCost);
 
   const solutions: OptimizerSolution[] = [
     optimizeFull({

--- a/wasmegg/artifact-explorer/src/lib/phases.ts
+++ b/wasmegg/artifact-explorer/src/lib/phases.ts
@@ -45,11 +45,13 @@ export function generateRecipeDag(id: string, recipeDag: RecipeDAG) {
 
 // Enumerate launch options: every visible ship crossed with its applicable
 // mission targets, each carrying fuel cost, duration, and per-launch yield
-// vectors. Missions shorter than minDurationSeconds (if given) are skipped.
+// vectors. Missions shorter than minDurationSeconds or whose ship costs more
+// gems than maxGemCost (if given) are skipped.
 export function enumerateLaunchOptions(
   playerConfig: ShipsConfig,
   dag: RecipeDAG,
-  minDurationSeconds?: number
+  minDurationSeconds?: number,
+  maxGemCost?: number
 ): LaunchOption[] {
   const options: LaunchOption[] = [];
 
@@ -67,6 +69,8 @@ export function enumerateLaunchOptions(
       const missionDuration = mission.boostedDurationSeconds(playerConfig);
       if (missionDuration < minDurationSeconds) continue;
     }
+
+    if (maxGemCost !== undefined && mission.virtueGemCost > maxGemCost) continue;
 
     const missionData = getMissionLootData(mission.missionTypeId);
     const levelLootData = missionData.levels[playerConfig.shipLevels[mission.shipType]];

--- a/wasmegg/artifact-explorer/src/lib/pipeline.spec.ts
+++ b/wasmegg/artifact-explorer/src/lib/pipeline.spec.ts
@@ -73,6 +73,18 @@ describe('enumerateLaunchOptions', () => {
       expect(o.actualTime).toBeGreaterThanOrEqual(minDuration);
     }
   });
+
+  it('drops missions whose ship costs more gems than maxGemCost', () => {
+    const all = enumerateLaunchOptions(perfectShipsConfig, dag);
+    const maxGemCost = 129e24; // Galeggtica price: everything up to and including it
+    const cheapOnly = enumerateLaunchOptions(perfectShipsConfig, dag, undefined, maxGemCost);
+    expect(cheapOnly.length).toBeGreaterThan(0);
+    expect(cheapOnly.length).toBeLessThan(all.length);
+    for (const o of cheapOnly) {
+      expect(o.ship.virtueGemCost).toBeLessThanOrEqual(maxGemCost);
+    }
+    expect(cheapOnly.some(o => o.ship.virtueGemCost === maxGemCost)).toBe(true);
+  });
 });
 
 describe('optimize', () => {

--- a/wasmegg/artifact-explorer/src/store/index.ts
+++ b/wasmegg/artifact-explorer/src/store/index.ts
@@ -381,13 +381,25 @@ export function setMinDurationHours(hours: number): void {
   missionFilters.value.minDurationHours = Math.max(0, hours);
 }
 
+export function setMaxGemCostEnabled(enabled: boolean): void {
+  missionFilters.value.maxGemCostEnabled = enabled;
+}
+
+export function setMaxGemCost(cost: number): void {
+  missionFilters.value.maxGemCost = Math.max(0, cost);
+}
+
 export function loadMissionFilters(): MissionFilters {
   const str = getLocalStorage(MISSION_FILTERS_LOCALSTORAGE_KEY);
   if (!str) return newMissionFilters();
   try {
     const parsed: unknown = JSON.parse(str);
     if (isMissionFilters(parsed)) {
-      return parsed;
+      return {
+        ...parsed,
+        maxGemCostEnabled: parsed.maxGemCostEnabled ?? false,
+        maxGemCost: parsed.maxGemCost ?? 0,
+      };
     }
   } catch (err) {
     console.warn(`error parsing mission filters: ${err}`);

--- a/wasmegg/artifact-explorer/src/store/schema.ts
+++ b/wasmegg/artifact-explorer/src/store/schema.ts
@@ -2,7 +2,7 @@
 // localStorage values. Kept free of side effects (no localStorage or window
 // access at import time) so it can be unit tested under node.
 
-import type { ei } from 'lib';
+import { virtueShipGemCosts, ei } from 'lib';
 
 type Spaceship = ei.MissionInfo.Spaceship;
 
@@ -71,14 +71,27 @@ export function isExtrasConfig(x: unknown): x is ExtrasConfig {
 export interface MissionFilters {
   minDurationHoursEnabled: boolean;
   minDurationHours: number;
+  // Maximum gem cost of a mission's ship on the Egg of Humility.
+  maxGemCostEnabled: boolean;
+  maxGemCost: number;
 }
 
 export function newMissionFilters(): MissionFilters {
-  return { minDurationHoursEnabled: false, minDurationHours: 0 };
+  return {
+    minDurationHoursEnabled: false,
+    minDurationHours: 0,
+    maxGemCostEnabled: false,
+    maxGemCost: virtueShipGemCosts[ei.MissionInfo.Spaceship.ATREGGIES],
+  };
 }
 
 export function isMissionFilters(x: unknown): x is MissionFilters {
   if (!x || typeof x !== 'object') return false;
   const m = x as MissionFilters;
-  return typeof m.minDurationHoursEnabled === 'boolean' && typeof m.minDurationHours === 'number';
+  return (
+    typeof m.minDurationHoursEnabled === 'boolean' &&
+    typeof m.minDurationHours === 'number' &&
+    (m.maxGemCostEnabled === undefined || typeof m.maxGemCostEnabled === 'boolean') &&
+    (m.maxGemCost === undefined || typeof m.maxGemCost === 'number')
+  );
 }


### PR DESCRIPTION
This allows players early in PoV to easily filter out missions that are too expensive for them to send.

Changelog: feature