### PR TITLE
fix: correct Secretary of Legendary to Secretary of Legendaries typo

### DIFF
--- a/wasmegg/rockets-tracker/src/components/PlayerCard.vue
+++ b/wasmegg/rockets-tracker/src/components/PlayerCard.vue
@@ -498,7 +498,7 @@
               <span class="whitespace-nowrap">Farmers Without Legendaries</span>.
             </template>
             <template v-else-if="randIndex % 5 === 1">
-              The Secretary of Legendary has launched an investigation into the unusual number of legendaries you
+              The Secretary of Legendaries has launched an investigation into the unusual number of legendaries you
               possess.
             </template>
             <template v-else-if="randIndex % 5 === 2">


### PR DESCRIPTION
## Description
Fixes a typo in the PlayerCard.vue component: The Secretary of Legendary should be The Secretary of Legendaries (plural to match the word legendaries in the same sentence).

## Changes
- wasmegg/rockets-tracker/src/components/PlayerCard.vue line 501

## Verification
Single commit, surgical fix, no other files modified.