### PR TITLE
fix: correct 'Secretary of Legendary' to 'Secretary of Legends' in PlayerCard.vue

### DIFF
--- a/wasmegg/rockets-tracker/src/components/PlayerCard.vue
+++ b/wasmegg/rockets-tracker/src/components/PlayerCard.vue
@@ -498,7 +498,7 @@
               <span class="whitespace-nowrap">Farmers Without Legendaries</span>.
             </template>
             <template v-else-if="randIndex % 5 === 1">
-              The Secretary of Legendary has launched an investigation into the unusual number of legendaries you
+              The Secretary of Legends has launched an investigation into the unusual number of legendaries you
               possess.
             </template>
             <template v-else-if="randIndex % 5 === 2">


### PR DESCRIPTION
Closing as duplicate. PR #704 (https://github.com/wasmegg-carpet/egg/pull/704) is the newer submission of the same fix.