### PR TITLE
Saving Clicks Galore

### DIFF
--- a/wasmegg/ascension-planner/src/components/actions/ResearchActions.vue
+++ b/wasmegg/ascension-planner/src/components/actions/ResearchActions.vue
@@ -79,6 +79,21 @@
       @update:roi-display-mode="elrRoiDisplayMode = $event"
     />
 
+    <button
+      v-if="currentView === 'elr'"
+      class="btn-premium btn-primary w-full py-4 flex items-center justify-center gap-2 group disabled:opacity-20 shadow-lg shadow-slate-900/10"
+      :disabled="!canBuyUntilSaleDeadline"
+      v-tippy="'Buys the top-ranked research over and over, recalculating after each purchase, and stops right before one that wouldn\'t finish before the research sale ends. Only available while the research sale is active.'"
+      @click="handleBuyUntilSaleDeadline"
+    >
+      <img
+        :src="iconURL('egginc-extras/icon_research_sale.png', 64)"
+        class="w-5 h-5 object-contain group-hover:scale-110 transition-transform"
+        alt="Research Sale"
+      />
+      <span>Buy Until Sale Ends</span>
+    </button>
+
     <MilestoneTargetPicker
       v-if="currentView === 'milestones'"
       v-model="milestoneTarget"
@@ -394,17 +409,21 @@ function handleBuyResearch(research: CommonResearch) {
   withExpiryCheck(duration, true, () => buyOneLevel(research));
 }
 
-// Top-ranked buyable item in the ROI view, i.e. the one "Buy Until Sale Warning" would buy next.
-const nextRoiCandidate = computed(() => sortedResearches.value.find(item => item.canBuy && !item.isMaxed));
+// Best-ranked buyable ROI item that doesn't fail the sale-warning check, i.e. the one
+// "Buy Until Sale Warning" would buy next. A higher-ranked item may be skipped over here
+// because it fails the check (e.g. too expensive to finish before the sale) while a
+// cheaper, lower-ranked one still passes.
+const nextRoiCandidate = computed(() =>
+  sortedResearches.value.find(item => item.canBuy && !item.isMaxed && !getSimulatedShowSaleWarning(item))
+);
 
-const canBuyUntilSaleWarning = computed(() => {
-  const next = nextRoiCandidate.value;
-  return !!next && !getSimulatedShowSaleWarning(next);
-});
+const canBuyUntilSaleWarning = computed(() => !!nextRoiCandidate.value);
 
-// Repeatedly buys the top-ranked ROI research, recalculating the list after each purchase
-// (since buying one research changes the math for the rest), stopping right before an item
-// that wouldn't earn back 70% of its cost before the next sale.
+// Repeatedly buys the best-ranked ROI research that still passes the sale-warning check,
+// recalculating the list after each purchase (since buying one research changes the math
+// for the rest). Items that fail the check are skipped rather than treated as a stopping
+// point, since a cheaper lower-ranked item may still be affordable in time. Stops only once
+// every remaining purchasable item fails the check.
 function handleBuyUntilSaleWarning() {
   batch(() => {
     let iterations = 0;
@@ -413,7 +432,37 @@ function handleBuyUntilSaleWarning() {
     while (iterations < maxIterations) {
       iterations++;
       const next = nextRoiCandidate.value;
-      if (!next || getSimulatedShowSaleWarning(next)) break;
+      if (!next) break;
+      if (!buyOneLevel(next.research)) break;
+    }
+  });
+}
+
+// Best-ranked buyable Delivery Impact item that would still finish before the sale ends,
+// i.e. the one "Buy Until Sale Ends" would buy next. A higher-ranked item may be skipped
+// over here because it fails the check while a cheaper, lower-ranked one still passes.
+const nextElrCandidate = computed(() =>
+  sortedResearches.value.find(item => item.canBuy && !item.isMaxed && !item.showDeadlineWarning)
+);
+
+const canBuyUntilSaleDeadline = computed(() => isResearchSaleActive.value && !!nextElrCandidate.value);
+
+// Repeatedly buys the best-ranked Delivery Impact research that would still finish before
+// the sale ends, recalculating the list after each purchase. Items that fail the check are
+// skipped rather than treated as a stopping point, since a cheaper lower-ranked item may
+// still be affordable in time. Stops only once every remaining purchasable item fails the
+// check.
+function handleBuyUntilSaleDeadline() {
+  if (!isResearchSaleActive.value) return;
+
+  batch(() => {
+    let iterations = 0;
+    const maxIterations = 1000;
+
+    while (iterations < maxIterations) {
+      iterations++;
+      const next = nextElrCandidate.value;
+      if (!next) break;
       if (!buyOneLevel(next.research)) break;
     }
   });

--- a/wasmegg/ascension-planner/src/components/actions/ResearchActions.vue
+++ b/wasmegg/ascension-planner/src/components/actions/ResearchActions.vue
@@ -53,6 +53,20 @@
           >?</span>
         </div>
       </div>
+
+      <button
+        class="btn-premium btn-primary w-full mt-6 py-4 flex items-center justify-center gap-2 group disabled:opacity-20 shadow-lg shadow-slate-900/10"
+        :disabled="!canBuyUntilSaleWarning"
+        v-tippy="'Buys the top-ranked research over and over, recalculating after each purchase, and stops right before one that won\'t earn back 70% of its cost before the next sale.'"
+        @click="handleBuyUntilSaleWarning"
+      >
+        <img
+          :src="iconURL('egginc-extras/icon_research_sale.png', 64)"
+          class="w-5 h-5 object-contain group-hover:scale-110 transition-transform"
+          alt="Research Sale"
+        />
+        <span>Buy Until Sale Warning</span>
+      </button>
     </div>
 
     <ElrViewControls
@@ -210,7 +224,8 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watch } from 'vue';
+import { computed, ref, watch } from 'vue';
+import { iconURL } from 'lib';
 import {
   getDiscountedVirtuePrice,
   getCommonResearches,
@@ -304,6 +319,11 @@ function getSimulatedBuyToHereSeconds(item: unknown): number | undefined {
   return typeof seconds === 'number' ? seconds : undefined;
 }
 
+// Only the ROI view branch populates showSaleWarning; other branches' item shapes don't have it.
+function getSimulatedShowSaleWarning(item: unknown): boolean {
+  return (item as { showSaleWarning?: unknown }).showSaleWarning === true;
+}
+
 /**
  * Buy a single level of research and create the action.
  * Returns true if successful, false if already maxed.
@@ -372,6 +392,31 @@ watch(
 function handleBuyResearch(research: CommonResearch) {
   const duration = getTimeToBuySeconds(research);
   withExpiryCheck(duration, true, () => buyOneLevel(research));
+}
+
+// Top-ranked buyable item in the ROI view, i.e. the one "Buy Until Sale Warning" would buy next.
+const nextRoiCandidate = computed(() => sortedResearches.value.find(item => item.canBuy && !item.isMaxed));
+
+const canBuyUntilSaleWarning = computed(() => {
+  const next = nextRoiCandidate.value;
+  return !!next && !getSimulatedShowSaleWarning(next);
+});
+
+// Repeatedly buys the top-ranked ROI research, recalculating the list after each purchase
+// (since buying one research changes the math for the rest), stopping right before an item
+// that wouldn't earn back 70% of its cost before the next sale.
+function handleBuyUntilSaleWarning() {
+  batch(() => {
+    let iterations = 0;
+    const maxIterations = 1000;
+
+    while (iterations < maxIterations) {
+      iterations++;
+      const next = nextRoiCandidate.value;
+      if (!next || getSimulatedShowSaleWarning(next)) break;
+      if (!buyOneLevel(next.research)) break;
+    }
+  });
 }
 
 function handleSmartBuy(threshold: number) {

--- a/wasmegg/ascension-planner/src/components/actions/ResearchItem.vue
+++ b/wasmegg/ascension-planner/src/components/actions/ResearchItem.vue
@@ -53,27 +53,8 @@
             </span>
           </div>
         </div>
-
-        <div
-          v-if="recommendationNote"
-          class="mt-1.5 p-1.5 inline-block bg-blue-50 border border-blue-100 rounded text-[9px] text-blue-800 leading-tight shadow-sm"
-        >
-          <div class="flex items-start gap-1">
-            <svg class="w-3 h-3 text-blue-500 shrink-0" fill="currentColor" viewBox="0 0 20 20">
-              <path
-                fill-rule="evenodd"
-                d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z"
-                clip-rule="evenodd"
-              />
-            </svg>
-            <span>
-              <span class="font-bold uppercase tracking-tight mr-1">Pair Suggestion:</span>
-              {{ recommendationNote }}
-            </span>
-          </div>
-        </div>
       </div>
-      
+
       <!-- Gem Cost -->
       <div class="text-right shrink-0">
         <template v-if="!isMaxed">
@@ -130,6 +111,25 @@
                 {{ hpp === Infinity || isNaN(hpp) ? '∞' : hpp.toFixed(1) }} hr/%
               </template>
             </div>
+          </div>
+        </div>
+
+        <div
+          v-if="recommendationNote"
+          class="mt-1.5 p-1.5 inline-block bg-blue-50 border border-blue-100 rounded text-[9px] text-blue-800 leading-tight shadow-sm"
+        >
+          <div class="flex items-start gap-1">
+            <svg class="w-3 h-3 text-blue-500 shrink-0" fill="currentColor" viewBox="0 0 20 20">
+              <path
+                fill-rule="evenodd"
+                d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z"
+                clip-rule="evenodd"
+              />
+            </svg>
+            <span>
+              <span class="font-bold uppercase tracking-tight mr-1">Pair Suggestion:</span>
+              {{ recommendationNote }}
+            </span>
           </div>
         </div>
       </div>

--- a/wasmegg/ascension-planner/src/components/actions/ResearchItem.vue
+++ b/wasmegg/ascension-planner/src/components/actions/ResearchItem.vue
@@ -113,25 +113,6 @@
             </div>
           </div>
         </div>
-
-        <div
-          v-if="recommendationNote"
-          class="mt-1.5 p-1.5 inline-block bg-blue-50 border border-blue-100 rounded text-[9px] text-blue-800 leading-tight shadow-sm"
-        >
-          <div class="flex items-start gap-1">
-            <svg class="w-3 h-3 text-blue-500 shrink-0" fill="currentColor" viewBox="0 0 20 20">
-              <path
-                fill-rule="evenodd"
-                d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z"
-                clip-rule="evenodd"
-              />
-            </svg>
-            <span>
-              <span class="font-bold uppercase tracking-tight mr-1">Pair Suggestion:</span>
-              {{ recommendationNote }}
-            </span>
-          </div>
-        </div>
       </div>
 
       <!-- Time Cost and Actions (Right aligned) -->
@@ -186,6 +167,31 @@
             Max
             <span v-if="maxTime" class="ml-0.5 text-[8px] opacity-70 font-mono font-medium lowercase tracking-normal">({{ maxTime }})</span>
           </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Row 3b: Pair Suggestion (Conditional, full width, own line) -->
+    <div
+      v-if="recommendationNote"
+      class="w-full pl-[38px]"
+    >
+      <div class="p-1.5 inline-block bg-blue-50 border border-blue-100 rounded text-[9px] text-blue-800 leading-tight shadow-sm">
+        <div class="flex items-start gap-1">
+          <svg class="w-3 h-3 text-blue-500 shrink-0" fill="currentColor" viewBox="0 0 20 20">
+            <path
+              fill-rule="evenodd"
+              d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z"
+              clip-rule="evenodd"
+            />
+          </svg>
+          <span>
+            <span class="font-bold uppercase tracking-tight mr-1">Pair Suggestion:</span>
+            {{ recommendationNote }}
+            <span v-if="showSaleWarning" class="block mt-0.5 text-amber-600 font-bold">
+              ⚠️ Even paired, this won't earn back 70% before the next sale.
+            </span>
+          </span>
         </div>
       </div>
     </div>

--- a/wasmegg/ascension-planner/src/components/actions/ResearchViewSelector.vue
+++ b/wasmegg/ascension-planner/src/components/actions/ResearchViewSelector.vue
@@ -4,10 +4,11 @@
     <div class="relative">
       <button
         @click="open = !open"
-        class="w-full flex items-center justify-between gap-2 px-4 py-3 text-base font-bold text-white bg-slate-800 rounded-lg shadow-md hover:bg-slate-900 transition-colors"
+        class="w-full flex items-center justify-between gap-2 px-4 py-2.5 text-sm font-bold text-gray-800 bg-white border-2 rounded-lg shadow-sm transition-colors"
+        :class="open ? 'border-indigo-500 ring-2 ring-indigo-100' : 'border-indigo-300 hover:border-indigo-400'"
       >
         <span>{{ selectedLabel }}</span>
-        <ChevronDownIcon class="w-5 h-5 text-slate-400 transition-transform" :class="{ 'rotate-180': open }" />
+        <ChevronDownIcon class="w-5 h-5 text-indigo-500 transition-transform" :class="{ 'rotate-180': open }" />
       </button>
 
       <div

--- a/wasmegg/ascension-planner/src/components/actions/SiloActions.vue
+++ b/wasmegg/ascension-planner/src/components/actions/SiloActions.vue
@@ -108,7 +108,7 @@
                   >1-Hr Max</span
                 >
                 <span class="text-[9px] font-mono-premium font-black text-violet-500 mt-0.5">
-                  {{ maxSilosIn1Hour.count }} silo{{ maxSilosIn1Hour.count !== 1 ? 's' : '' }} ·
+                  {{ maxSilosIn1Hour.count }} new silo{{ maxSilosIn1Hour.count !== 1 ? 's' : '' }} ·
                   {{ formatDuration(maxSilosIn1Hour.seconds) }}
                 </span>
               </div>

--- a/wasmegg/ascension-planner/src/composables/useResearchViews.ts
+++ b/wasmegg/ascension-planner/src/composables/useResearchViews.ts
@@ -1209,6 +1209,7 @@ export function useResearchViews() {
                   ? '0s'
                   : formatDuration(resultTimeToBuySeconds)
               : '',
+          timeToBuySeconds: resultTimeToBuySeconds,
           canBuy,
           isMaxed: false,
           roiSeconds,
@@ -1236,6 +1237,7 @@ export function useResearchViews() {
         .map(c => {
           let recommendationNote: string | undefined = undefined;
           let pairRoiSeconds: number | undefined = undefined;
+          let showSaleWarning = c.showSaleWarning;
 
           if (roiMode.value === 'immediate') {
             const isBottlenecked = c.roiSeconds === Infinity || c.roiSeconds > 3600 * 24 * 7;
@@ -1270,6 +1272,14 @@ export function useResearchViews() {
                   if (combinedRoiSeconds < c.roiSeconds) {
                     recommendationNote = `Buying this with "${partner.research.name}" would have a much better combined payback time of ${formatDuration(combinedRoiSeconds)}.`;
                     pairRoiSeconds = combinedRoiSeconds;
+
+                    // This item alone won't reach 70% payback before the next sale, but it
+                    // only makes sense to buy as part of the pair — so judge the sale warning
+                    // against the pair's combined payback time instead of this item's solo ROI.
+                    showSaleWarning = !isSale && (
+                      (absoluteSimTime + c.timeToBuySeconds >= nextSaleStart) ||
+                      (pairDelta * (nextSaleStart - (absoluteSimTime + c.timeToBuySeconds)) < 0.7 * pairTotalCost)
+                    );
                   }
                 }
               }
@@ -1283,6 +1293,7 @@ export function useResearchViews() {
             extraSeconds: c.totalRoiSeconds,
             recommendationNote,
             pairRoiSeconds,
+            showSaleWarning,
           };
         })
         .filter(c => {

--- a/wasmegg/ascension-planner/src/composables/useResearchViews.ts
+++ b/wasmegg/ascension-planner/src/composables/useResearchViews.ts
@@ -79,6 +79,7 @@ export interface ResearchViewItem {
   isLaying?: boolean;
   isShipping?: boolean;
   recommendationNote?: string;
+  pairRoiSeconds?: number;
   showSaleWarning?: boolean;
   showDeadlineWarning?: boolean;
 
@@ -1234,6 +1235,7 @@ export function useResearchViews() {
       return basicCandidates
         .map(c => {
           let recommendationNote: string | undefined = undefined;
+          let pairRoiSeconds: number | undefined = undefined;
 
           if (roiMode.value === 'immediate') {
             const isBottlenecked = c.roiSeconds === Infinity || c.roiSeconds > 3600 * 24 * 7;
@@ -1263,10 +1265,11 @@ export function useResearchViews() {
                 if (pairEarnings > partnerEarnings) {
                   const pairTotalCost = c.price + partner.price;
                   const pairDelta = pairEarnings - currentEarnings;
-                  const pairRoiSeconds = pairTotalCost / pairDelta;
+                  const combinedRoiSeconds = pairTotalCost / pairDelta;
 
-                  if (pairRoiSeconds < c.roiSeconds) {
-                    recommendationNote = `Buying this with "${partner.research.name}" would have a much better combined payback time of ${formatDuration(pairRoiSeconds)}.`;
+                  if (combinedRoiSeconds < c.roiSeconds) {
+                    recommendationNote = `Buying this with "${partner.research.name}" would have a much better combined payback time of ${formatDuration(combinedRoiSeconds)}.`;
+                    pairRoiSeconds = combinedRoiSeconds;
                   }
                 }
               }
@@ -1279,6 +1282,7 @@ export function useResearchViews() {
             extraLabel: 'Achieve ROI',
             extraSeconds: c.totalRoiSeconds,
             recommendationNote,
+            pairRoiSeconds,
           };
         })
         .filter(c => {
@@ -1288,10 +1292,12 @@ export function useResearchViews() {
         })
         .sort((a, b) => {
           if (a.canBuy !== b.canBuy) return a.canBuy ? -1 : 1;
-          if (a.totalRoiSeconds === b.totalRoiSeconds) {
+          const aSortSeconds = a.pairRoiSeconds !== undefined ? Math.min(a.totalRoiSeconds, a.pairRoiSeconds) : a.totalRoiSeconds;
+          const bSortSeconds = b.pairRoiSeconds !== undefined ? Math.min(b.totalRoiSeconds, b.pairRoiSeconds) : b.totalRoiSeconds;
+          if (aSortSeconds === bSortSeconds) {
             return a.price - b.price;
           }
-          return a.totalRoiSeconds - b.totalRoiSeconds;
+          return aSortSeconds - bSortSeconds;
         });
     }
 


### PR DESCRIPTION
* Earnings ROI button to buy all research that will hit 70% payback before sale starts
* Delivery impact button to buy all research possible before the end of the current sale
* Change sort order of Earnings ROI research
* Change wording on quick buy for silos so it's less confusing