### PR TITLE
better research-target buys

### DIFF
--- a/wasmegg/ascension-planner/src/auto/shifts/helpers/milestones.ts
+++ b/wasmegg/ascension-planner/src/auto/shifts/helpers/milestones.ts
@@ -237,10 +237,19 @@ export function runResearchMilestoneIfWorthwhile(
   const startSnapshot = computeSnapshot(startState, context, { skipGrowth: true });
   const absoluteSimTimeAtStart = helpers.getAbsTime();
   const mods = helpers.getModifiers();
+  const researchSaleDeadline = getNextSaleStart(absoluteSimTimeAtStart);
 
   const target = { researchId, targetLevel };
 
-  const chain = computeResearchMilestoneChain(target, startState, startSnapshot, context, mods, absoluteSimTimeAtStart);
+  const chain = computeResearchMilestoneChain(
+    target,
+    startState,
+    startSnapshot,
+    context,
+    mods,
+    absoluteSimTimeAtStart,
+    researchSaleDeadline
+  );
   const baseline = computeMilestoneBaseline(
     { kind: 'research', researchId, targetLevel },
     startSnapshot,

--- a/wasmegg/ascension-planner/src/calculations/milestoneChain.ts
+++ b/wasmegg/ascension-planner/src/calculations/milestoneChain.ts
@@ -12,6 +12,7 @@ import {
   findEventCrossings,
   type PurchaseEventCrossings,
 } from './researchROI';
+import { rankResearchByROI, buildRoiCandidateSequences, simulatePurchaseSequence } from './researchRanking';
 import type { EngineState, SimulationContext } from '@/engine/types';
 import type { CalculationsSnapshot } from '@/types';
 import { computeSnapshot } from '@/engine/compute';
@@ -54,7 +55,6 @@ export interface MilestoneChainItem {
   buyToHereSeconds: number;
   roiSeconds?: number;
   totalRoiSeconds?: number;
-  timeSavedSeconds?: number;
   showSaleWarning?: boolean;
   showDeadlineWarning?: boolean;
   // Whether this purchase's price reflects a research sale, and whether it completed during a
@@ -76,17 +76,28 @@ interface MilestoneChainResult {
 }
 
 // For a "research level" milestone there's always a well-defined fallback: just save up and buy
-// the target directly. So a detour through some other research is only worth suggesting if it
-// provably shortens the total time versus that direct purchase — not merely because the detour
-// has good ROI in isolation (a great-ROI item can still make you arrive at the target *later*,
-// since you also have to spend time saving up for the detour itself).
+// the target directly. A detour through some other research is only worth taking if it provably
+// shortens the total time versus that direct purchase — not merely because the detour has good
+// ROI in isolation (a great-ROI item can still make you arrive at the target *later*, since you
+// also have to spend time saving up for the detour itself).
+//
+// Which detour to consider at each step is driven by `rankResearchByROI` — the same "fastest
+// total ROI time" ordering (wait-to-afford + payback) the Earnings ROI research view and Smart
+// Buy's sale-aware flow already buy in (see `roiRankedResearches`/`simulateSaleAwareBuy`) — rather
+// than a bespoke search over every candidate's effect on the target. Only the single top-ranked
+// candidate is checked each step — as a solo purchase, and, if it's a bottleneck-paired
+// recommendation (see `buildRoiCandidateSequences`), as a two-purchase sequence with its pair
+// partner: if any of those beats buying the target directly, it's taken and the loop
+// repeats (re-ranking, since a purchase can shift the ROI order); the moment the top-ranked
+// candidate no longer helps in any of those forms, detouring stops and the target itself is bought.
 export function computeResearchMilestoneChain(
   target: { researchId: string; targetLevel: number },
   startState: EngineState,
   startSnapshot: CalculationsSnapshot,
   context: SimulationContext,
   mods: ResearchCostModifiers,
-  absoluteSimTimeAtStart: number
+  absoluteSimTimeAtStart: number,
+  researchSaleDeadline: number
 ): MilestoneChainResult {
   const targetResearch = getResearchById(target.researchId);
 
@@ -127,83 +138,89 @@ export function computeResearchMilestoneChain(
     const targetPrice = targetPurchase.price;
     const directSeconds = targetPurchase.waitSeconds;
 
-    let best: {
-      research: CommonResearch;
-      level: number;
-      price: number;
-      secondsToBuy: number;
-      pathSeconds: number;
-      duringSale: boolean;
-    } | null = null;
+    // No `deliveryImpactOnly` filter, 'immediate' roiMode — matches the Earnings ROI view's
+    // default (there's no equivalent toggle exposed for milestones), and already excludes the
+    // target itself only via the `.find` below, not the ranking itself.
+    const ranked = rankResearchByROI(
+      levels,
+      snapshot,
+      context,
+      mods,
+      isSale,
+      currentAbsoluteTime,
+      researchSaleDeadline,
+      'immediate',
+      false
+    );
+    // `showSaleWarning` (from `calculateResearchROI`, inside `rankResearchByROI`) means this
+    // candidate, bought right now, wouldn't earn back 70% of its cost before the next research
+    // sale starts — the same "not worth prepaying full price for" rule the manual planner's "Buy
+    // Until Sale Warning" button enforces (`meetsSaleAwareDeadline`). A detour is optional (the
+    // milestone chain always has the direct target purchase as its fallback), so it should never
+    // insert a purchase that flunks this rule — skip it and consider the next-best-ROI candidate
+    // instead, same as that button's own `ranked.find(...)` pattern.
+    const bestRoi = ranked.find(item => item.canBuy && item.research.id !== targetResearch.id && !item.showSaleWarning);
 
-    for (const r of getCommonResearches()) {
-      if (r.id === targetResearch.id) continue;
-      const level = levels[r.id] || 0;
-      if (level >= r.levels || !isTierUnlocked(levels, r.tier)) continue;
+    let bought = false;
+
+    if (bestRoi) {
       lastProgressLog = maybeLogProgress('computeResearchMilestoneChain', lastProgressLog, {
         target,
         outerIterations,
-        candidateResearchId: r.id,
+        candidateResearchId: bestRoi.research.id,
         elapsedMs: Math.round(performance.now() - loopStart),
       });
 
-      const detourPurchase = getSaleAwareTimeToSave(r, level, mods, isSale, currentAbsoluteTime, snapshot, transitions);
-      const price = detourPurchase.price;
-      const secondsToBuy = detourPurchase.waitSeconds;
-      if (secondsToBuy === Infinity) continue;
+      // `bestRoi` can rank this high purely because pairing it with `pairPartnerResearch` gives a
+      // great COMBINED payback (see `rankResearchByROI`'s bottleneck-pairing logic) — a laying or
+      // shipping research capped by the other side of the pipeline moves earnings by ~0 bought
+      // alone, so evaluating it solo (the only thing the previous version of this code did) would
+      // never beat `directSeconds`, and a genuinely-worthwhile pairing would never get taken. Try
+      // it solo, and — when a partner exists and is itself still purchasable — as a two-purchase
+      // sequence in both orders (whichever's cheaper to save up for first can finish sooner);
+      // take whichever sequence both completes and beats `directSeconds` by the widest margin.
+      const sequences = buildRoiCandidateSequences(bestRoi, levels, targetResearch.id);
 
-      const stateAfter = applyTime(
-        applyAction(state, {
-          type: 'buy_research',
-          payload: { researchId: r.id, fromLevel: level, toLevel: level + 1 },
-          cost: price,
-        }),
-        secondsToBuy,
-        snapshot,
-        { transitions }
-      );
-      const snapshotAfter = computeSnapshot(stateAfter, context);
-      const secondsToTargetAfter = getTimeToSave(
-        targetPrice,
-        snapshotAfter,
-        boostTransitionsFrom(snapshotAfter, currentAbsoluteTime + secondsToBuy)
-      );
-      const pathSeconds = secondsToBuy + secondsToTargetAfter;
+      let bestSequence: { result: NonNullable<ReturnType<typeof simulatePurchaseSequence>>; pathSeconds: number } | null =
+        null;
 
-      if (pathSeconds < directSeconds && (!best || pathSeconds < best.pathSeconds)) {
-        best = { research: r, level, price, secondsToBuy, pathSeconds, duringSale: detourPurchase.duringSale };
+      for (const sequence of sequences) {
+        const result = simulatePurchaseSequence(sequence, state, snapshot, currentAbsoluteTime, mods, context);
+        if (!result) continue;
+        const secondsToTargetAfter = getTimeToSave(
+          targetPrice,
+          result.snapshot,
+          boostTransitionsFrom(result.snapshot, currentAbsoluteTime + result.totalSecondsSpent)
+        );
+        const pathSeconds = result.totalSecondsSpent + secondsToTargetAfter;
+        if (pathSeconds < directSeconds && (!bestSequence || pathSeconds < bestSequence.pathSeconds)) {
+          bestSequence = { result, pathSeconds };
+        }
+      }
+
+      if (bestSequence) {
+        const isPair = bestSequence.result.items.length > 1;
+        for (const purchase of bestSequence.result.items) {
+          totalSeconds += purchase.timeToBuySeconds;
+          items.push({
+            ...purchase,
+            buyToHereSeconds: totalSeconds,
+            // A paired purchase's own solo `roiSeconds`/`totalRoiSeconds` (near-infinite, since
+            // that's exactly why it needed pairing to be worth taking) would be misleading here —
+            // show the combined figure that actually justified buying it instead.
+            roiSeconds: isPair ? bestRoi.pairRoiSeconds : bestRoi.roiSeconds,
+            totalRoiSeconds: isPair ? bestRoi.pairRoiSeconds : bestRoi.totalRoiSeconds,
+            showSaleWarning: bestRoi.showSaleWarning,
+            showDeadlineWarning: bestRoi.showDeadlineWarning,
+          });
+        }
+        state = bestSequence.result.state;
+        snapshot = bestSequence.result.snapshot;
+        bought = true;
       }
     }
 
-    if (best) {
-      totalSeconds += best.secondsToBuy;
-      state = applyAction(state, {
-        type: 'buy_research',
-        payload: { researchId: best.research.id, fromLevel: best.level, toLevel: best.level + 1 },
-        cost: best.price,
-      });
-      state = applyTime(state, best.secondsToBuy, snapshot, { transitions });
-      snapshot = computeSnapshot(state, context);
-
-      const timeSaved = directSeconds - best.pathSeconds;
-      items.push({
-        research: best.research,
-        targetLevel: best.level + 1,
-        currentLevel: best.level,
-        price: best.price,
-        timeToBuySeconds: best.secondsToBuy,
-        buyToHereSeconds: totalSeconds,
-        timeSavedSeconds: timeSaved,
-        duringSale: best.duringSale,
-        duringEarningsBoost: isEarningsBoostActive(currentAbsoluteTime + best.secondsToBuy),
-        eventCrossings: findEventCrossings(
-          currentAbsoluteTime,
-          best.secondsToBuy,
-          isSale,
-          isEarningsBoostActive(currentAbsoluteTime)
-        ),
-      });
-    } else {
+    if (!bought) {
       if (directSeconds === Infinity) break;
 
       totalSeconds += directSeconds;
@@ -566,8 +583,15 @@ export function computeTierMilestoneChain(
       reached: boolean;
     } | null = null;
 
-    if (roiCandidates.length > 0) {
-      const bestRoi = roiCandidates[0];
+    // Skip any candidate that wouldn't earn back 70% of its cost before the next research sale
+    // starts (`showSaleWarning`, from `calculateResearchROI`) — same "not worth prepaying full
+    // price for" rule the manual planner's "Buy Until Sale Warning" button enforces
+    // (`meetsSaleAwareDeadline`). A detour here is optional — cheapest-first is always the
+    // fallback — so it should never jump the queue on a purchase that flunks this rule; the
+    // next-best-ROI candidate that passes is used instead.
+    const bestRoi = roiCandidates.find(c => !c.roiResult.showSaleWarning);
+
+    if (bestRoi) {
       // Re-derive with this file's own boost-staleness-aware `transitions`, same reasoning as
       // reorderTierChainByROI above.
       const bestPurchase = getSaleAwareTimeToSave(

--- a/wasmegg/ascension-planner/src/calculations/researchROI.ts
+++ b/wasmegg/ascension-planner/src/calculations/researchROI.ts
@@ -91,6 +91,14 @@ export interface SaleAwarePurchase {
  * the *target* price is), so the wait to reach the full price is just `getTimeToSave(fullPrice,
  * snapshot, transitions)` computed from now — the same continuous earnings integral already used
  * everywhere else, unaffected by whether it happens to cross the sale's end partway through.
+ *
+ * And the same "won't finish before the sale ends" problem applies to the *upcoming* sale too:
+ * `saleWaitFromNow` can land well past the sale's own 24-hour window (e.g. an expensive purchase
+ * where saving up to even the discounted price takes several days) — in which case the discount
+ * was never actually reachable, since the price reverts to full partway through the wait. That
+ * route has to be discarded entirely rather than reported as a (too-optimistic) discounted
+ * purchase; a purchase this far out just falls back to full price, same as if no sale were coming
+ * at all.
  */
 export function getSaleAwareTimeToSave(
   research: CommonResearch,
@@ -127,7 +135,14 @@ export function getSaleAwareTimeToSave(
   // whatever's banked by then still counts, so the wait is never more than the longer of the two.
   const trueSaleWait = Math.max(timeUntilSale, saleWaitFromNow);
 
-  if (trueSaleWait < currentWait) {
+  // The discounted price is only actually reachable if the purchase completes before the
+  // upcoming sale's own end — otherwise the price reverts to full partway through the wait (see
+  // this function's doc comment), and `trueSaleWait`/`salePrice` describe a purchase that could
+  // never really happen.
+  const saleEnd = getNextSaleEnd(currentAbsoluteTime);
+  const completesWithinSale = isFinite(saleEnd) && currentAbsoluteTime + trueSaleWait <= saleEnd;
+
+  if (completesWithinSale && trueSaleWait < currentWait) {
     return { price: salePrice, waitSeconds: trueSaleWait, duringSale: true };
   }
   return { price: currentPrice, waitSeconds: currentWait, duringSale: false };

--- a/wasmegg/ascension-planner/src/calculations/researchRanking.ts
+++ b/wasmegg/ascension-planner/src/calculations/researchRanking.ts
@@ -11,16 +11,18 @@ import {
   isActuallyDuringSale,
   meetsROIByDeadline,
   MAX_ROI_PAYBACK_SEARCH_SECONDS,
+  findEventCrossings,
+  type PurchaseEventCrossings,
 } from './researchROI';
 import { calculateMaxVehicleSlots, calculateMaxTrainLength } from './shippingCapacity';
 import { getOptimalELRSet } from '@/lib/artifacts/virtue';
 import { calculateArtifactModifiers } from '@/lib/artifacts';
 import { computeRealisticELR } from './realisticELR';
-import type { SimulationContext } from '@/engine/types';
+import type { SimulationContext, EngineState } from '@/engine/types';
 import type { CalculationsSnapshot } from '@/types';
 import { computeSnapshot } from '@/engine/compute';
 import { createBaseEngineState } from '@/engine/adapter';
-import { applyAction, getTimeToSave, calculateEarningsForTime, boostTransitionsFrom } from '@/engine/apply';
+import { applyAction, applyTime, getTimeToSave, calculateEarningsForTime, boostTransitionsFrom } from '@/engine/apply';
 import { createSimAction } from '@/types/actions/meta';
 import { getNextPacificTime, isEarningsBoostActive, isResearchSaleActive } from '@/lib/events';
 import { ei } from 'lib';
@@ -765,4 +767,129 @@ export function buyUntilRealSaleStarts(
   );
 
   return { purchased, duringSalePurchases };
+}
+
+/** One purchase within a `simulatePurchaseSequence` result — same shape as `MilestoneChainItem`
+ *  minus the fields that only make sense once a caller decides where the sequence lands in a
+ *  larger chain (`buyToHereSeconds`) or how to display its ROI (`roiSeconds`/`totalRoiSeconds`/
+ *  `showSaleWarning`/`showDeadlineWarning` — a paired purchase's own solo figures are misleading;
+ *  see `buildRoiCandidateSequences`'s doc comment). */
+export interface SequencedPurchase {
+  research: CommonResearch;
+  targetLevel: number;
+  currentLevel: number;
+  price: number;
+  timeToBuySeconds: number;
+  duringSale: boolean;
+  duringEarningsBoost: boolean;
+  eventCrossings: PurchaseEventCrossings;
+}
+
+/**
+ * Simulates buying a sequence of research purchases back-to-back, starting from `state`/
+ * `snapshot`/`startAbsoluteTime`, each priced/waited via `getSaleAwareTimeToSave` at the moment
+ * it's actually reached — so a later purchase in the sequence correctly sees the earlier one's
+ * cost already paid, and any resulting change in earnings. Generic building block for any
+ * multi-purchase ROI-buying flow; pair with `buildRoiCandidateSequences` below to get pairing-
+ * aware sequences worth trying in the first place.
+ *
+ * Returns `null` if any purchase in the sequence turns out unaffordable (`waitSeconds ===
+ * Infinity`) rather than a partial result — a sequence that can't fully complete isn't a valid
+ * purchase plan, half-bought or not.
+ */
+export function simulatePurchaseSequence(
+  sequence: { research: CommonResearch; level: number }[],
+  state: EngineState,
+  snapshot: CalculationsSnapshot,
+  startAbsoluteTime: number,
+  mods: ResearchCostModifiers,
+  context: SimulationContext
+): { state: EngineState; snapshot: CalculationsSnapshot; items: SequencedPurchase[]; totalSecondsSpent: number } | null {
+  let curState = state;
+  let curSnapshot = snapshot;
+  let curTime = startAbsoluteTime;
+  let totalSecondsSpent = 0;
+  const purchasedItems: SequencedPurchase[] = [];
+
+  for (const { research, level } of sequence) {
+    const isSaleNow = isResearchSaleActive(curTime);
+    const transitionsNow = boostTransitionsFrom(curSnapshot, curTime);
+    const purchase = getSaleAwareTimeToSave(research, level, mods, isSaleNow, curTime, curSnapshot, transitionsNow);
+    if (purchase.waitSeconds === Infinity) return null;
+
+    purchasedItems.push({
+      research,
+      targetLevel: level + 1,
+      currentLevel: level,
+      price: purchase.price,
+      timeToBuySeconds: purchase.waitSeconds,
+      duringSale: purchase.duringSale,
+      duringEarningsBoost: isEarningsBoostActive(curTime + purchase.waitSeconds),
+      eventCrossings: findEventCrossings(curTime, purchase.waitSeconds, isSaleNow, isEarningsBoostActive(curTime)),
+    });
+
+    curState = applyTime(
+      applyAction(curState, {
+        type: 'buy_research',
+        payload: { researchId: research.id, fromLevel: level, toLevel: level + 1 },
+        cost: purchase.price,
+      }),
+      purchase.waitSeconds,
+      curSnapshot,
+      { transitions: transitionsNow }
+    );
+    curSnapshot = computeSnapshot(curState, context);
+    curTime += purchase.waitSeconds;
+    totalSecondsSpent += purchase.waitSeconds;
+  }
+
+  return { state: curState, snapshot: curSnapshot, items: purchasedItems, totalSecondsSpent };
+}
+
+/**
+ * Expands a `rankResearchByROI` candidate into the purchase sequence(s) worth trying in order to
+ * actually acquire it: always the solo purchase, plus — when the candidate only ranked this high
+ * because pairing it with `pairPartnerResearch` gives a great COMBINED payback (see
+ * `rankResearchByROI`'s bottleneck-pairing logic) and that partner is itself still purchasable —
+ * both orderings of buying the pair together (whichever's cheaper to save up for first can finish
+ * sooner). A bottlenecked laying/shipping research moves earnings by ~0 bought alone — that's
+ * exactly why it needed pairing to rank well at all — so any caller evaluating "is this candidate
+ * worth buying" against solo economics alone needs the pair option too, not just the single item.
+ *
+ * `excludeResearchId` guards against the partner happening to be whatever the caller is separately
+ * buying toward (e.g. a milestone's own target research) — pass that id to keep the pairing from
+ * silently reaching into a purchase the caller already accounts for elsewhere.
+ *
+ * Pure/cheap (no simulation) — feed each returned sequence through `simulatePurchaseSequence` to
+ * actually price/wait it out, then apply whatever decision policy fits the caller (the milestone
+ * chain takes whichever sequence beats buying its target directly; a plain "keep buying the best
+ * ROI" loop can just always prefer the pair sequence when one exists, since `rankResearchByROI`
+ * only offers it when the combined payback beats the solo one).
+ */
+export function buildRoiCandidateSequences(
+  candidate: ResearchRankingItem,
+  levels: Record<string, number>,
+  excludeResearchId?: string
+): { research: CommonResearch; level: number }[][] {
+  const sequences: { research: CommonResearch; level: number }[][] = [
+    [{ research: candidate.research, level: candidate.currentLevel }],
+  ];
+
+  const partner = candidate.pairPartnerResearch;
+  const partnerLevel = partner ? levels[partner.id] || 0 : undefined;
+  const partnerEligible =
+    !!partner && partner.id !== excludeResearchId && partnerLevel !== undefined && partnerLevel < partner.levels;
+
+  if (partnerEligible && partner) {
+    sequences.push([
+      { research: candidate.research, level: candidate.currentLevel },
+      { research: partner, level: partnerLevel! },
+    ]);
+    sequences.push([
+      { research: partner, level: partnerLevel! },
+      { research: candidate.research, level: candidate.currentLevel },
+    ]);
+  }
+
+  return sequences;
 }

--- a/wasmegg/ascension-planner/src/composables/useResearchViews.ts
+++ b/wasmegg/ascension-planner/src/composables/useResearchViews.ts
@@ -362,10 +362,10 @@ export function useResearchViews() {
   });
 
   // Converts the pure-calculation MilestoneChainItem shape (raw seconds, no formatting) into the
-  // view's ResearchViewItem shape. roiSeconds is only ever set on tier-milestone items (the ROI
-  // detour/reorder path); timeSavedSeconds is only ever set on research-milestone detour items —
-  // the two are mutually exclusive, matching how computeTierMilestoneChain/computeResearchMilestoneChain
-  // populate them.
+  // view's ResearchViewItem shape. roiSeconds/totalRoiSeconds are only set on detour items — both
+  // computeTierMilestoneChain's ROI-reorder path and computeResearchMilestoneChain's ROI-ranked
+  // detour path populate them the same way; direct target/cheapest-first purchases leave them
+  // unset.
   function toResearchViewItem(item: MilestoneChainItem): ResearchViewItem {
     const result: ResearchViewItem = {
       research: item.research,
@@ -395,9 +395,6 @@ export function useResearchViews() {
       result.extraStats = roiLabel;
       result.extraLabel = 'ROI';
       result.extraSeconds = item.roiSeconds;
-    } else if (item.timeSavedSeconds !== undefined) {
-      result.extraStats = isFinite(item.timeSavedSeconds) ? formatDuration(item.timeSavedSeconds) : '—';
-      result.extraLabel = 'Saves';
     }
 
     return result;
@@ -547,7 +544,8 @@ export function useResearchViews() {
               startSnapshot,
               context,
               mods,
-              absoluteSimTime
+              absoluteSimTime,
+              deadline
             );
     } finally {
       debugLogEnd('milestoneChain compute', { generation });

--- a/wasmegg/ascension-planner/src/engine/apply/math.ts
+++ b/wasmegg/ascension-planner/src/engine/apply/math.ts
@@ -37,6 +37,17 @@ export interface EarningsRateTransition {
 const BOOST_TRANSITION_HORIZON_SECONDS = 3 * 365 * 86400;
 
 /**
+ * The earnings boost's fixed multiplier while active — every real `setEarningsBoost`/
+ * `toggle_earnings_boost` call site in this codebase writes exactly `2` when activating and `1`
+ * when deactivating (the `1` is a reset placeholder, not a meaningful "boost strength"; nothing
+ * ever reads `multiplier` while `active` is false except this file's own rate projection below).
+ * Used instead of `prevSnapshot.earningsBoost.multiplier` whenever a rate needs to be projected
+ * for the OPPOSITE of the snapshot's current active state — see `calculateEarningsForTime`'s and
+ * `getTimeToSave`'s `rateFor` for why relying on the snapshot field there is unsafe.
+ */
+const EARNINGS_BOOST_MULTIPLIER = 2;
+
+/**
  * Builds the earnings-rate transitions needed for a `getTimeToSave`/`calculateEarningsForTime`/
  * `applyTime` call starting at `snapshot`, given the TRUE calendar time `absTime` that call
  * represents. `snapshot.earningsBoost.active` may be stale (many callers never toggle it as
@@ -190,9 +201,14 @@ export function calculateEarningsForTime(
   const V1 = prevSnapshot.elr > 0 ? prevSnapshot.offlineEarnings / prevSnapshot.elr : 0;
   if (V1 <= 0) return 0;
 
-  const multiplier = prevSnapshot.earningsBoost.multiplier || 1;
+  // `prevSnapshot.earningsBoost.multiplier` is only trustworthy for the snapshot's OWN current
+  // `active` state — it gets reset to 1 whenever a boost is toggled off (see
+  // `EARNINGS_BOOST_MULTIPLIER`'s doc comment), so it can't be used to project the rate for the
+  // OPPOSITE state (e.g. an upcoming boost while currently inactive). Use the snapshot's real
+  // current rate (`V1`) for the current state, and the fixed constant for the other.
   const currentActive = prevSnapshot.earningsBoost.active;
-  const rateFor = (active: boolean) => (active === currentActive ? V1 : active ? V1 * multiplier : V1 / multiplier);
+  const rateFor = (active: boolean) =>
+    active === currentActive ? V1 : active ? V1 * EARNINGS_BOOST_MULTIPLIER : V1 / EARNINGS_BOOST_MULTIPLIER;
 
   const eggsAt = (t: number) =>
     integrateRate(
@@ -272,9 +288,14 @@ export function getTimeToSave(
   const V1 = prevSnapshot.elr > 0 ? prevSnapshot.offlineEarnings / prevSnapshot.elr : 0;
   if (V1 <= 0) return Infinity;
 
-  const multiplier = prevSnapshot.earningsBoost.multiplier || 1;
+  // `prevSnapshot.earningsBoost.multiplier` is only trustworthy for the snapshot's OWN current
+  // `active` state — it gets reset to 1 whenever a boost is toggled off (see
+  // `EARNINGS_BOOST_MULTIPLIER`'s doc comment), so it can't be used to project the rate for the
+  // OPPOSITE state (e.g. an upcoming boost while currently inactive). Use the snapshot's real
+  // current rate (`V1`) for the current state, and the fixed constant for the other.
   const currentActive = prevSnapshot.earningsBoost.active;
-  const rateFor = (active: boolean) => (active === currentActive ? V1 : active ? V1 * multiplier : V1 / multiplier);
+  const rateFor = (active: boolean) =>
+    active === currentActive ? V1 : active ? V1 * EARNINGS_BOOST_MULTIPLIER : V1 / EARNINGS_BOOST_MULTIPLIER;
 
   const P0 = prevSnapshot.population;
   const I = prevSnapshot.offlineIHR / 60;


### PR DESCRIPTION
include 70% ROI, include event-awareness, include pair suggestions, sort by ROI