### PR TITLE
fix: correct Secretary of Legendary -> Secretary of Legendaries typo

### DIFF
--- a/wasmegg/rockets-tracker/src/components/PlayerCard.vue
+++ b/wasmegg/rockets-tracker/src/components/PlayerCard.vue
@@ -498,7 +498,7 @@
               <span class="whitespace-nowrap">Farmers Without Legendaries</span>.
             </template>
             <template v-else-if="randIndex % 5 === 1">
-              The Secretary of Legendary has launched an investigation into the unusual number of legendaries you
+              The Secretary of Legendaries has launched an investigation into the unusual number of legendaries you
               possess.
             </template>
             <template v-else-if="randIndex % 5 === 2">


### PR DESCRIPTION
Fixes #692

The game text at PlayerCard.vue line 501 says "Secretary of Legendary" but the plural form "Legendaries" is used consistently throughout the rest of the file (e.g., "Farmers Without Legendaries", "Zero Legendaries", "high-legendary-count"). This fixes the grammar to match.